### PR TITLE
fix(upload): last-selected file wins the read race, not last-completed

### DIFF
--- a/products/pm-evals-web/frontend/src/components/upload-form.tsx
+++ b/products/pm-evals-web/frontend/src/components/upload-form.tsx
@@ -8,7 +8,7 @@
 // JSX text nodes throughout — filenames and server-sent messages are escaped
 // by React, never injected as markup.
 
-import { useId, useState } from "react";
+import { useId, useRef, useState } from "react";
 
 import { compareRuns, type Comparison, type ValidationProblem } from "@/lib/api";
 import {
@@ -84,6 +84,11 @@ export function UploadForm({ fetcher = fetch, onComparison, onLoadingChange }: U
   // the in-flight input lock, no handleSelect completion can ever land while
   // a comparison is loading.
   const [pendingReads, setPendingReads] = useState(0);
+  // Per-source selection token: every handleSelect bumps its source's counter,
+  // and a read only applies its result if the token is still current. A slower
+  // earlier read completing after a newer selection is discarded, so the file
+  // that wins is the last SELECTED, never the last to finish reading (F-1).
+  const readGeneration = useRef<Record<UploadSource, number>>({ baseline: 0, candidate: 0 });
 
   const pairIssues: LocalIssue[] =
     selected.baseline?.pre.run && selected.candidate?.pre.run
@@ -117,6 +122,9 @@ export function UploadForm({ fetcher = fetch, onComparison, onLoadingChange }: U
     setApiProblems(null);
     setApiError(null);
     clearComparison();
+    // Claim this source's newest selection token before any await, so a read
+    // started earlier can tell it has been superseded (a re-select or a clear).
+    const generation = (readGeneration.current[source] += 1);
     if (file === null) {
       setSelected((prev) => ({ ...prev, [source]: undefined }));
       return;
@@ -143,8 +151,12 @@ export function UploadForm({ fetcher = fetch, onComparison, onLoadingChange }: U
         run: null,
       };
     }
-    setSelected((prev) => ({ ...prev, [source]: { file, pre } }));
-    setPhase("empty");
+    // Discard a result the user has already replaced: only the latest selection
+    // for this source may land, regardless of which read finished first.
+    if (readGeneration.current[source] === generation) {
+      setSelected((prev) => ({ ...prev, [source]: { file, pre } }));
+      setPhase("empty");
+    }
     setPendingReads((n) => n - 1);
   }
 

--- a/products/pm-evals-web/frontend/src/components/upload-form.tsx
+++ b/products/pm-evals-web/frontend/src/components/upload-form.tsx
@@ -122,6 +122,11 @@ export function UploadForm({ fetcher = fetch, onComparison, onLoadingChange }: U
     setApiProblems(null);
     setApiError(null);
     clearComparison();
+    // Any selection change invalidates a shown verdict, so normalize the phase
+    // now — on every path (clear, applied, or a later-discarded read) — rather
+    // than only when a read lands, which could otherwise strand phase at
+    // "success" with an empty status region.
+    setPhase("empty");
     // Claim this source's newest selection token before any await, so a read
     // started earlier can tell it has been superseded (a re-select or a clear).
     const generation = (readGeneration.current[source] += 1);
@@ -152,10 +157,10 @@ export function UploadForm({ fetcher = fetch, onComparison, onLoadingChange }: U
       };
     }
     // Discard a result the user has already replaced: only the latest selection
-    // for this source may land, regardless of which read finished first.
+    // for this source may land, regardless of which read finished first. (Phase
+    // was already normalized to "empty" at the top, on every path.)
     if (readGeneration.current[source] === generation) {
       setSelected((prev) => ({ ...prev, [source]: { file, pre } }));
-      setPhase("empty");
     }
     setPendingReads((n) => n - 1);
   }

--- a/products/pm-evals-web/frontend/tests/upload-form.test.tsx
+++ b/products/pm-evals-web/frontend/tests/upload-form.test.tsx
@@ -177,6 +177,50 @@ describe("UploadForm — loading state (J-5)", () => {
     }
   });
 
+  it("discards a stale slow read: the last-SELECTED file wins, not the last-COMPLETED (F-1)", async () => {
+    // Re-selecting the same source while its first read is still in flight is a
+    // race: without a per-source generation token, the slower FIRST read
+    // completing AFTER the faster SECOND read overwrites the newer file, and the
+    // form then submits the stale pair while the input holds the newer file.
+    const releases: Array<() => void> = [];
+    const RealFileReader = FileReader;
+    class GatedFileReader {
+      result: string | ArrayBuffer | null = null;
+      error: DOMException | null = null;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsText(file: File): void {
+        const inner = new RealFileReader();
+        inner.onload = () => {
+          releases.push(() => {
+            this.result = inner.result;
+            this.onload?.();
+          });
+        };
+        inner.readAsText(file);
+      }
+    }
+    vi.stubGlobal("FileReader", GatedFileReader as unknown as typeof FileReader);
+    try {
+      render(<UploadForm />);
+      // First selection (its read will be released LAST — the stale one).
+      selectFile(/baseline/i, fileOf(VALID_BASELINE, "stale-A.json"));
+      await waitFor(() => expect(releases).toHaveLength(1));
+      // Re-select the SAME source before the first read resolves.
+      selectFile(/baseline/i, fileOf(VALID_BASELINE, "fresh-B.json"));
+      await waitFor(() => expect(releases).toHaveLength(2));
+      // The newer selection (B) completes first...
+      act(() => releases[1]());
+      // ...then the older selection (A) completes late; it must be discarded.
+      act(() => releases[0]());
+      // The form holds the last-SELECTED file, never the last-COMPLETED one.
+      await waitFor(() => expect(screen.getByText(/fresh-B\.json/)).toBeInTheDocument());
+      expect(screen.queryByText(/stale-A\.json/)).not.toBeInTheDocument();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("announces status changes politely to assistive technology", async () => {
     const never: typeof fetch = () => new Promise(() => {});
     render(<UploadForm fetcher={never} />);

--- a/products/pm-evals-web/frontend/tests/upload-form.test.tsx
+++ b/products/pm-evals-web/frontend/tests/upload-form.test.tsx
@@ -216,9 +216,33 @@ describe("UploadForm — loading state (J-5)", () => {
       // The form holds the last-SELECTED file, never the last-COMPLETED one.
       await waitFor(() => expect(screen.getByText(/fresh-B\.json/)).toBeInTheDocument());
       expect(screen.queryByText(/stale-A\.json/)).not.toBeInTheDocument();
+      // The discarded read still balanced pendingReads back to 0: had A's
+      // decrement not run, pendingReads would stay stuck > 0 and the button
+      // could never enable. Release a candidate read and the button enables.
+      selectFile(/candidate/i, fileOf(VALID_CANDIDATE, "candidate.json"));
+      await waitFor(() => expect(releases).toHaveLength(3));
+      act(() => releases[2]());
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: /compare runs/i })).toBeEnabled(),
+      );
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it("clearing a source while a comparison shows returns to the empty state, not a stranded success", async () => {
+    // After a verdict is shown, changing a selection invalidates it; the phase
+    // must normalize to empty on every path — including a clear — so no empty
+    // status region is left behind under a stale "success" phase.
+    render(<UploadForm fetcher={fetchReturning(200, { comparison: PROCEED_COMPARISON })} />);
+    await selectBothValidFiles();
+    fireEvent.click(screen.getByRole("button", { name: /compare runs/i }));
+    expect((await screen.findByRole("status")).textContent).toContain("PROCEED");
+    // Clear the baseline input (no file selected).
+    fireEvent.change(screen.getByLabelText(/baseline/i), { target: { files: [] } });
+    await waitFor(() => expect(screen.queryByText(/PROCEED/)).not.toBeInTheDocument());
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /compare runs/i })).toBeDisabled();
   });
 
   it("announces status changes politely to assistive technology", async () => {


### PR DESCRIPTION
# Pull request

## What changed and why

Dogfood finding **frontend F-1 (MEDIUM)**: `handleSelect` had no per-source
generation token. `pendingReads` blocks submit only *while* reads are in flight,
so when a source is re-selected before its first read resolves, the **slower
earlier read completing last overwrites the newer file**. After both settle
`pendingReads === 0`, the file-note and the submitted pair are the stale file,
while the file input and the user's intent hold the newer one.

Fix: a per-source `readGeneration` ref. Every `handleSelect` claims a fresh token
before any `await`; a read applies its result only if the token is still
current. A superseded read (a re-select, or a clear) is discarded, so the file
that wins is the **last selected**, regardless of which read finishes first.

One concern: the upload-form read-race correctness. No API/contract change.

## Requirement reference

Dogfood frontend F-1 (`docs/v3/dogfood/lens-reviews/v3-frontend-accessibility-reviewer.md`).
V3 completion plan item 2 — remaining frontend/backend integration gaps.

## Architecture impact

None. Internal to `upload-form.tsx`; adds one `useRef`. No new state machine, no
schema/API/typed-client change (typed-client drift check confirms no drift).

## Tests added

Committed **red first** (`070c0e8`), then green (`6e0438e`), in
`tests/upload-form.test.tsx`:

- `discards a stale slow read: the last-SELECTED file wins, not the last-COMPLETED (F-1)`
  — a gated `FileReader` releases two same-source reads out of selection order
  (newer first, older last) and asserts the form holds the newer file. This
  complements the existing pending-read test (which covers submit-blocking while
  a read is in flight) with the out-of-order-completion case it did not reach.

Run: `npx vitest run` (in `products/pm-evals-web/frontend`).

## Risk level

low — a narrowing correctness fix; a discarded read is one the user already
replaced. All previously-valid flows unaffected (74 vitest, e2e 15/15).

## Rollback plan

Revert this PR. No state or config to clean up.

## Evidence

```
vitest: 74 passed (upload-form 17/17, incl. the new F-1 race + the existing pending-read race)
tsc --noEmit: OK · next build: OK · typed-client: no drift
e2e (local, real backend+frontend): 15 passed
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq6EsYm5H7fmfJFPMcpV8g)_