### PR TITLE
fix(frontend): run the mobile journey at 375px and link aria-controls

### DIFF
--- a/products/pm-evals-web/e2e/playwright.config.ts
+++ b/products/pm-evals-web/e2e/playwright.config.ts
@@ -31,10 +31,16 @@ export default defineConfig({
       testIgnore: /responsive\.spec\.ts/,
     },
     {
-      // the device profile supplies the mobile viewport/UA; Chromium is
-      // forced because it is the only installed engine (documented seam)
+      // the device profile supplies the mobile UA; the viewport is pinned to the
+      // contract's 375px (PD-V3-09) rather than the iPhone 12 profile's 390px, so
+      // the whole mobile journey is exercised at the declared width. Chromium is
+      // forced because it is the only installed engine (documented seam).
       name: "mobile-chromium",
-      use: { ...devices["iPhone 12"], browserName: "chromium" },
+      use: {
+        ...devices["iPhone 12"],
+        viewport: { width: 375, height: 812 },
+        browserName: "chromium",
+      },
       testMatch: /responsive\.spec\.ts/,
     },
   ],

--- a/products/pm-evals-web/e2e/tests/a11y.spec.ts
+++ b/products/pm-evals-web/e2e/tests/a11y.spec.ts
@@ -46,7 +46,14 @@ test("S-2 dashboard and downloads after a real comparison (J-6/J-8) are axe-clea
 test("S-3 trace detail (J-7) is axe-clean", async ({ page }) => {
   await page.goto("/");
   await compareFixtures(page);
-  await page.getByRole("button", { name: /^T-006$/ }).click();
-  await expect(page.getByRole("region", { name: /trace T-006 detail/i })).toBeVisible();
+  const traceButton = page.getByRole("button", { name: /^T-006$/ });
+  await traceButton.click();
+  const detail = page.getByRole("region", { name: /trace T-006 detail/i });
+  await expect(detail).toBeVisible();
+  // The expanded button is programmatically linked to the region it reveals
+  // (aria-controls → the detail's id), so AT users can follow the relationship.
+  const controls = await traceButton.getAttribute("aria-controls");
+  expect(controls).toBe(await detail.getAttribute("id"));
+  expect(controls).toBeTruthy();
   await expectNoViolations(page);
 });

--- a/products/pm-evals-web/e2e/tests/responsive.spec.ts
+++ b/products/pm-evals-web/e2e/tests/responsive.spec.ts
@@ -1,6 +1,7 @@
-// PD-V3-09: the journey works at a phone viewport (iPhone 12 profile,
-// 390x844) with no horizontal page overflow — the criterion table scrolls
-// inside its own container, never the page.
+// PD-V3-09: the journey works at the contract's declared 375px phone viewport
+// (the mobile-chromium project pins width 375 with the iPhone 12 UA) with no
+// horizontal page overflow — the criterion table scrolls inside its own
+// container, never the page.
 import { expect, test } from "@playwright/test";
 
 import { compareFixtures } from "./helpers";
@@ -19,6 +20,8 @@ test("the journey completes at a phone viewport without horizontal overflow", as
   page,
 }) => {
   await page.goto("/");
+  // The whole journey below runs at the contract's declared 375px width.
+  expect(page.viewportSize()?.width).toBe(375);
   await expect(page.getByRole("heading", { name: /compare eval runs/i })).toBeVisible();
   await expectNoHorizontalOverflow(page);
 

--- a/products/pm-evals-web/frontend/src/components/trace-explorer.tsx
+++ b/products/pm-evals-web/frontend/src/components/trace-explorer.tsx
@@ -108,6 +108,11 @@ export function TraceExplorer({
                   )
                 }
                 aria-expanded={selectedTrace === trace.trace_id}
+                aria-controls={
+                  selectedTrace === trace.trace_id
+                    ? `trace-detail-${trace.trace_id}`
+                    : undefined
+                }
               >
                 {trace.trace_id}
               </button>{" "}
@@ -124,7 +129,12 @@ export function TraceExplorer({
 
 function TraceDetail({ trace }: { trace: TraceComparison }) {
   return (
-    <div role="region" aria-label={`Trace ${trace.trace_id} detail`} className="trace-detail">
+    <div
+      id={`trace-detail-${trace.trace_id}`}
+      role="region"
+      aria-label={`Trace ${trace.trace_id} detail`}
+      className="trace-detail"
+    >
       <h3>{trace.trace_id}</h3>
       <dl className="trace-evidence">
         <div>

--- a/products/pm-evals-web/frontend/src/components/trace-explorer.tsx
+++ b/products/pm-evals-web/frontend/src/components/trace-explorer.tsx
@@ -12,6 +12,15 @@ import type { Comparison, CriterionCell, TraceComparison } from "@/lib/api";
 
 type DirectionFilter = "all" | "improved" | "regressed";
 
+// The trace_id is uploaded content (the backend only enforces min_length=1), so
+// encode it before it becomes a DOM id / aria-controls IDREF: encodeURIComponent
+// strips ASCII whitespace (space -> %20, etc.), keeping the value a single valid
+// IDREF even for a hostile trace_id. The button and its region derive their link
+// from this one helper, so they always match.
+function traceDetailId(traceId: string): string {
+  return `trace-detail-${encodeURIComponent(traceId)}`;
+}
+
 function matchesDirection(trace: TraceComparison, filter: DirectionFilter): boolean {
   if (filter === "all") return true;
   if (filter === "improved") return trace.direction === "improved" || trace.direction === "mixed";
@@ -109,9 +118,7 @@ export function TraceExplorer({
                 }
                 aria-expanded={selectedTrace === trace.trace_id}
                 aria-controls={
-                  selectedTrace === trace.trace_id
-                    ? `trace-detail-${trace.trace_id}`
-                    : undefined
+                  selectedTrace === trace.trace_id ? traceDetailId(trace.trace_id) : undefined
                 }
               >
                 {trace.trace_id}
@@ -130,7 +137,7 @@ export function TraceExplorer({
 function TraceDetail({ trace }: { trace: TraceComparison }) {
   return (
     <div
-      id={`trace-detail-${trace.trace_id}`}
+      id={traceDetailId(trace.trace_id)}
       role="region"
       aria-label={`Trace ${trace.trace_id} detail`}
       className="trace-detail"

--- a/products/pm-evals-web/frontend/tests/trace-explorer.test.tsx
+++ b/products/pm-evals-web/frontend/tests/trace-explorer.test.tsx
@@ -130,4 +130,21 @@ describe("TraceExplorer — S-3 Trace Detail (J-7)", () => {
     });
     expect(screen.getByText(/no changed traces match/i)).toBeInTheDocument();
   });
+
+  it("keeps aria-controls a valid IDREF for a trace_id containing whitespace", () => {
+    // trace_id is uploaded content (backend only enforces min_length=1); a
+    // whitespace id must not produce an invalid DOM id / multi-token aria-controls.
+    const hostile = {
+      ...edge,
+      trace_details: [{ ...edge.trace_details[0], trace_id: "T 006" }],
+    } as Comparison;
+    render(<TraceExplorer comparison={hostile} />);
+    const button = screen.getByRole("button", { name: /^T 006$/ });
+    fireEvent.click(button);
+    const controls = button.getAttribute("aria-controls");
+    const region = screen.getByRole("region", { name: /trace T 006 detail/i });
+    expect(controls).toBe(region.getAttribute("id")); // link is consistent
+    expect(controls).toBeTruthy();
+    expect(controls).not.toMatch(/\s/); // a single valid IDREF has no whitespace
+  });
 });


### PR DESCRIPTION
# Pull request

## What changed and why

Two dogfood frontend/accessibility findings, both plan verification items:

- **F5 / product-conformance 2 — 375px journey.** The `mobile-chromium` e2e
  project used the iPhone 12 profile's 390px viewport, so the contract's declared
  375px width (PD-V3-09) was never exercised by the primary journey (only a single
  S-3 table check set 375 explicitly). Pin the project viewport to 375×812
  (keeping the iPhone 12 UA), so the whole mobile journey runs at the declared
  width; the journey spec asserts `viewportSize().width === 375`.
- **F6 — `aria-expanded` without `aria-controls`.** S-3 trace buttons announced
  "expanded" with no programmatic link to what expanded. Add `aria-controls`
  (only when expanded, so it never references a non-existent element and stays
  axe-clean) pointing to the detail region's `id`, both routed through a single
  `traceDetailId()` helper that `encodeURIComponent`s the uploaded `trace_id` (so
  a whitespace/hostile id can't produce an invalid IDREF). The S-3 a11y spec
  asserts the button↔region link.

One concern: frontend accessibility & 375px-journey conformance. No API/contract
change.

## Requirement reference

Dogfood frontend F5, F6 and product-conformance finding 2
(`docs/v3/dogfood/lens-reviews/`); PD-V3-09 (375px, a11y).

## Architecture impact

None. One e2e config viewport pin, spec assertions, and one component's
`aria-controls`/`id` (via a sanitizing helper). No schema/API/typed-client change.

## Tests added

- `e2e/responsive.spec.ts`: journey asserts the 375px width; `a11y.spec.ts` S-3
  asserts `button.aria-controls === detail.id` (truthy).
- `frontend/tests/trace-explorer.test.tsx`: a whitespace `trace_id` keeps
  `aria-controls` a single valid whitespace-free IDREF matching the region id.

Run: `npx playwright test a11y.spec.ts responsive.spec.ts` (e2e); `npx vitest run` (frontend).

## Risk level

low — test/config + one component attribute (via a sanitizing helper). e2e
a11y (axe-clean) + responsive-at-375 and full vitest pass.

## Rollback plan

Revert this PR. No production impact.

## Evidence

```
frontend vitest: 10 trace-explorer tests (incl. whitespace-IDREF) + full suite pass · tsc clean · next build clean
e2e: a11y (axe-clean S-3 with aria-controls) + responsive journey at 375px pass
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq6EsYm5H7fmfJFPMcpV8g)_