### PR TITLE
fix(frontend): derive the 413 size-limit message from the upload cap

### DIFF
--- a/products/pm-evals-web/frontend/src/lib/api.ts
+++ b/products/pm-evals-web/frontend/src/lib/api.ts
@@ -3,13 +3,12 @@
 // and CI fails when it drifts). The UI can never depend on an undocumented
 // field: these are the only response types the app knows.
 import type { components } from "@/lib/api-types.gen";
-import { MAX_UPLOAD_BYTES } from "@/lib/validate";
+import { MAX_UPLOAD_MB } from "@/lib/validate";
 
-// The size the 413 message reports is derived from the upload cap (floored to
-// whole MB like the backend and the client mirror), so it can never drift into
-// a stale literal when the cap changes. mirror-parity.test.ts keeps
-// MAX_UPLOAD_BYTES equal to the backend cap.
-const MAX_UPLOAD_MB = Math.floor(MAX_UPLOAD_BYTES / (1024 * 1024));
+// The size the 413 message reports is the single MAX_UPLOAD_MB derived in the
+// client mirror (floored to whole MB from MAX_UPLOAD_BYTES, like the backend),
+// so it can never drift into a stale literal when the cap changes.
+// mirror-parity.test.ts keeps that cap equal to the backend's.
 const OVERSIZE_MESSAGE = `One of the files is larger than the ${MAX_UPLOAD_MB} MB limit.`;
 
 export type Comparison = components["schemas"]["Comparison"];

--- a/products/pm-evals-web/frontend/src/lib/api.ts
+++ b/products/pm-evals-web/frontend/src/lib/api.ts
@@ -3,6 +3,14 @@
 // and CI fails when it drifts). The UI can never depend on an undocumented
 // field: these are the only response types the app knows.
 import type { components } from "@/lib/api-types.gen";
+import { MAX_UPLOAD_BYTES } from "@/lib/validate";
+
+// The size the 413 message reports is derived from the upload cap (floored to
+// whole MB like the backend and the client mirror), so it can never drift into
+// a stale literal when the cap changes. mirror-parity.test.ts keeps
+// MAX_UPLOAD_BYTES equal to the backend cap.
+const MAX_UPLOAD_MB = Math.floor(MAX_UPLOAD_BYTES / (1024 * 1024));
+const OVERSIZE_MESSAGE = `One of the files is larger than the ${MAX_UPLOAD_MB} MB limit.`;
 
 export type Comparison = components["schemas"]["Comparison"];
 export type CompareResponse = components["schemas"]["CompareResponse"];
@@ -79,7 +87,7 @@ export async function compareRuns(
     return { kind: "validation", problems: await readValidationProblems(response) };
   }
   if (response.status === 413) {
-    return { kind: "error", message: "One of the files is larger than the 5 MB limit." };
+    return { kind: "error", message: OVERSIZE_MESSAGE };
   }
   if (!response.ok) {
     return { kind: "error", message: `The comparison failed (HTTP ${response.status}).` };
@@ -111,7 +119,7 @@ export async function downloadReport(
     return { kind: "validation", problems: await readValidationProblems(response) };
   }
   if (response.status === 413) {
-    return { kind: "error", message: "One of the files is larger than the 5 MB limit." };
+    return { kind: "error", message: OVERSIZE_MESSAGE };
   }
   if (!response.ok) {
     return { kind: "error", message: `The report download failed (HTTP ${response.status}).` };

--- a/products/pm-evals-web/frontend/src/lib/validate.ts
+++ b/products/pm-evals-web/frontend/src/lib/validate.ts
@@ -69,7 +69,7 @@ function idsOf(entries: unknown[], key: string): { ids: string[]; complete: bool
 // The cap in whole MB, floored like the backend's message
 // (MAX_UPLOAD_BYTES // (1024 * 1024)), so the displayed limit is derived from
 // the constant and can never drift from it into a stale hardcoded number.
-const MAX_UPLOAD_MB = Math.floor(MAX_UPLOAD_BYTES / (1024 * 1024));
+export const MAX_UPLOAD_MB = Math.floor(MAX_UPLOAD_BYTES / (1024 * 1024));
 
 export function preValidateFile(source: UploadSource, size: number, text: string): PreValidation {
   if (size > MAX_UPLOAD_BYTES) {

--- a/products/pm-evals-web/frontend/tests/api-client.test.ts
+++ b/products/pm-evals-web/frontend/tests/api-client.test.ts
@@ -2,6 +2,13 @@
 import { describe, expect, it } from "vitest";
 
 import { compareRuns, downloadReport, health } from "@/lib/api";
+import { MAX_UPLOAD_BYTES } from "@/lib/validate";
+
+// The size-limit the client reports on a 413 must be DERIVED from the upload
+// cap, not a hardcoded number that could survive a cap change and mislead the
+// user. mirror-parity.test.ts keeps MAX_UPLOAD_BYTES equal to the backend cap,
+// so deriving from it here transitively pins the message to the server's cap.
+const EXPECTED_MB = Math.floor(MAX_UPLOAD_BYTES / (1024 * 1024));
 
 function fileOf(content: string, name = "run.json"): File {
   return new File([content], name, { type: "application/json" });
@@ -51,10 +58,11 @@ describe("compareRuns", () => {
     }
   });
 
-  it("maps 413 to the size-limit message", async () => {
+  it("maps 413 to a size-limit message derived from the upload cap", async () => {
     const result = await compareRuns(fileOf("{}"), fileOf("{}"), fetchReturning(413, { detail: "too big" }));
     expect(result.kind).toBe("error");
-    if (result.kind === "error") expect(result.message).toContain("5 MB");
+    // the displayed limit is computed from MAX_UPLOAD_BYTES, never a stale literal
+    if (result.kind === "error") expect(result.message).toContain(`${EXPECTED_MB} MB limit`);
   });
 
   it("maps network failure to an unreachable error", async () => {
@@ -140,7 +148,7 @@ describe("downloadReport", () => {
     }
   });
 
-  it("maps 413 to the size-limit message", async () => {
+  it("maps 413 to a size-limit message derived from the upload cap", async () => {
     const result = await downloadReport(
       fileOf("{}"),
       fileOf("{}"),
@@ -148,7 +156,7 @@ describe("downloadReport", () => {
       fetchReturning(413, { detail: "too big" }),
     );
     expect(result.kind).toBe("error");
-    if (result.kind === "error") expect(result.message).toContain("5 MB");
+    if (result.kind === "error") expect(result.message).toContain(`${EXPECTED_MB} MB limit`);
   });
 
   it("surfaces named per-source issues on the J-4 422 shape", async () => {


### PR DESCRIPTION
# Pull request

## What changed and why

The typed API client's two 413 handlers (`compareRuns`, `downloadReport`) hardcoded the string `"5 MB"`, while the client mirror (`src/lib/validate.ts`) and its pre-validation message already **derive** the cap from `MAX_UPLOAD_BYTES`. That split is a silent drift hole: raise the backend/mirror cap and the pre-upload check would say "10 MB" while a server 413 still said "5 MB" — the same journey showing two different limits, one of them wrong.

This imports `MAX_UPLOAD_BYTES` into `api.ts` and interpolates the floored whole-MB into a single `OVERSIZE_MESSAGE` used by both 413 paths. `mirror-parity.test.ts` already keeps `MAX_UPLOAD_BYTES` equal to the backend cap, so the message is now transitively pinned to the server's real limit.

One concern: the API client's 413 size-limit text. No API/contract/schema change.

## Requirement reference

Dogfood follow-up to PR #40 (size-boundary): "derive api.ts 413 messages from the cap constant" (task tracked after #40). Reinforces PD-V3 size-cap honesty; complements arch F-3 mirror parity (PR #44).

## Architecture impact

None. One `lib` import (`api.ts` → `validate.ts`, already a sibling module the frontend depends on) and one derived constant. No new module boundary, schema, or typed-client change.

## Tests added

- `tests/api-client.test.ts`: both 413 tests (compare + report) now assert the message contains `` `${Math.floor(MAX_UPLOAD_BYTES/(1024*1024))} MB limit` `` — the value **derived** from the cap, not a literal.

Run: `npx vitest run tests/api-client.test.ts tests/mirror-parity.test.ts`

## Risk level

low — one component's error string, fully gated. `tsc` clean, `next build` clean, full vitest 79/79.

## Rollback plan

Revert this PR. No production/state impact.

## Evidence

```
Mutation proof (tests-first): temporarily set MAX_UPLOAD_BYTES = 10*1024*1024 →
  api-client.test.ts: 2 failed | 13 passed
    × maps 413 to a size-limit message derived from the upload cap (compareRuns)
      expected 'One of the files is larger than the 5 MB limit.' to contain '10 MB limit'
    × maps 413 to a size-limit message derived from the upload cap (downloadReport)
  Restored the cap → fix applied → all green.

vitest: api-client + mirror-parity 18/18 · full suite 79/79
tsc --noEmit: clean · next build: clean
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq6EsYm5H7fmfJFPMcpV8g)_