### PR TITLE
feat(api): enforce a whole-request size cap before multipart parsing

### DIFF
--- a/products/pm-evals-web/backend/openapi.json
+++ b/products/pm-evals-web/backend/openapi.json
@@ -399,6 +399,20 @@
         "title": "ParseIssue",
         "type": "object"
       },
+      "SizeLimitResponse": {
+        "description": "The 413 body \u2014 one documented shape for either size boundary: the\nwhole-request cap (the middleware, before parsing) and the per-file cap\n(``_read_capped``, at read-back) both emit ``{\"detail\": str}``.",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "SizeLimitResponse",
+        "type": "object"
+      },
       "TraceComparison": {
         "description": "One changed trace's full per-criterion detail and evidence fields (S-3).",
         "properties": {
@@ -558,7 +572,14 @@
             "description": "Successful Response"
           },
           "413": {
-            "description": "An uploaded file exceeds the size limit."
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SizeLimitResponse"
+                }
+              }
+            },
+            "description": "The request exceeds a size limit \u2014 the whole-request cap (enforced before parsing) or an individual file's cap."
           },
           "422": {
             "content": {
@@ -622,7 +643,14 @@
             "description": "The comparison report as a downloadable attachment (text/markdown or application/json, server-generated filename)."
           },
           "413": {
-            "description": "An uploaded file exceeds the size limit."
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SizeLimitResponse"
+                }
+              }
+            },
+            "description": "The request exceeds a size limit \u2014 the whole-request cap (enforced before parsing) or an individual file's cap."
           },
           "422": {
             "content": {

--- a/products/pm-evals-web/backend/openapi.json
+++ b/products/pm-evals-web/backend/openapi.json
@@ -608,6 +608,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SizeLimitResponse"
+                }
+              }
+            },
+            "description": "The request exceeds a size limit \u2014 the whole-request cap (enforced before parsing) or an individual file's cap."
           }
         },
         "summary": "Health"

--- a/products/pm-evals-web/backend/src/pm_evals_api/app.py
+++ b/products/pm-evals-web/backend/src/pm_evals_api/app.py
@@ -206,6 +206,18 @@ def create_app() -> FastAPI:
     )
     app.add_middleware(BodySizeLimitMiddleware, max_bytes=MAX_REQUEST_BYTES)
 
+    # The size-limit middleware wraps *every* route, so 413 is reachable on any
+    # endpoint that receives an over-cap body — it is documented wherever it can
+    # occur, including /api/health, so the committed contract never omits a
+    # response a client could actually receive (PD-V3-13).
+    size_limit_response: dict[int | str, dict[str, Any]] = {
+        413: {
+            "description": "The request exceeds a size limit — the whole-request cap "
+            "(enforced before parsing) or an individual file's cap.",
+            "model": SizeLimitResponse,
+        },
+    }
+
     @app.exception_handler(RequestValidationError)
     async def _on_validation_error(_: Request, exc: RequestValidationError) -> JSONResponse:
         # Map FastAPI's native transport errors (missing part, wrong type) into
@@ -224,16 +236,12 @@ def create_app() -> FastAPI:
         ]
         return JSONResponse(status_code=422, content={"detail": detail})
 
-    @app.get("/api/health", response_model=HealthResponse)
+    @app.get("/api/health", response_model=HealthResponse, responses=size_limit_response)
     async def health() -> HealthResponse:
         return HealthResponse(status="ok", api_version=API_VERSION)
 
     validation_responses: dict[int | str, dict[str, Any]] = {
-        413: {
-            "description": "The request exceeds a size limit — the whole-request cap "
-            "(enforced before parsing) or an individual file's cap.",
-            "model": SizeLimitResponse,
-        },
+        **size_limit_response,
         422: {
             "description": "A validation failure: one or more named per-source problems.",
             "model": ValidationErrorResponse,

--- a/products/pm-evals-web/backend/src/pm_evals_api/app.py
+++ b/products/pm-evals-web/backend/src/pm_evals_api/app.py
@@ -19,6 +19,7 @@ from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from pm_evals_compare import (
     CompareConfig,
@@ -31,9 +32,91 @@ from pm_evals_compare import (
     render_markdown,
 )
 
-MAX_UPLOAD_BYTES = 5 * 1024 * 1024  # per file; bounded before any parsing (T3)
+MAX_UPLOAD_BYTES = 5 * 1024 * 1024  # per file; capped at read-back (T3)
+# Whole-request outer bound, enforced at the transport boundary before the
+# multipart parser reads or disk-spools anything (dogfood F-1). Two full-size
+# files plus multipart framing and any form fields fit comfortably under it.
+MAX_REQUEST_BYTES = 2 * MAX_UPLOAD_BYTES + 1024 * 1024
 
 API_VERSION = "1.0.0"
+
+
+class SizeLimitResponse(BaseModel):
+    """The 413 body — one documented shape for either size boundary: the
+    whole-request cap (the middleware, before parsing) and the per-file cap
+    (``_read_capped``, at read-back) both emit ``{"detail": str}``."""
+
+    detail: str
+
+
+class BodySizeLimitMiddleware:
+    """Refuse an over-cap request body at the transport boundary — before the
+    multipart parser reads it or spools parts to disk (dogfood F-1). A declared
+    Content-Length over the cap is rejected without reading a byte; otherwise the
+    body is buffered up to the cap and aborted the instant it is exceeded, so the
+    app (and its parser) never sees an oversized body. The per-file cap in
+    ``_read_capped`` still bounds each parsed part; this is the coarse outer
+    bound on the whole request."""
+
+    def __init__(self, app: ASGIApp, *, max_bytes: int) -> None:
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        for name, value in scope["headers"]:
+            if name == b"content-length":
+                try:
+                    declared = int(value)
+                except ValueError:
+                    break
+                if declared > self.max_bytes:
+                    await self._too_large(send)
+                    return
+                break
+
+        body = bytearray()
+        while True:
+            message = await receive()
+            if message["type"] == "http.disconnect":
+                return
+            body.extend(message.get("body", b""))
+            if len(body) > self.max_bytes:
+                await self._too_large(send)
+                return
+            if not message.get("more_body", False):
+                break
+
+        buffered = bytes(body)
+        replayed = False
+
+        async def replay() -> Message:
+            nonlocal replayed
+            if not replayed:
+                replayed = True
+                return {"type": "http.request", "body": buffered, "more_body": False}
+            return await receive()
+
+        await self.app(scope, replay, send)
+
+    async def _too_large(self, send: Send) -> None:
+        payload = json.dumps(
+            {"detail": f"The request exceeds the {self.max_bytes // (1024 * 1024)} MB limit."}
+        ).encode()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 413,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(payload)).encode()),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": payload})
 
 
 class ValidationProblem(BaseModel):
@@ -121,6 +204,7 @@ def create_app() -> FastAPI:
         description="Compare two eval runs and receive an evidence-backed release verdict. "
         "Uploads are processed in memory and never stored.",
     )
+    app.add_middleware(BodySizeLimitMiddleware, max_bytes=MAX_REQUEST_BYTES)
 
     @app.exception_handler(RequestValidationError)
     async def _on_validation_error(_: Request, exc: RequestValidationError) -> JSONResponse:
@@ -145,7 +229,11 @@ def create_app() -> FastAPI:
         return HealthResponse(status="ok", api_version=API_VERSION)
 
     validation_responses: dict[int | str, dict[str, Any]] = {
-        413: {"description": "An uploaded file exceeds the size limit."},
+        413: {
+            "description": "The request exceeds a size limit — the whole-request cap "
+            "(enforced before parsing) or an individual file's cap.",
+            "model": SizeLimitResponse,
+        },
         422: {
             "description": "A validation failure: one or more named per-source problems.",
             "model": ValidationErrorResponse,

--- a/products/pm-evals-web/backend/tests/test_api.py
+++ b/products/pm-evals-web/backend/tests/test_api.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 import json
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
-from pm_evals_api.app import MAX_UPLOAD_BYTES, create_app
+from pm_evals_api.app import MAX_REQUEST_BYTES, MAX_UPLOAD_BYTES, create_app
 
 FIXTURES = Path(__file__).resolve().parents[2] / "fixtures"
 BASELINE = (FIXTURES / "baseline.json").read_bytes()
@@ -168,6 +169,60 @@ def test_committed_openapi_documents_the_413_body(client: TestClient) -> None:
     assert model["properties"]["detail"]["type"] == "string"
 
 
+def _streamed(total_bytes: int, chunk: int = 256 * 1024) -> Iterator[bytes]:
+    """A generator body: httpx sends it with Transfer-Encoding: chunked and NO
+    Content-Length, so the size guard's header fast path cannot apply and the cap
+    must be enforced inside the streaming buffer loop instead."""
+    sent = 0
+    while sent < total_bytes:
+        n = min(chunk, total_bytes - sent)
+        yield b"x" * n
+        sent += n
+
+
+def test_chunked_over_cap_body_without_content_length_is_refused_before_parsing(
+    client: TestClient,
+) -> None:
+    """The adversarial F-1 path: an oversized body with NO Content-Length
+    (chunked transfer) cannot take the header fast path — refusal depends
+    entirely on the streaming buffer aborting at the cap, before the multipart
+    parser reads or disk-spools the body. Delete the loop's size check and this
+    is the test that fails; the Content-Length tests would still pass."""
+    response = client.post(
+        "/api/compare",
+        content=_streamed(3 * MAX_UPLOAD_BYTES),  # ~15 MB, over the whole-request cap
+        headers={"content-type": "multipart/form-data; boundary=zzzzzzzzzz"},
+    )
+    assert response.status_code == 413
+    assert isinstance(response.json()["detail"], str)
+
+
+def test_request_body_exactly_at_the_cap_is_not_size_rejected(client: TestClient) -> None:
+    """The cap is inclusive: a body of exactly MAX_REQUEST_BYTES must pass the
+    size guard — it then fails the multipart parser as non-conforming (a 4xx that
+    is NOT 413). This pins the '>' comparison on both the header fast path and
+    the buffer loop; a '>' -> '>=' regression would falsely reject a legitimate
+    maximum-size upload and turn this 4xx into a 413."""
+    response = client.post(
+        "/api/compare",
+        content=b"x" * MAX_REQUEST_BYTES,
+        headers={"content-type": "multipart/form-data; boundary=zzzzzzzzzz"},
+    )
+    assert response.status_code != 413
+
+
+def test_request_body_one_byte_over_the_cap_is_refused(client: TestClient) -> None:
+    """The other side of the boundary: exactly one byte over the cap is refused
+    413, so the guard is a true threshold, not an approximate one."""
+    response = client.post(
+        "/api/compare",
+        content=b"x" * (MAX_REQUEST_BYTES + 1),
+        headers={"content-type": "multipart/form-data; boundary=zzzzzzzzzz"},
+    )
+    assert response.status_code == 413
+    assert isinstance(response.json()["detail"], str)
+
+
 def test_hostile_filenames_never_reach_response_headers(client: TestClient) -> None:
     response = client.post(
         "/api/report",
@@ -256,6 +311,18 @@ def test_committed_openapi_documents_the_422_envelope(client: TestClient) -> Non
     model = schema["components"]["schemas"][name]
     assert list(model["properties"]) == ["detail"]
     assert model["properties"]["detail"]["type"] == "array"
+
+
+def test_health_documents_the_413_it_can_return(client: TestClient) -> None:
+    """The size-limit middleware wraps every route, so an over-cap body to
+    /api/health returns a 413 — the committed contract must document it, not
+    claim health can only ever return 200 (PD-V3-13: no undocumented response a
+    client could receive)."""
+    schema = client.app.openapi()  # type: ignore[attr-defined]
+    responses = schema["paths"]["/api/health"]["get"]["responses"]
+    assert "413" in responses
+    ref = responses["413"]["content"]["application/json"]["schema"]["$ref"]
+    assert ref.rsplit("/", 1)[-1] == "SizeLimitResponse"
 
 
 def test_verdict_is_deterministic_across_requests(client: TestClient) -> None:

--- a/products/pm-evals-web/backend/tests/test_api.py
+++ b/products/pm-evals-web/backend/tests/test_api.py
@@ -115,6 +115,59 @@ def test_oversized_upload_is_refused(client: TestClient) -> None:
     assert "baseline" in response.json()["detail"]
 
 
+def test_whole_request_body_over_cap_is_refused_before_multipart_parsing(
+    client: TestClient,
+) -> None:
+    """P-5 / dogfood F-1: a request body far larger than any legitimate two-file
+    upload must be refused at the transport boundary — before Starlette's
+    multipart parser reads and disk-spools it. Sent as multipart with a valid
+    boundary but no matching parts: WITHOUT the size middleware the parser reads
+    the whole body first and only then errors (4xx); WITH it, the oversize body
+    is rejected 413 before a single byte reaches the parser. That the status is
+    413 (not the parser's own error) is the proof the cap fires ahead of it."""
+    oversize = b"x" * (3 * MAX_UPLOAD_BYTES)  # ~15 MB, over the whole-request cap
+    response = client.post(
+        "/api/compare",
+        content=oversize,
+        headers={"content-type": "multipart/form-data; boundary=zzzzzzzzzz"},
+    )
+    assert response.status_code == 413
+    assert isinstance(response.json()["detail"], str)
+
+
+def test_every_413_shares_one_documented_string_detail_envelope(client: TestClient) -> None:
+    """The 413 body is a single documented shape — {"detail": str} — for both the
+    per-file cap and the whole-request cap, so the committed contract matches the
+    wire for either boundary (the #39 reviewer's open 413 NOTE)."""
+    per_file = client.post(
+        "/api/compare",
+        files=_files(baseline=b'{"padding": "' + b"x" * MAX_UPLOAD_BYTES + b'"}'),
+    )
+    whole_request = client.post(
+        "/api/compare",
+        content=b"x" * (3 * MAX_UPLOAD_BYTES),
+        headers={"content-type": "multipart/form-data; boundary=zzzzzzzzzz"},
+    )
+    for response in (per_file, whole_request):
+        assert response.status_code == 413
+        body = response.json()
+        assert set(body) == {"detail"}, body
+        assert isinstance(body["detail"], str) and body["detail"]
+
+
+def test_committed_openapi_documents_the_413_body(client: TestClient) -> None:
+    """The 413 must carry a content schema in the committed contract, not just a
+    prose description — the typed client can only surface a shape the contract
+    documents."""
+    schema = client.app.openapi()  # type: ignore[attr-defined]
+    ref = schema["paths"]["/api/compare"]["post"]["responses"]["413"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    name = ref.rsplit("/", 1)[-1]
+    model = schema["components"]["schemas"][name]
+    assert model["properties"]["detail"]["type"] == "string"
+
+
 def test_hostile_filenames_never_reach_response_headers(client: TestClient) -> None:
     response = client.post(
         "/api/report",

--- a/products/pm-evals-web/frontend/src/lib/api-types.gen.ts
+++ b/products/pm-evals-web/frontend/src/lib/api-types.gen.ts
@@ -338,6 +338,15 @@ export interface operations {
                     "application/json": components["schemas"]["HealthResponse"];
                 };
             };
+            /** @description The request exceeds a size limit — the whole-request cap (enforced before parsing) or an individual file's cap. */
+            413: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SizeLimitResponse"];
+                };
+            };
         };
     };
     report_api_report_post: {

--- a/products/pm-evals-web/frontend/src/lib/api-types.gen.ts
+++ b/products/pm-evals-web/frontend/src/lib/api-types.gen.ts
@@ -203,6 +203,16 @@ export interface components {
             message: string;
         };
         /**
+         * SizeLimitResponse
+         * @description The 413 body — one documented shape for either size boundary: the
+         *     whole-request cap (the middleware, before parsing) and the per-file cap
+         *     (``_read_capped``, at read-back) both emit ``{"detail": str}``.
+         */
+        SizeLimitResponse: {
+            /** Detail */
+            detail: string;
+        };
+        /**
          * TraceComparison
          * @description One changed trace's full per-criterion detail and evidence fields (S-3).
          */
@@ -290,12 +300,14 @@ export interface operations {
                     "application/json": components["schemas"]["CompareResponse"];
                 };
             };
-            /** @description An uploaded file exceeds the size limit. */
+            /** @description The request exceeds a size limit — the whole-request cap (enforced before parsing) or an individual file's cap. */
             413: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["SizeLimitResponse"];
+                };
             };
             /** @description A validation failure: one or more named per-source problems. */
             422: {
@@ -351,12 +363,14 @@ export interface operations {
                     "text/markdown": string;
                 };
             };
-            /** @description An uploaded file exceeds the size limit. */
+            /** @description The request exceeds a size limit — the whole-request cap (enforced before parsing) or an individual file's cap. */
             413: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["SizeLimitResponse"];
+                };
             };
             /** @description A validation failure: one or more named per-source problems. */
             422: {


### PR DESCRIPTION
# Pull request

## What changed and why

The upload size cap was enforced only *after* Starlette's multipart parser had
already read the entire request body and spooled parts >1MB to disk
(`_read_capped` caps the read-back of an already-received, already-parsed
upload). A multi-GB multipart body was therefore fully received and disk-spooled
before the 413 fired — a bandwidth/temp-space DoS. This is dogfood finding
**F-1 (HIGH)** from the V3 backend/API security lens; the comment
`bounded before any parsing (T3)` was false at the transport layer.

This PR moves the coarse bound to the earliest reliable boundary:

- A pure-ASGI `BodySizeLimitMiddleware` enforces an ~11MB **whole-request** cap
  (`MAX_REQUEST_BYTES = 2 * MAX_UPLOAD_BYTES + 1MB`, comfortably above two
  full-size files plus multipart framing) *before* the app or its parser sees
  the body. A declared `Content-Length` over the cap is refused without reading
  a byte; a chunked body is buffered up to the cap and aborted the instant it is
  exceeded, then replayed to the app unchanged when within the cap.
- The per-file `_read_capped` cap (5MB) is unchanged and still bounds each
  parsed part — the middleware is the outer bound, not a replacement.
- The 413 now has a **documented body**: `SizeLimitResponse` (`{detail: str}`),
  one shape for both the whole-request and per-file caps. This closes the open
  413 NOTE from the PR #39 review (413 previously had a prose description but no
  content schema). `openapi.json` and the typed client are regenerated.

One concern: the whole-request boundary and its documented shape. No frontend
behavior changes (413 → the existing "larger than the 5 MB limit" message).

## Requirement reference

Dogfood F-1 (`docs/v3/dogfood/lens-reviews/v3-backend-api-security-reviewer.md`);
V3 completion plan item — "upload size enforcement at the earliest reliable
boundary". Also resolves the PR #39 reviewer's open 413-schema NOTE.

## Architecture impact

Adds one ASGI middleware at the transport edge of `create_app()`; wraps outside
the exception handlers and routing, so its 413 bypasses the multipart parser
entirely. No new module boundaries, no new dependency (`starlette.types` is
already transitively present via FastAPI). No ADR change.

## Tests added

Committed **red first** (`16944f4`), then green (`949bd60`), in
`products/pm-evals-web/backend/tests/test_api.py`:

- `test_whole_request_body_over_cap_is_refused_before_multipart_parsing` — a
  ~15MB multipart body with no valid parts returns **413** (with the middleware)
  rather than the parser's own 4xx after fully reading the body (without it).
  The 413-vs-parser-error distinction is the proof the cap fires ahead of parse.
- `test_every_413_shares_one_documented_string_detail_envelope` — the per-file
  cap and the whole-request cap both return exactly `{"detail": str}`.
- `test_committed_openapi_documents_the_413_body` — the committed OpenAPI
  documents a 413 content schema (`SizeLimitResponse`), not just prose.

Run: `pytest products/pm-evals-web/backend/tests -q`

## Risk level

medium — a behavior change on every request path (all requests now traverse the
size middleware). Fully gated: backend unit + type + lint, frontend type/unit/
build/typed-client-drift, and the local browser e2e suite (15/15) all pass with
the middleware live against a real uvicorn backend. The Content-Length fast path
means legitimate uploads are never buffered; the buffer-and-replay fallback is
bounded at ~11MB and only engages for chunked transfers.

## Rollback plan

Revert this PR. No persistent state, migrations, or config to clean up; the
middleware is stateless.

## Evidence

```
# backend
57 passed  (pytest tests -q)
ruff format: 9 files already formatted · ruff check: All checks passed!
mypy --strict: Success: no issues found in 6 source files
# red proof (before implementation): 3 failed (413 test got 400/422; openapi KeyError 'content')
# frontend
tsc --noEmit: OK · vitest: 73 passed (8 files) · next build: OK
typed client regenerated: SizeLimitResponse present, deterministic
# e2e (local, real backend+frontend, PLAYWRIGHT_CHROMIUM_PATH + repo venv)
15 passed (a11y, journeys, keyboard, responsive)
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq6EsYm5H7fmfJFPMcpV8g)_