### PR TITLE
test(e2e): cover the S-3 trace filter and Show select in the browser

### DIFF
--- a/products/pm-evals-web/e2e/tests/trace-filter.spec.ts
+++ b/products/pm-evals-web/e2e/tests/trace-filter.spec.ts
@@ -10,7 +10,7 @@ import { compareFixtures } from "./helpers";
 
 test("S-3 changed-trace filters narrow the browser view (J-7)", async ({ page }) => {
   await page.goto("/");
-  await compareFixtures(page); // REGRESSION: 4 changed traces, mixed direction
+  await compareFixtures(page); // REGRESSION: 4 changed traces, both directions present
 
   const traces = page.getByRole("region", { name: /changed traces/i });
   const list = traces.getByRole("list", { name: /changed traces/i });
@@ -23,9 +23,10 @@ test("S-3 changed-trace filters narrow the browser view (J-7)", async ({ page })
   await expect(list.getByRole("button")).toHaveCount(1);
   await expect(list.getByRole("button", { name: /^T-006/ })).toBeVisible();
 
-  // A filter that matches nothing shows the declared empty state.
+  // A filter that matches nothing shows the declared empty state and no rows.
   await traces.getByLabel(/filter changed traces/i).fill("T-999");
   await expect(traces.getByText(/no changed traces match the filter/i)).toBeVisible();
+  await expect(list.getByRole("button")).toHaveCount(0);
 
   // Clear the text filter, then filter by direction via the Show select.
   await traces.getByLabel(/filter changed traces/i).fill("");

--- a/products/pm-evals-web/e2e/tests/trace-filter.spec.ts
+++ b/products/pm-evals-web/e2e/tests/trace-filter.spec.ts
@@ -1,0 +1,42 @@
+// UX F-3 / GATE-1: the S-3 "Filter changed traces" input and the "Show"
+// direction select were exercised only in jsdom; every browser path clicked a
+// trace directly, so the filter half of J-7 could regress in the real build
+// while browser E2E still reported green. This drives both controls in the real
+// build against the REGRESSION fixture, whose changed traces span both
+// directions: T-001/T-002/T-006 regressed, T-003 improved (4 total).
+import { expect, test } from "@playwright/test";
+
+import { compareFixtures } from "./helpers";
+
+test("S-3 changed-trace filters narrow the browser view (J-7)", async ({ page }) => {
+  await page.goto("/");
+  await compareFixtures(page); // REGRESSION: 4 changed traces, mixed direction
+
+  const traces = page.getByRole("region", { name: /changed traces/i });
+  const list = traces.getByRole("list", { name: /changed traces/i });
+
+  // All four changed traces are shown before any filtering.
+  await expect(list.getByRole("button")).toHaveCount(4);
+
+  // The text filter narrows the list to matching trace ids.
+  await traces.getByLabel(/filter changed traces/i).fill("T-006");
+  await expect(list.getByRole("button")).toHaveCount(1);
+  await expect(list.getByRole("button", { name: /^T-006/ })).toBeVisible();
+
+  // A filter that matches nothing shows the declared empty state.
+  await traces.getByLabel(/filter changed traces/i).fill("T-999");
+  await expect(traces.getByText(/no changed traces match the filter/i)).toBeVisible();
+
+  // Clear the text filter, then filter by direction via the Show select.
+  await traces.getByLabel(/filter changed traces/i).fill("");
+  await traces.getByLabel(/^show$/i).selectOption("regressed");
+  await expect(list.getByRole("button")).toHaveCount(3); // T-001, T-002, T-006
+  await expect(list.getByRole("button", { name: /^T-003/ })).toHaveCount(0);
+
+  await traces.getByLabel(/^show$/i).selectOption("improved");
+  await expect(list.getByRole("button")).toHaveCount(1); // T-003
+  await expect(list.getByRole("button", { name: /^T-003/ })).toBeVisible();
+
+  await traces.getByLabel(/^show$/i).selectOption("all");
+  await expect(list.getByRole("button")).toHaveCount(4);
+});


### PR DESCRIPTION
# Pull request

## What changed and why

Dogfood finding **UX F-3 (MINOR, GATE-1)**: no browser spec touched the S-3
"Filter changed traces" input or the "Show" direction select — every e2e path
clicked a trace button directly, so the filter half of journey step J-7 could
regress in the real build while browser E2E still reported green. Filtering was
proven only in jsdom (`trace-explorer.test.tsx`).

Add `e2e/tests/trace-filter.spec.ts`: against the REGRESSION fixture's four
mixed-direction changed traces (T-001/T-002/T-006 regressed, T-003 improved), it
narrows the list by text, shows the declared empty state on a non-match, and
filters by direction via the Show select — all in the real production build.

One concern: browser coverage of the S-3 filter controls. Test-only.

## Requirement reference

Dogfood UX F-3 (`docs/v3/dogfood/lens-reviews/v3-ux-journey-reviewer.md`),
GATE-1 (the full primary journey passes browser E2E).

## Architecture impact

None. Adds one Playwright spec; no production code touched.

## Tests added

- `e2e/tests/trace-filter.spec.ts` — exercises the text filter (narrow + empty
  state) and the Show select (regressed/improved/all). The controls already
  work; the test guards them in-browser. Proven **non-vacuous by mutation**:
  disabling the text filter makes the count assertion fail (4, not 1).

Run: `npx playwright test trace-filter.spec.ts` (in `products/pm-evals-web/e2e`).

## Risk level

low — test-only browser coverage addition.

## Rollback plan

Revert this PR. No production impact.

## Evidence

```
playwright: 16 passed (new trace-filter 1/1)
mutation (text filter disabled): 1 failed — toHaveCount(1) got 4 (reverted, rebuilt clean)
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq6EsYm5H7fmfJFPMcpV8g)_