### PR TITLE
fix(engine): baseline-authoritative guardrail governance (F-4, PD-V3-19)

### DIFF
--- a/docs/v3/approved-product-decisions.md
+++ b/docs/v3/approved-product-decisions.md
@@ -123,3 +123,26 @@ of them requires a ProductChangeRequest, never an engineering fix.
 - **PD-V3-18 — Honest evidence only**: synthetic evidence is labeled
   synthetic; no real-user claims from fixtures; no manufactured timestamps or
   activity; disagreement and uncertainty are preserved in the record.
+- **PD-V3-19 — Guardrail thresholds are baseline-authoritative** (dogfood
+  backend finding F-4; approved by the repo owner 2026-07-18): a criterion's
+  `min_pass_rate` guardrail is governed by the **baseline** run, never the
+  artifact under evaluation.
+  - The baseline's explicitly configured `min_pass_rate` governs.
+  - When the baseline omits it, the locked system default
+    (`DEFAULT_MIN_PASS_RATE = 0.0` — no floor unless a run configures one, so
+    pre-existing comparisons keep their verdict) applies.
+  - The candidate run may **strengthen** the threshold but may never
+    **weaken** it. The effective threshold is
+    `max(baseline_threshold, candidate_threshold)`, where the candidate value
+    participates only when it is **explicitly present**.
+  - Resolution uses explicit `is not None` handling, never truthiness, so an
+    explicit candidate `0.0` cannot trigger a falsy-fallback defect and cannot
+    bypass the baseline.
+  - Every comparison records, per criterion: the baseline threshold, the
+    candidate-declared threshold, the effective threshold, the policy
+    (`baseline-authoritative`), and whether the candidate `unset`, `matched`,
+    `strengthened`, or attempted to weaken (`weakened_ignored`) the gate.
+  - Rationale: a release guardrail the evaluated artifact can lower is not a
+    guardrail; threshold changes must flow through the baseline as a
+    deliberate, reviewable act. Supersedes the prior
+    `candidate_min_pass_rate or baseline_min_pass_rate` truthiness resolution.

--- a/products/pm-evals-web/backend/openapi.json
+++ b/products/pm-evals-web/backend/openapi.json
@@ -328,6 +328,9 @@
             "title": "Description",
             "type": "string"
           },
+          "guardrail": {
+            "$ref": "#/components/schemas/GuardrailGovernance"
+          },
           "hard_gate": {
             "title": "Hard Gate",
             "type": "boolean"
@@ -356,9 +359,58 @@
           "delta",
           "newly_passing",
           "newly_failing",
-          "covered_traces"
+          "covered_traces",
+          "guardrail"
         ],
         "title": "CriterionDelta",
+        "type": "object"
+      },
+      "GuardrailGovernance": {
+        "description": "Baseline-authoritative provenance for one criterion's min_pass_rate\nguardrail (PD-V3-19).\n\nThe baseline governs the threshold; the candidate \u2014 the artifact under\nevaluation \u2014 may STRENGTHEN it but may never WEAKEN it. Resolution is by\nexplicit `is not None`, never truthiness, so an explicit candidate 0.0 is a\nreal value (which cannot lower the baseline), not a falsy fallback trigger.",
+        "properties": {
+          "baseline_threshold": {
+            "title": "Baseline Threshold",
+            "type": "number"
+          },
+          "candidate_effect": {
+            "enum": [
+              "unset",
+              "matched",
+              "strengthened",
+              "weakened_ignored"
+            ],
+            "title": "Candidate Effect",
+            "type": "string"
+          },
+          "candidate_threshold": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Candidate Threshold"
+          },
+          "effective_threshold": {
+            "title": "Effective Threshold",
+            "type": "number"
+          },
+          "policy": {
+            "const": "baseline-authoritative",
+            "default": "baseline-authoritative",
+            "title": "Policy",
+            "type": "string"
+          }
+        },
+        "required": [
+          "baseline_threshold",
+          "candidate_threshold",
+          "effective_threshold",
+          "candidate_effect"
+        ],
+        "title": "GuardrailGovernance",
         "type": "object"
       },
       "HealthResponse": {

--- a/products/pm-evals-web/backend/src/pm_evals_compare/compare.py
+++ b/products/pm-evals-web/backend/src/pm_evals_compare/compare.py
@@ -45,6 +45,29 @@ class CompareConfig(BaseModel):
     hard_gate_coverage: float = Field(default=1.0, ge=0.0, le=1.0)
 
 
+DEFAULT_MIN_PASS_RATE = 0.0
+"""Locked system floor for a criterion's pass-rate guardrail when the baseline
+run does not configure one (PD-V3-19). 0.0 means no floor unless a run sets one,
+so comparisons predating this policy keep their verdict."""
+
+
+class GuardrailGovernance(BaseModel):
+    """Baseline-authoritative provenance for one criterion's min_pass_rate
+    guardrail (PD-V3-19).
+
+    The baseline governs the threshold; the candidate — the artifact under
+    evaluation — may STRENGTHEN it but may never WEAKEN it. Resolution is by
+    explicit `is not None`, never truthiness, so an explicit candidate 0.0 is a
+    real value (which cannot lower the baseline), not a falsy fallback trigger.
+    """
+
+    policy: Literal["baseline-authoritative"] = "baseline-authoritative"
+    baseline_threshold: float
+    candidate_threshold: float | None
+    effective_threshold: float
+    candidate_effect: Literal["unset", "matched", "strengthened", "weakened_ignored"]
+
+
 class CriterionDelta(BaseModel):
     criterion_id: str
     description: str
@@ -55,6 +78,7 @@ class CriterionDelta(BaseModel):
     newly_passing: list[str]
     newly_failing: list[str]
     covered_traces: int
+    guardrail: GuardrailGovernance
 
 
 class VerdictReason(BaseModel):
@@ -135,6 +159,38 @@ def check_compatibility(baseline: EvalRun, candidate: EvalRun) -> list[str]:
 
 def _pass_rate(passes: int, total: int) -> float:
     return round(passes / total, 6) if total else 0.0
+
+
+def _resolve_guardrail(
+    baseline_min: float | None, candidate_min: float | None
+) -> GuardrailGovernance:
+    """Baseline-authoritative guardrail resolution (PD-V3-19).
+
+    The baseline's explicit threshold governs; the locked default applies when it
+    omits one. The candidate may only strengthen — the effective threshold is
+    max(baseline, candidate) with the candidate participating only when it is
+    explicitly present (`is not None`, never truthiness, so 0.0 counts).
+    """
+    baseline_threshold = baseline_min if baseline_min is not None else DEFAULT_MIN_PASS_RATE
+    if candidate_min is None:
+        return GuardrailGovernance(
+            baseline_threshold=baseline_threshold,
+            candidate_threshold=None,
+            effective_threshold=baseline_threshold,
+            candidate_effect="unset",
+        )
+    if candidate_min > baseline_threshold:
+        effect: Literal["matched", "strengthened", "weakened_ignored"] = "strengthened"
+    elif candidate_min == baseline_threshold:
+        effect = "matched"
+    else:
+        effect = "weakened_ignored"
+    return GuardrailGovernance(
+        baseline_threshold=baseline_threshold,
+        candidate_threshold=candidate_min,
+        effective_threshold=max(baseline_threshold, candidate_min),
+        candidate_effect=effect,
+    )
 
 
 def _criterion_cell(
@@ -298,6 +354,9 @@ def compare_runs(
         newly_passing_traces.update(newly_pass)
         newly_failing_traces.update(newly_fail)
 
+        candidate_criterion = next(c for c in candidate.criteria if c.id == criterion.id)
+        guardrail = _resolve_guardrail(criterion.min_pass_rate, candidate_criterion.min_pass_rate)
+
         delta = CriterionDelta(
             criterion_id=criterion.id,
             description=criterion.description,
@@ -308,6 +367,7 @@ def compare_runs(
             newly_passing=newly_pass,
             newly_failing=newly_fail,
             covered_traces=covered,
+            guardrail=guardrail,
         )
         criteria_deltas.append(delta)
 
@@ -351,9 +411,11 @@ def compare_runs(
                         "release rules cannot be evaluated",
                     )
                 )
-        candidate_criterion = next(c for c in candidate.criteria if c.id == criterion.id)
-        threshold = candidate_criterion.min_pass_rate or criterion.min_pass_rate
-        if threshold is not None and c_total:
+        # Baseline-authoritative guardrail (PD-V3-19): the candidate cannot weaken
+        # the effective threshold, and an explicit 0.0 is honored, not treated as
+        # a falsy fallback. A 0.0 effective floor can never bite (rate >= 0.0).
+        threshold = guardrail.effective_threshold
+        if c_total:
             rate = _pass_rate(c_pass, c_total)
             if rate < threshold:
                 failing = [

--- a/products/pm-evals-web/backend/src/pm_evals_compare/report.py
+++ b/products/pm-evals-web/backend/src/pm_evals_compare/report.py
@@ -79,6 +79,24 @@ def render_markdown(comparison: Comparison, *, generated_at: str | None = None) 
             f"| {_pct(d.baseline_pass_rate)} | {_pct(d.candidate_pass_rate)} "
             f"| {_pct(d.delta)} | {len(d.newly_passing)} | {len(d.newly_failing)} |"
         )
+    lines += [
+        "",
+        "## Guardrails",
+        "",
+        "Policy: **baseline-authoritative** — the baseline governs each "
+        "`min_pass_rate` guardrail; a candidate may strengthen a threshold but "
+        "never weaken it.",
+        "",
+        "| Criterion | Baseline | Candidate | Effective | Candidate effect |",
+        "|---|---|---|---|---|",
+    ]
+    for d in c.criteria:
+        g = d.guardrail
+        candidate = "—" if g.candidate_threshold is None else _pct(g.candidate_threshold)
+        lines.append(
+            f"| {d.criterion_id} | {_pct(g.baseline_threshold)} | {candidate} "
+            f"| {_pct(g.effective_threshold)} | {g.candidate_effect} |"
+        )
     lines += ["", "## Changed traces", ""]
     if c.newly_failing_traces:
         lines.append("Newly failing: " + ", ".join(f"`{t}`" for t in c.newly_failing_traces))

--- a/products/pm-evals-web/backend/tests/test_compare.py
+++ b/products/pm-evals-web/backend/tests/test_compare.py
@@ -11,7 +11,14 @@ import json
 from pathlib import Path
 from typing import Any
 
-from pm_evals_compare.compare import CompareConfig, check_compatibility, compare_runs
+from pm_evals_compare.compare import (
+    DEFAULT_MIN_PASS_RATE,
+    Comparison,
+    CompareConfig,
+    GuardrailGovernance,
+    check_compatibility,
+    compare_runs,
+)
 from pm_evals_compare.models import EvalRun, parse_run
 from pm_evals_compare.report import render_json, render_markdown, to_json_report
 
@@ -403,6 +410,142 @@ def test_baseline_declared_guardrail_still_applies_to_the_candidate() -> None:
     comparison = compare_runs(baseline, candidate)
     assert comparison.verdict == "HOLD"
     assert any(r.kind == "guardrail" for r in comparison.reasons)
+
+
+# --- F-4: baseline-authoritative guardrail governance (PD-V3-19) ---------------------------
+#
+# A 6-trace pair where the candidate fails C-TONE on exactly one trace, so the
+# candidate's C-TONE pass rate is 5/6 ≈ 0.833. C-ACC passes everywhere, so ONLY
+# the C-TONE min_pass_rate guardrail can drive the verdict: effective > 0.833 →
+# HOLD, effective ≤ 0.833 → PROCEED. This lets a single threshold decide the
+# verdict, isolating the governance rule.
+
+
+def _guardrail_pair(
+    *, baseline_min: float | None, candidate_min: float | None
+) -> tuple[EvalRun, EvalRun]:
+    def tone(min_pass_rate: float | None) -> dict[str, Any]:
+        cell: dict[str, Any] = {"id": "C-TONE"}
+        if min_pass_rate is not None:
+            cell["min_pass_rate"] = min_pass_rate
+        return cell
+
+    rows = {f"T-{i}": {"C-ACC": "pass", "C-TONE": "pass"} for i in range(1, 7)}
+    cand_rows = dict(rows)
+    cand_rows["T-2"] = {"C-ACC": "pass", "C-TONE": "fail"}  # candidate C-TONE = 5/6 ≈ 0.833
+    baseline = _run(
+        "b",
+        criteria=[{"id": "C-ACC", "hard_gate": True}, tone(baseline_min)],
+        traces=_traces(rows),
+    )
+    candidate = _run(
+        "c",
+        criteria=[{"id": "C-ACC", "hard_gate": True}, tone(candidate_min)],
+        traces=_traces(cand_rows),
+    )
+    return baseline, candidate
+
+
+def _tone_guardrail(comparison: Comparison) -> GuardrailGovernance:
+    return next(d for d in comparison.criteria if d.criterion_id == "C-TONE").guardrail
+
+
+def test_candidate_below_baseline_cannot_weaken_the_gate() -> None:
+    # The load-bearing rule: baseline 0.9, candidate declares a weaker 0.5.
+    # Baseline-authoritative → effective 0.9 → candidate's 0.833 fails → HOLD.
+    # (The old `candidate or baseline` truthiness would have used 0.5 → PROCEED.)
+    comparison = compare_runs(*_guardrail_pair(baseline_min=0.9, candidate_min=0.5))
+    assert comparison.verdict == "HOLD"
+    assert any(r.kind == "guardrail" and r.criterion_id == "C-TONE" for r in comparison.reasons)
+    g = _tone_guardrail(comparison)
+    assert g.effective_threshold == 0.9
+    assert g.candidate_effect == "weakened_ignored"
+
+
+def test_candidate_equal_to_baseline_is_unchanged() -> None:
+    comparison = compare_runs(*_guardrail_pair(baseline_min=0.9, candidate_min=0.9))
+    assert comparison.verdict == "HOLD"
+    g = _tone_guardrail(comparison)
+    assert g.baseline_threshold == 0.9
+    assert g.effective_threshold == 0.9
+    assert g.candidate_effect == "matched"
+
+
+def test_candidate_above_baseline_strengthens_the_gate() -> None:
+    # baseline 0.5 would pass 0.833; candidate raises the bar to 0.9 → HOLD.
+    comparison = compare_runs(*_guardrail_pair(baseline_min=0.5, candidate_min=0.9))
+    assert comparison.verdict == "HOLD"
+    g = _tone_guardrail(comparison)
+    assert g.baseline_threshold == 0.5
+    assert g.candidate_threshold == 0.9
+    assert g.effective_threshold == 0.9
+    assert g.candidate_effect == "strengthened"
+
+
+def test_candidate_zero_does_not_bypass_the_baseline() -> None:
+    # Explicit 0.0 must be honored as a real value, not a falsy fallback trigger;
+    # it still cannot lower the baseline 0.9 floor.
+    comparison = compare_runs(*_guardrail_pair(baseline_min=0.9, candidate_min=0.0))
+    assert comparison.verdict == "HOLD"
+    g = _tone_guardrail(comparison)
+    assert g.candidate_threshold == 0.0
+    assert g.effective_threshold == 0.9
+    assert g.candidate_effect == "weakened_ignored"
+
+
+def test_missing_candidate_threshold_uses_the_baseline() -> None:
+    comparison = compare_runs(*_guardrail_pair(baseline_min=0.9, candidate_min=None))
+    assert comparison.verdict == "HOLD"
+    g = _tone_guardrail(comparison)
+    assert g.candidate_threshold is None
+    assert g.effective_threshold == 0.9
+    assert g.candidate_effect == "unset"
+
+
+def test_missing_baseline_threshold_uses_the_locked_default() -> None:
+    comparison = compare_runs(*_guardrail_pair(baseline_min=None, candidate_min=None))
+    assert comparison.verdict == "PROCEED"  # default 0.0 floor never bites
+    g = _tone_guardrail(comparison)
+    assert g.baseline_threshold == DEFAULT_MIN_PASS_RATE == 0.0
+    assert g.effective_threshold == 0.0
+
+
+def test_report_exposes_baseline_candidate_and_effective_thresholds() -> None:
+    comparison = compare_runs(*_guardrail_pair(baseline_min=0.9, candidate_min=0.7))
+    tone = next(
+        d
+        for d in to_json_report(comparison)["comparison"]["criteria"]
+        if d["criterion_id"] == "C-TONE"
+    )
+    assert tone["guardrail"]["baseline_threshold"] == 0.9
+    assert tone["guardrail"]["candidate_threshold"] == 0.7
+    assert tone["guardrail"]["effective_threshold"] == 0.9
+    assert tone["guardrail"]["policy"] == "baseline-authoritative"
+    md = render_markdown(comparison)
+    assert "Guardrails" in md
+    assert "baseline-authoritative" in md
+    assert "C-TONE" in md
+
+
+def test_guardrail_governance_output_is_deterministic() -> None:
+    pair = _guardrail_pair(baseline_min=0.9, candidate_min=0.5)
+    first = compare_runs(*pair)
+    second = compare_runs(*_guardrail_pair(baseline_min=0.9, candidate_min=0.5))
+    assert first.model_dump() == second.model_dump()
+    assert render_json(first) == render_json(second)
+
+
+def test_guardrail_free_comparison_does_not_regress() -> None:
+    # No min_pass_rate anywhere: the verdict and the default provenance must match
+    # the pre-F-4 behavior (a clean improvement still PROCEEDs).
+    rows = {f"T-{i}": {"C-ACC": "pass", "C-TONE": "pass"} for i in range(1, 7)}
+    baseline = _run("b", traces=_traces(rows))
+    candidate = _run("c", traces=_traces(rows))
+    comparison = compare_runs(baseline, candidate)
+    assert comparison.verdict == "PROCEED"
+    for d in comparison.criteria:
+        assert d.guardrail.effective_threshold == 0.0
+        assert d.guardrail.candidate_effect == "unset"
 
 
 def test_thin_evidence_boundary_is_exact() -> None:

--- a/products/pm-evals-web/backend/tests/test_compare.py
+++ b/products/pm-evals-web/backend/tests/test_compare.py
@@ -510,6 +510,29 @@ def test_missing_baseline_threshold_uses_the_locked_default() -> None:
     assert g.effective_threshold == 0.0
 
 
+def test_candidate_strengthens_above_the_default_floor() -> None:
+    # baseline omits its threshold (default 0.0); the candidate raises the bar to
+    # 0.9 → the candidate strengthens FROM the locked default, and 0.833 fails.
+    comparison = compare_runs(*_guardrail_pair(baseline_min=None, candidate_min=0.9))
+    assert comparison.verdict == "HOLD"
+    g = _tone_guardrail(comparison)
+    assert g.baseline_threshold == 0.0
+    assert g.effective_threshold == 0.9
+    assert g.candidate_effect == "strengthened"
+
+
+def test_candidate_zero_matches_the_default_floor() -> None:
+    # baseline omits its threshold (default 0.0); the candidate declares an
+    # explicit 0.0 → honored as a real value equal to the floor → "matched", not
+    # dropped to "unset" (which a truthy `not candidate_min` would produce).
+    comparison = compare_runs(*_guardrail_pair(baseline_min=None, candidate_min=0.0))
+    assert comparison.verdict == "PROCEED"
+    g = _tone_guardrail(comparison)
+    assert g.candidate_threshold == 0.0
+    assert g.effective_threshold == 0.0
+    assert g.candidate_effect == "matched"
+
+
 def test_report_exposes_baseline_candidate_and_effective_thresholds() -> None:
     comparison = compare_runs(*_guardrail_pair(baseline_min=0.9, candidate_min=0.7))
     tone = next(

--- a/products/pm-evals-web/frontend/src/lib/api-types.gen.ts
+++ b/products/pm-evals-web/frontend/src/lib/api-types.gen.ts
@@ -175,12 +175,42 @@ export interface components {
             delta: number;
             /** Description */
             description: string;
+            guardrail: components["schemas"]["GuardrailGovernance"];
             /** Hard Gate */
             hard_gate: boolean;
             /** Newly Failing */
             newly_failing: string[];
             /** Newly Passing */
             newly_passing: string[];
+        };
+        /**
+         * GuardrailGovernance
+         * @description Baseline-authoritative provenance for one criterion's min_pass_rate
+         *     guardrail (PD-V3-19).
+         *
+         *     The baseline governs the threshold; the candidate — the artifact under
+         *     evaluation — may STRENGTHEN it but may never WEAKEN it. Resolution is by
+         *     explicit `is not None`, never truthiness, so an explicit candidate 0.0 is a
+         *     real value (which cannot lower the baseline), not a falsy fallback trigger.
+         */
+        GuardrailGovernance: {
+            /** Baseline Threshold */
+            baseline_threshold: number;
+            /**
+             * Candidate Effect
+             * @enum {string}
+             */
+            candidate_effect: "unset" | "matched" | "strengthened" | "weakened_ignored";
+            /** Candidate Threshold */
+            candidate_threshold: number | null;
+            /** Effective Threshold */
+            effective_threshold: number;
+            /**
+             * Policy
+             * @default baseline-authoritative
+             * @constant
+             */
+            policy: "baseline-authoritative";
         };
         /** HealthResponse */
         HealthResponse: {

--- a/products/pm-evals-web/frontend/tests/fixtures/comparison_improved.json
+++ b/products/pm-evals-web/frontend/tests/fixtures/comparison_improved.json
@@ -15,6 +15,13 @@
       "criterion_id": "C-ACCURACY",
       "delta": 0.125,
       "description": "The answer is factually accurate for the customer's plan",
+      "guardrail": {
+        "baseline_threshold": 0.0,
+        "candidate_effect": "unset",
+        "candidate_threshold": null,
+        "effective_threshold": 0.0,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": true,
       "newly_failing": [],
       "newly_passing": [
@@ -28,6 +35,13 @@
       "criterion_id": "C-GROUNDED",
       "delta": 0.125,
       "description": "Every claim is grounded in the retrieved policy documents",
+      "guardrail": {
+        "baseline_threshold": 0.0,
+        "candidate_effect": "unset",
+        "candidate_threshold": null,
+        "effective_threshold": 0.0,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": true,
       "newly_failing": [],
       "newly_passing": [
@@ -41,6 +55,13 @@
       "criterion_id": "C-TONE",
       "delta": 0.125,
       "description": "Tone is professional and empathetic",
+      "guardrail": {
+        "baseline_threshold": 0.75,
+        "candidate_effect": "matched",
+        "candidate_threshold": 0.75,
+        "effective_threshold": 0.75,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": false,
       "newly_failing": [],
       "newly_passing": [
@@ -54,6 +75,13 @@
       "criterion_id": "C-BREVITY",
       "delta": 0.0,
       "description": "Reply fits in four sentences or fewer",
+      "guardrail": {
+        "baseline_threshold": 0.0,
+        "candidate_effect": "unset",
+        "candidate_threshold": null,
+        "effective_threshold": 0.0,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": false,
       "newly_failing": [],
       "newly_passing": []

--- a/products/pm-evals-web/frontend/tests/fixtures/comparison_insufficient.json
+++ b/products/pm-evals-web/frontend/tests/fixtures/comparison_insufficient.json
@@ -15,6 +15,13 @@
       "criterion_id": "C-ACCURACY",
       "delta": 0.125,
       "description": "The answer is factually accurate for the customer's plan",
+      "guardrail": {
+        "baseline_threshold": 0.0,
+        "candidate_effect": "unset",
+        "candidate_threshold": null,
+        "effective_threshold": 0.0,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": true,
       "newly_failing": [],
       "newly_passing": [
@@ -28,6 +35,13 @@
       "criterion_id": "C-GROUNDED",
       "delta": 0.125,
       "description": "Every claim is grounded in the retrieved policy documents",
+      "guardrail": {
+        "baseline_threshold": 0.0,
+        "candidate_effect": "unset",
+        "candidate_threshold": null,
+        "effective_threshold": 0.0,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": true,
       "newly_failing": [],
       "newly_passing": [
@@ -41,6 +55,13 @@
       "criterion_id": "C-TONE",
       "delta": 0.125,
       "description": "Tone is professional and empathetic",
+      "guardrail": {
+        "baseline_threshold": 0.75,
+        "candidate_effect": "matched",
+        "candidate_threshold": 0.75,
+        "effective_threshold": 0.75,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": false,
       "newly_failing": [],
       "newly_passing": [
@@ -54,6 +75,13 @@
       "criterion_id": "C-BREVITY",
       "delta": 0.0,
       "description": "Reply fits in four sentences or fewer",
+      "guardrail": {
+        "baseline_threshold": 0.0,
+        "candidate_effect": "unset",
+        "candidate_threshold": null,
+        "effective_threshold": 0.0,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": false,
       "newly_failing": [],
       "newly_passing": []

--- a/products/pm-evals-web/frontend/tests/fixtures/comparison_regression.json
+++ b/products/pm-evals-web/frontend/tests/fixtures/comparison_regression.json
@@ -15,6 +15,13 @@
       "criterion_id": "C-ACCURACY",
       "delta": 0.125,
       "description": "The answer is factually accurate for the customer's plan",
+      "guardrail": {
+        "baseline_threshold": 0.0,
+        "candidate_effect": "unset",
+        "candidate_threshold": null,
+        "effective_threshold": 0.0,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": true,
       "newly_failing": [],
       "newly_passing": [
@@ -28,6 +35,13 @@
       "criterion_id": "C-GROUNDED",
       "delta": -0.125,
       "description": "Every claim is grounded in the retrieved policy documents",
+      "guardrail": {
+        "baseline_threshold": 0.0,
+        "candidate_effect": "unset",
+        "candidate_threshold": null,
+        "effective_threshold": 0.0,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": true,
       "newly_failing": [
         "T-006"
@@ -41,6 +55,13 @@
       "criterion_id": "C-TONE",
       "delta": -0.25,
       "description": "Tone is professional and empathetic",
+      "guardrail": {
+        "baseline_threshold": 0.75,
+        "candidate_effect": "matched",
+        "candidate_threshold": 0.75,
+        "effective_threshold": 0.75,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": false,
       "newly_failing": [
         "T-001",
@@ -55,6 +76,13 @@
       "criterion_id": "C-BREVITY",
       "delta": 0.0,
       "description": "Reply fits in four sentences or fewer",
+      "guardrail": {
+        "baseline_threshold": 0.0,
+        "candidate_effect": "unset",
+        "candidate_threshold": null,
+        "effective_threshold": 0.0,
+        "policy": "baseline-authoritative"
+      },
       "hard_gate": false,
       "newly_failing": [],
       "newly_passing": []


### PR DESCRIPTION
# Pull request

## What changed and why

The per-criterion `min_pass_rate` guardrail threshold was resolved with `candidate_criterion.min_pass_rate or criterion.min_pass_rate` (`compare.py`). Two defects:
- **Governance loophole:** the **candidate** run — the artifact under evaluation — could declare a *lower* threshold than the baseline and be judged against its own weaker bar. A release guardrail the evaluated artifact can lower is not a guardrail.
- **Falsy-zero bug:** an explicit candidate `0.0` was silently discarded by the truthy `or` and replaced with the baseline's value.

Per approved product decision **PD-V3-19** (dogfood finding **F-4**, Option A — baseline-authoritative):
- the **baseline's** explicit `min_pass_rate` governs; when it omits one, the locked `DEFAULT_MIN_PASS_RATE = 0.0` applies (no floor unless a run configures one, so pre-existing comparisons keep their verdict);
- the candidate may **strengthen** but never **weaken** — `effective = max(baseline_threshold, candidate_threshold)`, the candidate participating only when explicitly present (`is not None`, never truthiness, so an explicit `0.0` is honored and cannot bypass the baseline);
- every criterion records `GuardrailGovernance` provenance: baseline threshold, candidate-declared threshold, effective threshold, `policy: baseline-authoritative`, and whether the candidate was `unset` / `matched` / `strengthened` / `weakened_ignored`. Surfaced in the JSON report (via `model_dump`) and a new markdown `## Guardrails` section.

One concern: guardrail threshold governance (engine + its report surfacing). This is a deliberate behavior change gated by PD-V3-19.

## Requirement reference

Dogfood backend finding **F-4**; product decision **PD-V3-19** (`docs/v3/approved-product-decisions.md`).

## Architecture impact

`Comparison.criteria[].guardrail` is a new response field → `openapi.json`, the generated `api-types.gen.ts`, and the three golden comparison fixtures were regenerated deterministically from the engine (not hand-edited). No new module; the frontend consumes the type without a UI change.

## Tests added

`tests/test_compare.py` — 9 tests written and run **red before** the fix:
candidate-below-baseline-cannot-weaken; equal-is-unchanged; above-strengthens; `0.0`-does-not-bypass; missing-candidate-uses-baseline; missing-baseline-uses-locked-default; report-exposes-baseline/candidate/effective; deterministic output; guardrail-free comparison does not regress.

Run: `pytest tests/test_compare.py`

## Risk level

medium — a deliberate release-gate behavior change (guardrail governance), gated by PD-V3-19 and signed off by the repo owner. Mutation-verified load-bearing logic; full gates green.

## Rollback plan

Revert this PR. Reverts the engine logic, report section, and regenerated artifacts together. No persisted state.

## Evidence

```
Tests-first red: new tests fail on missing symbols / old logic before the fix.
Mutation proof:
  max(baseline,candidate) -> candidate_min  => test_candidate_below_baseline_cannot_weaken FAILS
  `is None` -> truthiness                    => test_candidate_zero_does_not_bypass FAILS
  both restored -> 47/47 test_compare pass
Backend: pytest 83 passed · ruff format --check · ruff check · mypy (strict) — all clean
Frontend: vitest 79/79 · tsc --noEmit · next build · api-types regen idempotent (no drift) — all clean
openapi.json + api-types.gen.ts + 3 goldens regenerated from the engine.
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq6EsYm5H7fmfJFPMcpV8g)_