### PR TITLE
fix(api): one documented 422 envelope for every validation failure (P-4)

### DIFF
--- a/products/pm-evals-web/backend/openapi.json
+++ b/products/pm-evals-web/backend/openapi.json
@@ -456,6 +456,23 @@
         "title": "TraceComparison",
         "type": "object"
       },
+      "ValidationErrorResponse": {
+        "description": "The single 422 envelope: every validation failure \u2014 malformed upload,\nout-of-range config, or a native transport type error \u2014 is reported as\n``{\"detail\": [ValidationProblem, ...]}`` so one committed schema matches\nthe wire for all of them (P-4).",
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationProblem"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "ValidationErrorResponse",
+        "type": "object"
+      },
       "ValidationProblem": {
         "properties": {
           "issues": {
@@ -466,10 +483,6 @@
             "type": "array"
           },
           "source": {
-            "enum": [
-              "baseline",
-              "candidate"
-            ],
             "title": "Source",
             "type": "string"
           }
@@ -551,15 +564,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/ValidationProblem"
-                  },
-                  "title": "Response 422 Compare Api Compare Post",
-                  "type": "array"
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
                 }
               }
             },
-            "description": "Malformed upload(s): named per-source parse issues."
+            "description": "A validation failure: one or more named per-source problems."
           }
         },
         "summary": "Compare"
@@ -619,15 +628,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/ValidationProblem"
-                  },
-                  "title": "Response 422 Report Api Report Post",
-                  "type": "array"
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
                 }
               }
             },
-            "description": "Malformed upload(s): named per-source parse issues."
+            "description": "A validation failure: one or more named per-source problems."
           }
         },
         "summary": "Report"

--- a/products/pm-evals-web/backend/src/pm_evals_api/app.py
+++ b/products/pm-evals-web/backend/src/pm_evals_api/app.py
@@ -15,7 +15,8 @@ import hashlib
 import json
 from typing import Any, Literal
 
-from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel
 
@@ -36,8 +37,19 @@ API_VERSION = "1.0.0"
 
 
 class ValidationProblem(BaseModel):
-    source: Literal["baseline", "candidate"]
+    # "baseline" | "candidate" for upload issues, or a request-field name
+    # (e.g. "min_matched_traces") for transport-level validation errors.
+    source: str
     issues: list[ParseIssue]
+
+
+class ValidationErrorResponse(BaseModel):
+    """The single 422 envelope: every validation failure — malformed upload,
+    out-of-range config, or a native transport type error — is reported as
+    ``{"detail": [ValidationProblem, ...]}`` so one committed schema matches
+    the wire for all of them (P-4)."""
+
+    detail: list[ValidationProblem]
 
 
 class CompareResponse(BaseModel):
@@ -86,11 +98,19 @@ async def _parse_pair(
     return base_result.run, cand_result.run, _sha256(base_bytes), _sha256(cand_bytes)
 
 
+def _validation_error(source: str, message: str, *, location: str | None = None) -> HTTPException:
+    """A 422 in the single documented envelope: {"detail": [ValidationProblem]}."""
+    problem = ValidationProblem(
+        source=source, issues=[ParseIssue(location=location or source, message=message)]
+    )
+    return HTTPException(status_code=422, detail=[problem.model_dump()])
+
+
 def _config(min_matched_traces: int | None) -> CompareConfig:
     if min_matched_traces is None:
         return CompareConfig()
     if min_matched_traces < 1:
-        raise HTTPException(status_code=422, detail="min_matched_traces must be >= 1")
+        raise _validation_error("min_matched_traces", "must be >= 1")
     return CompareConfig(min_matched_traces=min_matched_traces)
 
 
@@ -102,6 +122,24 @@ def create_app() -> FastAPI:
         "Uploads are processed in memory and never stored.",
     )
 
+    @app.exception_handler(RequestValidationError)
+    async def _on_validation_error(_: Request, exc: RequestValidationError) -> JSONResponse:
+        # Map FastAPI's native transport errors (missing part, wrong type) into
+        # the SAME {"detail": [ValidationProblem]} envelope every other 422 uses,
+        # grouped by request field so the source is real, never mis-attributed.
+        by_source: dict[str, list[ParseIssue]] = {}
+        for err in exc.errors():
+            parts = [str(p) for p in err["loc"] if p != "body"]
+            source = parts[0] if parts else "request"
+            by_source.setdefault(source, []).append(
+                ParseIssue(location=".".join(parts) or source, message=err["msg"])
+            )
+        detail = [
+            ValidationProblem(source=source, issues=issues).model_dump()
+            for source, issues in by_source.items()
+        ]
+        return JSONResponse(status_code=422, content={"detail": detail})
+
     @app.get("/api/health", response_model=HealthResponse)
     async def health() -> HealthResponse:
         return HealthResponse(status="ok", api_version=API_VERSION)
@@ -109,8 +147,8 @@ def create_app() -> FastAPI:
     validation_responses: dict[int | str, dict[str, Any]] = {
         413: {"description": "An uploaded file exceeds the size limit."},
         422: {
-            "description": "Malformed upload(s): named per-source parse issues.",
-            "model": list[ValidationProblem],
+            "description": "A validation failure: one or more named per-source problems.",
+            "model": ValidationErrorResponse,
         },
     }
 

--- a/products/pm-evals-web/backend/tests/test_api.py
+++ b/products/pm-evals-web/backend/tests/test_api.py
@@ -164,6 +164,47 @@ def test_invalid_min_matched_traces_is_refused(client: TestClient) -> None:
     assert response.status_code == 422
 
 
+def _assert_validation_envelope(response: Any) -> None:
+    assert response.status_code == 422
+    body = response.json()
+    assert set(body) == {"detail"}, body  # one documented envelope: {"detail": [...]}
+    assert isinstance(body["detail"], list) and body["detail"]
+    for problem in body["detail"]:
+        assert set(problem) == {"source", "issues"}, problem
+        assert isinstance(problem["source"], str) and problem["source"]
+        assert isinstance(problem["issues"], list) and problem["issues"]
+        for issue in problem["issues"]:
+            assert {"location", "message"} <= set(issue), issue
+
+
+def test_every_422_shares_one_documented_envelope(client: TestClient) -> None:
+    """P-4: malformed-parse, out-of-range config, native type errors, and a
+    missing part must all return the SAME {"detail": [ValidationProblem]} shape
+    the committed OpenAPI documents — not three different wire shapes."""
+    malformed = client.post("/api/compare", files=_files(candidate=b"{broken"))
+    bad_config = client.post("/api/compare", files=_files(), data={"min_matched_traces": "0"})
+    non_integer = client.post("/api/compare", files=_files(), data={"min_matched_traces": "abc"})
+    missing_part = client.post(
+        "/api/compare", files={"baseline": ("b.json", BASELINE, "application/json")}
+    )
+    for response in (malformed, bad_config, non_integer, missing_part):
+        _assert_validation_envelope(response)
+    # the config error names its own field, not a mis-attributed upload source
+    assert bad_config.json()["detail"][0]["source"] == "min_matched_traces"
+    assert missing_part.json()["detail"][0]["source"] == "candidate"
+
+
+def test_committed_openapi_documents_the_422_envelope(client: TestClient) -> None:
+    schema = client.app.openapi()  # type: ignore[attr-defined]
+    ref = schema["paths"]["/api/compare"]["post"]["responses"]["422"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    name = ref.rsplit("/", 1)[-1]
+    model = schema["components"]["schemas"][name]
+    assert list(model["properties"]) == ["detail"]
+    assert model["properties"]["detail"]["type"] == "array"
+
+
 def test_verdict_is_deterministic_across_requests(client: TestClient) -> None:
     first = client.post("/api/compare", files=_files(candidate=REGRESSION)).json()
     second = client.post("/api/compare", files=_files(candidate=REGRESSION)).json()

--- a/products/pm-evals-web/e2e/tests/keyboard.spec.ts
+++ b/products/pm-evals-web/e2e/tests/keyboard.spec.ts
@@ -69,7 +69,12 @@ test("status changes are exposed to assistive technology", async ({ page }) => {
   await page.getByLabel(/baseline/i).setInputFiles(BASELINE_FIXTURE);
   await page.getByLabel(/candidate/i).setInputFiles(REGRESSION_FIXTURE);
   await page.getByRole("button", { name: /compare runs/i }).click();
-  const status = page.getByRole("status");
+  // Scope to the S-1 compare-status: while a comparison is in flight the S-3
+  // trace explorer also renders a role="status" ("Loading trace comparison…"),
+  // so an unscoped getByRole("status") is ambiguous in slower environments.
+  const status = page
+    .getByRole("region", { name: /compare two runs/i })
+    .getByRole("status");
   await expect(status).toBeVisible();
   await expect(status).toHaveAttribute("aria-live", "polite");
   await expect(status).toContainText(/HOLD/);

--- a/products/pm-evals-web/frontend/src/lib/api-types.gen.ts
+++ b/products/pm-evals-web/frontend/src/lib/api-types.gen.ts
@@ -227,15 +227,23 @@ export interface components {
             /** Trace Id */
             trace_id: string;
         };
+        /**
+         * ValidationErrorResponse
+         * @description The single 422 envelope: every validation failure — malformed upload,
+         *     out-of-range config, or a native transport type error — is reported as
+         *     ``{"detail": [ValidationProblem, ...]}`` so one committed schema matches
+         *     the wire for all of them (P-4).
+         */
+        ValidationErrorResponse: {
+            /** Detail */
+            detail: components["schemas"]["ValidationProblem"][];
+        };
         /** ValidationProblem */
         ValidationProblem: {
             /** Issues */
             issues: components["schemas"]["ParseIssue"][];
-            /**
-             * Source
-             * @enum {string}
-             */
-            source: "baseline" | "candidate";
+            /** Source */
+            source: string;
         };
         /** VerdictReason */
         VerdictReason: {
@@ -289,13 +297,13 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Malformed upload(s): named per-source parse issues. */
+            /** @description A validation failure: one or more named per-source problems. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ValidationProblem"][];
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
                 };
             };
         };
@@ -350,13 +358,13 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Malformed upload(s): named per-source parse issues. */
+            /** @description A validation failure: one or more named per-source problems. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ValidationProblem"][];
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
                 };
             };
         };

--- a/products/pm-evals-web/frontend/src/lib/api.ts
+++ b/products/pm-evals-web/frontend/src/lib/api.ts
@@ -12,6 +12,7 @@ export type CriterionCell = components["schemas"]["CriterionCell"];
 export type HealthResponse = components["schemas"]["HealthResponse"];
 export type ParseIssue = components["schemas"]["ParseIssue"];
 export type ValidationProblem = components["schemas"]["ValidationProblem"];
+export type ValidationErrorResponse = components["schemas"]["ValidationErrorResponse"];
 export type VerdictReason = components["schemas"]["VerdictReason"];
 
 export type ApiResult<T> =
@@ -48,7 +49,15 @@ async function readValidationProblems(response: Response): Promise<ValidationPro
   if (
     Array.isArray(detail) &&
     detail.length > 0 &&
-    detail.every((p) => typeof p === "object" && p !== null && "source" in p)
+    // require the full documented shape: a source AND an issues array — a
+    // source-bearing entry without issues would otherwise crash the renderer
+    detail.every(
+      (p) =>
+        typeof p === "object" &&
+        p !== null &&
+        typeof (p as { source?: unknown }).source === "string" &&
+        Array.isArray((p as { issues?: unknown }).issues),
+    )
   ) {
     return detail as ValidationProblem[];
   }

--- a/products/pm-evals-web/frontend/tests/api-client.test.ts
+++ b/products/pm-evals-web/frontend/tests/api-client.test.ts
@@ -75,6 +75,32 @@ describe("compareRuns", () => {
     }
   });
 
+  it("surfaces a real request-field source from the unified 422 envelope (P-4)", async () => {
+    // the backend now names transport-field errors by their real source, not a
+    // mis-attributed "baseline"
+    const detail = [
+      { source: "min_matched_traces", issues: [{ location: "min_matched_traces", message: "must be >= 1" }] },
+    ];
+    const result = await compareRuns(fileOf("{}"), fileOf("{}"), fetchReturning(422, { detail }));
+    expect(result.kind).toBe("validation");
+    if (result.kind === "validation") {
+      expect(result.problems[0].source).toBe("min_matched_traces");
+    }
+  });
+
+  it("falls back safely when a 422 problem has a source but no issues array", async () => {
+    // a malformed problem must never reach the renderer's problem.issues.map
+    const result = await compareRuns(
+      fileOf("{}"),
+      fileOf("{}"),
+      fetchReturning(422, { detail: [{ source: "candidate" }] }),
+    );
+    expect(result.kind).toBe("validation");
+    if (result.kind === "validation") {
+      expect(Array.isArray(result.problems[0].issues)).toBe(true);
+    }
+  });
+
   it("maps a non-JSON 422 body to the recoverable framework message, never a crash", async () => {
     const htmlError: typeof fetch = async () =>
       new Response("<html>Bad Gateway</html>", {


### PR DESCRIPTION
# Pull request

## What changed and why

Resolves dogfood finding **P-4**: `/api/compare` (and `/api/report`) returned **three different 422 wire shapes** — `{"detail":[ValidationProblem]}` (malformed parse), `{"detail":"string"}` (out-of-range config), and FastAPI's native `{"detail":[{loc,msg,type}]}` (missing part / wrong type) — while the committed OpenAPI documented one. A typed client generated from the schema mis-parsed two of them.

Now **every 422 uses one documented envelope** `{"detail": [ValidationProblem]}`:
- `ValidationProblem.source` widened from a `baseline|candidate` Literal to `str`, so a request field (e.g. `min_matched_traces`) names itself.
- New `ValidationErrorResponse` model is the single documented 422 schema; both endpoints declare it.
- A `RequestValidationError` handler maps FastAPI's native transport errors into the same envelope, grouped by the **real** field — no more mis-attributing a missing candidate to `baseline` (dogfood F-3).
- `_config` raises the same envelope. `openapi.json` + the typed client are regenerated and byte-pinned.
- The frontend client now requires a `source` string **and** an `issues` array before trusting a 422 body, so a malformed problem can never crash the renderer's `problem.issues.map` (dogfood F-2); real field sources surface instead of the generic fallback.

Out of scope (separate follow-ups): upload size at the earliest boundary, parser hardening (NaN / duplicate keys), backend lockfile/audit.

## Requirement reference

Dogfood finding P-4 (422 wire-shape vs committed OpenAPI); PD-V3 API contract (API-1..3). Related: F-2 (client crash path), F-3 (source mis-attribution).

## Architecture impact

No new endpoint. `ValidationProblem.source` type widens (`Literal` → `str`); one new response model; one exception handler. The typed client regenerates from the committed schema (drift-checked in CI).

## Tests added

Red-first (`40152ac`) → green (`fca359c`):
- `backend/tests/test_api.py` — all four 422 kinds share one envelope; the committed OpenAPI documents that envelope; config/native errors name their real source.
- `frontend/tests/api-client.test.ts` — the client surfaces a real request-field source; falls back safely when a problem lacks an `issues` array.

Run: backend `PYTHONPATH=src pytest`; frontend `npx vitest run` + `tsc`; e2e `npx playwright test`.

## Risk level

medium — changes the 422 wire contract (a bug fix that makes wire match schema). Fully gated; typed client + OpenAPI regenerated and pinned; existing parse-error 422 shape unchanged (only config/native shapes converge onto it).

## Rollback plan

Revert this PR. No migration/state; the frozen candidate and dogfood evidence are untouched.

## Evidence

- backend `54 passed`, mypy `--strict` + ruff clean; frontend `vitest 73` + `tsc` + `next build`; Playwright e2e `15 passed` vs real servers; pmpe running (OS unaffected — product-only change).
- Frozen candidate `243eddf72005` and `docs/v3/dogfood/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq6EsYm5H7fmfJFPMcpV8g

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq6EsYm5H7fmfJFPMcpV8g)_