### PR TITLE
test(api): guard the no-egress half of the J-1 "no data leaves" promise

### DIFF
--- a/products/pm-evals-web/backend/tests/test_api.py
+++ b/products/pm-evals-web/backend/tests/test_api.py
@@ -413,10 +413,19 @@ def test_a_request_opens_no_outbound_connection(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """J-1's "no data leaves this app" rests on the backend calling nothing
-    outbound (app.py: "No egress: the backend calls nothing"). The no-persistence
-    half is tested; guard the no-egress half too: any socket connection attempt
-    during a compare or a report — a dependency adding telemetry, say — would
-    break the promise shown to the user, so fail on any connect."""
+    outbound (app.py: "No egress: the backend calls nothing"). Guard the
+    no-egress half: record every in-process TCP connect() during a compare and a
+    report (both formats) and assert none is initiated. This observes the named
+    threat — a dependency adding an HTTP client — because requests / urllib /
+    httpx and asyncio all funnel outbound TCP through ``socket.socket.connect``.
+
+    Scope: this proves no in-process TCP connect on the request path. It does not
+    prove the absence of exotic channels (a subprocess with its own socket table,
+    UDP sendto, C-level DNS, or a socket connected before the patch) — the app
+    statically imports none of those primitives (grep of src/ shows no socket /
+    requests / urllib / httpx / subprocess import), which is why they cannot
+    occur. On the Linux CI target the asyncio self-pipe uses ``socketpair`` (no
+    connect), so the count is deterministic."""
     import socket
 
     connects: list[Any] = []
@@ -429,7 +438,27 @@ def test_a_request_opens_no_outbound_connection(
     monkeypatch.setattr(socket.socket, "connect", recording_connect)
     assert client.post("/api/compare", files=_files(candidate=REGRESSION)).status_code == 200
     assert client.post("/api/report", files=_files(), data={"format": "json"}).status_code == 200
+    assert (
+        client.post(
+            "/api/report", files=_files(candidate=REGRESSION), data={"format": "markdown"}
+        ).status_code
+        == 200
+    )
     assert connects == [], f"the backend attempted an outbound connection: {connects}"
+
+    # Positive control: without this, `connects == []` could pass because the
+    # recorder is not armed (a drifted monkeypatch target), not because the
+    # backend is silent. A deliberate connect to a closed local port must be
+    # recorded — proving the chokepoint above is live.
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.settimeout(0.05)
+    try:
+        probe.connect(("127.0.0.1", 1))
+    except OSError:
+        pass  # refused/unreachable is fine — the connect() call is what we assert on
+    finally:
+        probe.close()
+    assert connects == [("127.0.0.1", 1)], "the egress guard is not armed — it recorded no connect"
 
 
 def test_openapi_schema_is_committed_and_current(client: TestClient) -> None:

--- a/products/pm-evals-web/backend/tests/test_api.py
+++ b/products/pm-evals-web/backend/tests/test_api.py
@@ -409,6 +409,29 @@ def test_spooled_upload_and_error_path_leave_no_residue(
     assert list(spool.iterdir()) == []
 
 
+def test_a_request_opens_no_outbound_connection(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """J-1's "no data leaves this app" rests on the backend calling nothing
+    outbound (app.py: "No egress: the backend calls nothing"). The no-persistence
+    half is tested; guard the no-egress half too: any socket connection attempt
+    during a compare or a report — a dependency adding telemetry, say — would
+    break the promise shown to the user, so fail on any connect."""
+    import socket
+
+    connects: list[Any] = []
+    real_connect = socket.socket.connect
+
+    def recording_connect(self: socket.socket, address: Any) -> Any:
+        connects.append(address)
+        return real_connect(self, address)
+
+    monkeypatch.setattr(socket.socket, "connect", recording_connect)
+    assert client.post("/api/compare", files=_files(candidate=REGRESSION)).status_code == 200
+    assert client.post("/api/report", files=_files(), data={"format": "json"}).status_code == 200
+    assert connects == [], f"the backend attempted an outbound connection: {connects}"
+
+
 def test_openapi_schema_is_committed_and_current(client: TestClient) -> None:
     """The committed OpenAPI schema is the contract (PD-V3-13): the live app
     must match it byte-for-byte under the export serialization (the CI diff


### PR DESCRIPTION
# Pull request

## What changed and why

Dogfood finding **UX F-4 (MINOR)**: the app tells the user "no data leaves this
app" (J-1). The "never stored" half is backend-tested
(`test_uploads_leave_no_residue`), but nothing verified the no-third-party-egress
guardrail the sentence also rests on — so a dependency that added telemetry (an
outbound call) would silently make the promise false, and no test would flag it.

Add `test_a_request_opens_no_outbound_connection`: it records every
`socket.socket.connect` during a compare and a report and asserts none occurs.
The backend's contract is "No egress: the backend calls nothing" (`app.py`), and
this guards it.

One concern: the no-egress guarantee behind the J-1 promise. Test-only.

## Requirement reference

Dogfood UX F-4 (`docs/v3/dogfood/lens-reviews/v3-ux-journey-reviewer.md`);
the `app.py` no-egress contract; J-1 (`explainer.tsx` "no data leaves this app").

## Architecture impact

None. Adds one backend test; no production code, schema, or API change.

## Tests added

- `backend/tests/test_api.py::test_a_request_opens_no_outbound_connection` —
  monkeypatches `socket.socket.connect` to record attempts; a compare and a
  report make zero outbound connections. Proven non-vacuous: a deliberate
  `connect` is recorded by the same hook.

Run: `pytest products/pm-evals-web/backend/tests -q -k outbound`

## Risk level

low — test-only coverage addition.

## Rollback plan

Revert this PR. No production impact.

## Evidence

```
backend: 74 passed · ruff format/check clean · mypy --strict clean
egress test: compare + report → 0 outbound connections; a deliberate connect IS recorded
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq6EsYm5H7fmfJFPMcpV8g)_