### PR TITLE
fix(frontend): attribute an unreadable framework 422 to the request, not baseline

### DIFF
--- a/products/pm-evals-web/frontend/src/lib/api.ts
+++ b/products/pm-evals-web/frontend/src/lib/api.ts
@@ -29,10 +29,13 @@ function comparePayload(baseline: File, candidate: File): FormData {
 
 function frameworkFallback(): ValidationProblem[] {
   // framework-shaped or unreadable 422 (missing part / bad form field / non-JSON
-  // body) — anything that is not the J-4 named-issues shape
+  // body) — anything that is not the J-4 named-issues shape. The client cannot
+  // tell which file the server faulted, so it attributes the problem to the
+  // "request" itself (matching the issue's location) rather than mis-blaming
+  // the baseline file.
   return [
     {
-      source: "baseline",
+      source: "request",
       issues: [{ location: "request", message: "The request was not accepted. Re-select both files and try again." }],
     },
   ];

--- a/products/pm-evals-web/frontend/tests/api-client.test.ts
+++ b/products/pm-evals-web/frontend/tests/api-client.test.ts
@@ -51,6 +51,22 @@ describe("compareRuns", () => {
     }
   });
 
+  it("attributes an unreadable framework 422 to the request, not a specific file", async () => {
+    // when the client cannot read which file the server rejected (framework
+    // shape / non-JSON body), it must not blame "baseline" — the honest source
+    // is the request itself, matching the issue's location.
+    const result = await compareRuns(
+      fileOf("{}"),
+      fileOf("{}"),
+      fetchReturning(422, { detail: [{ loc: ["body", "baseline"], msg: "x", type: "missing" }] }),
+    );
+    expect(result.kind).toBe("validation");
+    if (result.kind === "validation") {
+      expect(result.problems[0].source).toBe("request");
+      expect(result.problems[0].source).not.toBe("baseline");
+    }
+  });
+
   it("maps 413 to the size-limit message", async () => {
     const result = await compareRuns(fileOf("{}"), fileOf("{}"), fetchReturning(413, { detail: "too big" }));
     expect(result.kind).toBe("error");


### PR DESCRIPTION
# Pull request

## What changed and why

When the typed API client receives a 422 it cannot read as the J-4 named-issues shape — a missing form part, a bad form field, a non-JSON body — `frameworkFallback()` synthesizes a recoverable `ValidationProblem`. It hardcoded `source: "baseline"`. The dashboard renders each problem as `**{source}**: {message}`, so a generic request-level failure the client genuinely cannot pin to a file was displayed as a *baseline-file* problem — a small but real dishonesty about what the client knows.

This changes the synthesized source to `"request"`, matching the issue's own `location: "request"`. The backend already names real per-file sources on the documented J-4 envelope (guarded by the existing P-4 test), so this only touches the unreadable-fallback path where no file is identifiable.

One concern: the client's framework-fallback source attribution. No API/contract/schema change (`source` is a free `string` in the committed OpenAPI `ValidationProblem`).

## Requirement reference

Dogfood frontend-accessibility lens finding **F3** (`docs/v3/dogfood/lens-reviews/`): `frameworkFallback` mis-attributes a request-level failure to the baseline file.

## Architecture impact

None. One string literal in one helper; renderer already treats `source` as an opaque label.

## Tests added

- `tests/api-client.test.ts`: "attributes an unreadable framework 422 to the request, not a specific file" asserts `problems[0].source === "request"` and `!== "baseline"`.

Run: `npx vitest run tests/api-client.test.ts`

## Risk level

low — one helper's `source` value, fully gated. Full vitest 80/80, `tsc` clean, `next build` clean.

## Rollback plan

Revert this PR. No production/state impact.

## Evidence

```
Red-first: new test failed on the old value → AssertionError: expected 'baseline' to be 'request'.
Fix applied → green.
vitest: full suite 80/80 · tsc --noEmit clean · next build clean
Merged current main (#49) into the branch; api-client conflict (adjacent test) resolved keeping both tests.
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq6EsYm5H7fmfJFPMcpV8g)_