### PR TITLE
feat(portfolio): M2 — broad deterministic repository scanner

### DIFF
--- a/docs/portfolio-auditor/threat-model.md
+++ b/docs/portfolio-auditor/threat-model.md
@@ -37,8 +37,8 @@ A verdict without evidence damages a real person's repository standing.
 - PD-PA-06 pinned; policy `redact_private_origins_in_public_reports` is
   schema-enforced to `true` (an edited policy fails validation).
 - Secret hits are recorded as rule/path/line only — the value is never
-  stored, logged, or rendered (scanner tests plant placeholder secrets and
-  assert full redaction).
+  stored, logged, or rendered (M2 scanner tests plant placeholder secrets
+  and assert full redaction).
 - Fixture private repos exist precisely to test that no private source,
   name, or configuration reaches a public report.
 
@@ -48,7 +48,7 @@ A verdict without evidence damages a real person's repository standing.
   (schema-enforced `explicit_repository_allowlist_required: true`).
 - Dry-run is the default; destructive actions are refused
   (`block_destructive_actions: true`).
-- Deep inspection wraps every pass in `readonly_snapshot` /
+- Deep inspection (M4) will wrap every pass in `readonly_snapshot` /
   `verify_unmodified` — a modified tree fails the run, mirroring PD-06
   reviewer guarantees.
 - Remediation (M7) targets sandbox repositories only; the merge decision

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/owners/acme.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/owners/acme.json
@@ -1,0 +1,1 @@
+["healthy-lib", "slop-wrapper", "stale-fork", "internal-service"]

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/healthy-lib/files.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/healthy-lib/files.json
@@ -1,0 +1,10 @@
+{
+  "README.md": "# healthy-lib\n\n![CI](https://img.shields.io/badge/ci-passing-green)\n\nA small utility library for parsing configuration files.\n\n## Installation\n\n```bash\npip install healthy-lib\n```\n\n## Usage\n\n```python\nfrom healthy_lib import parse\nconfig = parse(\"config.yaml\")\n```\n\nParses YAML and TOML. Covered by unit tests on every push.\n\n## Limitations\n\nDoes not support JSON5 or environment interpolation yet.\n",
+  "LICENSE": "MIT License\n\nCopyright (c) 2025 acme\n\nPermission is hereby granted, free of charge, to any person obtaining a copy...\n",
+  "CONTRIBUTING.md": "# Contributing\n\nRun `pytest` before opening a PR. All changes need a test.\n",
+  "pyproject.toml": "[project]\nname = \"healthy-lib\"\nversion = \"0.3.1\"\ndependencies = [\n  \"PyYAML==6.0.1\",\n  \"tomli==2.0.1\"\n]\n\n[project.scripts]\nhealthy-lib = \"healthy_lib.cli:main\"\n",
+  "poetry.lock": "# generated lockfile\n[[package]]\nname = \"PyYAML\"\nversion = \"6.0.1\"\n",
+  ".github/workflows/ci.yml": "name: ci\non: [push, pull_request]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: pip install -e .[dev]\n      - run: pytest\n",
+  "docs/index.md": "# healthy-lib docs\n\nSee usage.md.\n",
+  "docs/usage.md": "# Usage\n\nCall `parse(path)`.\n"
+}

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/healthy-lib/metadata.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/healthy-lib/metadata.json
@@ -1,0 +1,16 @@
+{
+  "owner": "acme",
+  "name": "healthy-lib",
+  "visibility": "PUBLIC",
+  "description": "A small, well-tested utility library for parsing config files.",
+  "topics": ["python", "configuration", "parsing"],
+  "default_branch": "main",
+  "created_at": "2025-02-01T00:00:00+00:00",
+  "pushed_at": "2026-07-10T00:00:00+00:00",
+  "license": "MIT",
+  "stargazers_count": 120,
+  "forks_count": 15,
+  "archived": false,
+  "is_fork": false,
+  "primary_language": "Python"
+}

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/healthy-lib/tree.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/healthy-lib/tree.json
@@ -1,0 +1,16 @@
+[
+  "README.md",
+  "LICENSE",
+  "CONTRIBUTING.md",
+  "pyproject.toml",
+  "poetry.lock",
+  ".github/workflows/ci.yml",
+  "src/healthy_lib/__init__.py",
+  "src/healthy_lib/core.py",
+  "src/healthy_lib/parser.py",
+  "tests/test_core.py",
+  "tests/test_parser.py",
+  "tests/test_edge_cases.py",
+  "docs/index.md",
+  "docs/usage.md"
+]

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/internal-service/files.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/internal-service/files.json
@@ -1,0 +1,8 @@
+{
+  "README.md": "# internal-service\n\nPrivate billing service. Internal use only.\n\n## Setup\n\n```bash\npip install -r requirements.txt\n```\n",
+  "requirements.txt": "flask==3.0.0\nstripe==7.0.0\nrequests>=2.31\n",
+  "app/settings.py": "STRIPE_KEY = 'EXAMPLE_placeholder_billing_secret_0002'\nDEBUG = True\n",
+  "app/billing.py": "def charge(customer, amount):\n    return {'ok': True}\n",
+  "tests/test_billing.py": "from app.billing import charge\n\ndef test_charge():\n    assert charge('c', 1)['ok']\n",
+  ".github/workflows/test.yml": "name: test\non: [push]\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: pytest\n"
+}

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/internal-service/metadata.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/internal-service/metadata.json
@@ -1,0 +1,16 @@
+{
+  "owner": "acme",
+  "name": "internal-service",
+  "visibility": "PRIVATE",
+  "description": "Internal billing service (private).",
+  "topics": ["internal", "billing"],
+  "default_branch": "main",
+  "created_at": "2025-09-01T00:00:00+00:00",
+  "pushed_at": "2026-07-01T00:00:00+00:00",
+  "license": "UNLICENSED",
+  "stargazers_count": 0,
+  "forks_count": 0,
+  "archived": false,
+  "is_fork": false,
+  "primary_language": "Python"
+}

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/internal-service/tree.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/internal-service/tree.json
@@ -1,0 +1,9 @@
+[
+  "README.md",
+  "requirements.txt",
+  "app/__init__.py",
+  "app/billing.py",
+  "app/settings.py",
+  "tests/test_billing.py",
+  ".github/workflows/test.yml"
+]

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/slop-wrapper/files.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/slop-wrapper/files.json
@@ -1,0 +1,6 @@
+{
+  "README.md": "# slop-wrapper\n\nThe **production-ready**, enterprise-grade AI platform used by millions of developers worldwide.\n\nOur system is 100% accurate and blazing fast — 10x faster than any competitor. It scales to billions of requests with zero downtime and industry-leading 5ms latency. Battle-tested in production at Fortune 500 companies.\n\n## Features\n\n- State-of-the-art AI\n- Infinitely scalable\n- 99.999% uptime guaranteed\n\nJust works out of the box.\n",
+  "package.json": "{\n  \"name\": \"slop-wrapper\",\n  \"version\": \"1.0.0\",\n  \"main\": \"index.js\",\n  \"dependencies\": {\n    \"express\": \"^4.18.0\",\n    \"axios\": \"^1.4.0\",\n    \"lodash\": \"*\"\n  }\n}\n",
+  "index.js": "const config = require('./config');\nconst axios = require('axios');\n\nmodule.exports = function run(input) {\n  return axios.post(config.endpoint, { input });\n};\n",
+  "config.js": "module.exports = {\n  endpoint: 'https://api.example.com/v1',\n  apiKey: 'EXAMPLE_placeholder_secret_abcdef0123',\n  awsKey: 'aws_secret_FAKE_placeholder_0000'\n};\n"
+}

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/slop-wrapper/metadata.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/slop-wrapper/metadata.json
@@ -1,0 +1,16 @@
+{
+  "owner": "acme",
+  "name": "slop-wrapper",
+  "visibility": "PUBLIC",
+  "description": "The ultimate enterprise-grade AI platform.",
+  "topics": ["ai", "platform", "enterprise"],
+  "default_branch": "main",
+  "created_at": "2026-05-20T00:00:00+00:00",
+  "pushed_at": "2026-06-01T00:00:00+00:00",
+  "license": null,
+  "stargazers_count": 3,
+  "forks_count": 0,
+  "archived": false,
+  "is_fork": false,
+  "primary_language": "JavaScript"
+}

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/slop-wrapper/tree.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/slop-wrapper/tree.json
@@ -1,0 +1,6 @@
+[
+  "README.md",
+  "package.json",
+  "index.js",
+  "config.js"
+]

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/stale-fork/files.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/stale-fork/files.json
@@ -1,0 +1,5 @@
+{
+  "README.md": "# stale-fork\n\nForked from upstream/thing. No longer maintained.\n",
+  "main.py": "print('hello from a fork')\n",
+  "LICENSE": "Apache License 2.0\n"
+}

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/stale-fork/metadata.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/stale-fork/metadata.json
@@ -1,0 +1,16 @@
+{
+  "owner": "acme",
+  "name": "stale-fork",
+  "visibility": "PUBLIC",
+  "description": "Fork of upstream/thing.",
+  "topics": [],
+  "default_branch": "master",
+  "created_at": "2023-11-01T00:00:00+00:00",
+  "pushed_at": "2024-01-01T00:00:00+00:00",
+  "license": "Apache-2.0",
+  "stargazers_count": 0,
+  "forks_count": 0,
+  "archived": true,
+  "is_fork": true,
+  "primary_language": "Python"
+}

--- a/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/stale-fork/tree.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/repos/acme/stale-fork/tree.json
@@ -1,0 +1,1 @@
+["README.md", "main.py", "LICENSE"]

--- a/src/pmpe/portfolio/__init__.py
+++ b/src/pmpe/portfolio/__init__.py
@@ -8,6 +8,12 @@ the archived loop-engineering prototype.
 """
 
 from pmpe.portfolio.contract import AuditorBundle, load_auditor_bundle
+from pmpe.portfolio.datasource import (
+    FixtureRepositorySource,
+    LiveAccessUnavailable,
+    LiveRepositorySource,
+    RepositorySource,
+)
 from pmpe.portfolio.models import (
     AISlopVerdict,
     BusinessAccuracyVerdict,
@@ -18,6 +24,7 @@ from pmpe.portfolio.models import (
     SlopPolicy,
 )
 from pmpe.portfolio.policy import AuditorPolicy, load_policy
+from pmpe.portfolio.scanner import RepoScan, scan_portfolio, scan_repository
 
 __all__ = [
     "AISlopVerdict",
@@ -26,9 +33,16 @@ __all__ = [
     "BusinessAccuracyVerdict",
     "EvidenceRef",
     "Finding",
+    "FixtureRepositorySource",
+    "LiveAccessUnavailable",
+    "LiveRepositorySource",
     "RecommendationVerdict",
+    "RepoScan",
+    "RepositorySource",
     "Severity",
     "SlopPolicy",
     "load_auditor_bundle",
     "load_policy",
+    "scan_portfolio",
+    "scan_repository",
 ]

--- a/src/pmpe/portfolio/datasource.py
+++ b/src/pmpe/portfolio/datasource.py
@@ -1,0 +1,117 @@
+"""Read-only repository access behind a protocol.
+
+``FixtureRepositorySource`` reads snapshot fixtures — the only path that
+works in V1 builds (PD-PA-04). ``LiveRepositorySource`` is a loud
+placeholder: live retrieval, when the operator eventually supplies the
+repository allowlist, is performed by the agent layer writing snapshots
+into a fixture directory which this module then reads. The Python runtime
+never talks to the network or a model API (PD-11), and no test requires
+either.
+
+Fixture layout::
+
+    <root>/
+      owners/<owner>.json                     # ["repo-a", "repo-b", ...]
+      repos/<owner>/<name>/metadata.json      # repository metadata mapping
+      repos/<owner>/<name>/tree.json          # ["path/one", "path/two", ...]
+      repos/<owner>/<name>/files.json         # {"path": "text content", ...}
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from pmpe.domain.errors import PmpeError
+
+
+class LiveAccessUnavailable(PmpeError):  # noqa: N818 — it names a condition, not an event
+    """Raised when repository data is requested that no snapshot provides."""
+
+
+class RepositorySource(Protocol):
+    """Read-only access to a portfolio of repository snapshots."""
+
+    def discover(self, owner: str) -> list[str]: ...
+
+    def metadata(self, owner: str, name: str) -> dict[str, Any]: ...
+
+    def tree(self, owner: str, name: str) -> list[str]: ...
+
+    def files(self, owner: str, name: str) -> dict[str, str]: ...
+
+
+class FixtureRepositorySource:
+    """Reads repository snapshots from a fixture directory."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        if not self.root.is_dir():
+            raise FileNotFoundError(f"fixture root does not exist: {self.root}")
+
+    def _load(self, path: Path) -> Any:
+        with path.open(encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def _repo_dir(self, owner: str, name: str) -> Path:
+        return self.root / "repos" / owner / name
+
+    def discover(self, owner: str) -> list[str]:
+        path = self.root / "owners" / f"{owner}.json"
+        if not path.is_file():
+            raise LiveAccessUnavailable(f"no owner index for {owner} at {path}")
+        names = self._load(path)
+        if not isinstance(names, list):
+            raise ValueError(f"corrupt owner index: {path}")
+        return [str(n) for n in names]
+
+    def metadata(self, owner: str, name: str) -> dict[str, Any]:
+        path = self._repo_dir(owner, name) / "metadata.json"
+        if not path.is_file():
+            raise LiveAccessUnavailable(f"no metadata snapshot for {owner}/{name} at {path}")
+        data = self._load(path)
+        if not isinstance(data, dict):
+            raise ValueError(f"corrupt metadata fixture: {path}")
+        return data
+
+    def tree(self, owner: str, name: str) -> list[str]:
+        path = self._repo_dir(owner, name) / "tree.json"
+        if not path.is_file():
+            raise LiveAccessUnavailable(f"no tree snapshot for {owner}/{name} at {path}")
+        data = self._load(path)
+        if not isinstance(data, list):
+            raise ValueError(f"corrupt tree fixture: {path}")
+        return [str(p) for p in data]
+
+    def files(self, owner: str, name: str) -> dict[str, str]:
+        path = self._repo_dir(owner, name) / "files.json"
+        if not path.is_file():
+            return {}
+        data = self._load(path)
+        if not isinstance(data, dict):
+            raise ValueError(f"corrupt files fixture: {path}")
+        return {str(k): str(v) for k, v in data.items()}
+
+
+class LiveRepositorySource:
+    """Loud placeholder: live GitHub access does not exist in V1 builds."""
+
+    def __init__(self, reason: str | None = None) -> None:
+        self.reason = reason or (
+            "live GitHub access is not available in V1 builds (PD-PA-04): the "
+            "operator has not supplied a repository allowlist; fetch snapshots "
+            "into a fixture directory and re-run against that fixture root"
+        )
+
+    def discover(self, owner: str) -> list[str]:
+        raise LiveAccessUnavailable(self.reason)
+
+    def metadata(self, owner: str, name: str) -> dict[str, Any]:
+        raise LiveAccessUnavailable(self.reason)
+
+    def tree(self, owner: str, name: str) -> list[str]:
+        raise LiveAccessUnavailable(self.reason)
+
+    def files(self, owner: str, name: str) -> dict[str, str]:
+        raise LiveAccessUnavailable(self.reason)

--- a/src/pmpe/portfolio/datasource.py
+++ b/src/pmpe/portfolio/datasource.py
@@ -42,23 +42,36 @@ class RepositorySource(Protocol):
     def files(self, owner: str, name: str) -> dict[str, str]: ...
 
 
+def _safe_segment(value: str, label: str) -> str:
+    """One path segment, contained: no separators, no traversal, non-empty.
+
+    Owner and repository names come from configuration; a crafted name must
+    never read outside the fixture root (M2 review hardening, pre-M3).
+    """
+    if not value or value in (".", "..") or "/" in value or "\\" in value:
+        raise ValueError(f"{label} must be a plain name, got {value!r}")
+    return value
+
+
 class FixtureRepositorySource:
     """Reads repository snapshots from a fixture directory."""
 
     def __init__(self, root: str | Path) -> None:
-        self.root = Path(root)
+        self.root = Path(root).resolve()
         if not self.root.is_dir():
             raise FileNotFoundError(f"fixture root does not exist: {self.root}")
 
     def _load(self, path: Path) -> Any:
-        with path.open(encoding="utf-8") as fh:
+        resolved = path.resolve()
+        resolved.relative_to(self.root)  # containment: never read outside the root
+        with resolved.open(encoding="utf-8") as fh:
             return json.load(fh)
 
     def _repo_dir(self, owner: str, name: str) -> Path:
-        return self.root / "repos" / owner / name
+        return self.root / "repos" / _safe_segment(owner, "owner") / _safe_segment(name, "name")
 
     def discover(self, owner: str) -> list[str]:
-        path = self.root / "owners" / f"{owner}.json"
+        path = self.root / "owners" / f"{_safe_segment(owner, 'owner')}.json"
         if not path.is_file():
             raise LiveAccessUnavailable(f"no owner index for {owner} at {path}")
         names = self._load(path)

--- a/src/pmpe/portfolio/models.py
+++ b/src/pmpe/portfolio/models.py
@@ -281,6 +281,11 @@ def gate_slop_verdict(
     downgraded, whatever the confidence. INSUFFICIENT_EVIDENCE passes
     through untouched — uncertainty is always expressible.
     """
+    if sole_basis == "":
+        raise ValueError(
+            "sole_basis must be None (no sole basis) or a named basis — "
+            "an empty string is ambiguous caller input"
+        )
     if proposed is AISlopVerdict.INSUFFICIENT_EVIDENCE:
         return proposed
     if sole_basis is not None and sole_basis in policy.forbidden_sole_bases:

--- a/src/pmpe/portfolio/scanner.py
+++ b/src/pmpe/portfolio/scanner.py
@@ -397,15 +397,38 @@ _CLAIM_RULES: list[tuple[str, re.Pattern[str]]] = [
 ]
 
 
+#: Credential-in-URL (https://user:token@host) — a common install-command
+#: pattern the assignment-shaped rules cannot see.
+_URL_CREDENTIAL_RE = re.compile(r"://[^/\s:@]+:[^/\s@]+@")
+
+
 def _basename(path: str) -> str:
     return path.rsplit("/", 1)[-1]
 
 
 def _find_readme(files: dict[str, str]) -> str | None:
-    for path, content in files.items():
-        if _basename(path).lower().startswith("readme"):
-            return content
-    return None
+    """Deterministic README selection: shallowest path, then lexicographic.
+
+    Multiple READMEs (``README.md`` + ``docs/README.md``) must never make
+    the chosen one depend on ``files()`` iteration order (AC-PA-002).
+    """
+    candidates = [path for path in files if _basename(path).lower().startswith("readme")]
+    if not candidates:
+        return None
+    best = min(candidates, key=lambda p: (p.count("/"), p.lower()))
+    return files[best]
+
+
+def redact_text(text: str) -> str:
+    """Replace every secret-shaped span in ``text`` with the redaction marker.
+
+    Output fields that copy repository text verbatim (claim text, install
+    commands, descriptions) MUST pass through here — redaction is holistic,
+    not a property of the secret_hits subsystem alone (PD-PA-06).
+    """
+    for _, pattern in _SECRET_RULES:
+        text = pattern.sub(REDACTED, text)
+    return _URL_CREDENTIAL_RE.sub(f"://{REDACTED}@", text)
 
 
 def detect_secrets(files: dict[str, str]) -> list[SecretHit]:
@@ -423,7 +446,12 @@ def detect_secrets(files: dict[str, str]) -> list[SecretHit]:
 def extract_mechanical_claims(
     readme_text: str, location_file: str = "README.md"
 ) -> list[MechanicalClaim]:
-    """Pull candidate claim sentences from a README for later accuracy grading."""
+    """Pull candidate claim sentences from a README for later accuracy grading.
+
+    Redaction happens BEFORE truncation: truncating first could clip a
+    secret so the pattern no longer matches while most of the value
+    survives in the kept prefix.
+    """
     claims: list[MechanicalClaim] = []
     for lineno, raw in enumerate(readme_text.splitlines(), start=1):
         line = raw.strip()
@@ -433,7 +461,9 @@ def extract_mechanical_claims(
             if pattern.search(line):
                 claims.append(
                     MechanicalClaim(
-                        text=line[:200], category=category, location=f"{location_file}:{lineno}"
+                        text=redact_text(line)[:200],
+                        category=category,
+                        location=f"{location_file}:{lineno}",
                     )
                 )
     return claims
@@ -535,7 +565,9 @@ def _install_commands(readme_text: str) -> list[str]:
             continue
         m = _INSTALL_CMD.match(raw)
         if m:
-            cmds.append(m.group(1).strip())
+            # Install commands routinely embed registry credentials
+            # (--extra-index-url https://user:token@host) — redact before copy.
+            cmds.append(redact_text(m.group(1).strip()))
     return cmds
 
 
@@ -654,7 +686,7 @@ def scan_repository(
         owner=owner,
         name=name,
         visibility=RepoVisibility(str(meta.get("visibility", "PUBLIC"))),
-        description=str(meta.get("description") or ""),
+        description=redact_text(str(meta.get("description") or "")),
         topics=[str(t) for t in meta.get("topics", [])],
         default_branch=str(meta.get("default_branch", "main")),
         stars=int(meta.get("stargazers_count", 0)),

--- a/src/pmpe/portfolio/scanner.py
+++ b/src/pmpe/portfolio/scanner.py
@@ -1,0 +1,760 @@
+"""Broad, read-only repository scanner (M2).
+
+Derives *mechanical, observable* signals from repository snapshots — never
+model output, never the network, never a judgment. Secret values are never
+emitted; a detected secret is recorded only as ``(rule, path, line)`` with a
+redaction marker (PD-PA-06). Signals feed risk selection (M3), deep
+inspection (M4), and the AI-slop classifier (M5); the scanner itself decides
+nothing.
+
+Determinism: every list is deterministically ordered, the clock is the
+``now`` parameter (an unparseable or absent ``now`` degrades the age to
+"unknown", never to a wall-clock read), and repeated scans of the same
+snapshots are byte-identical.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from typing import Any
+
+from pmpe.portfolio.datasource import RepositorySource
+from pmpe.portfolio.models import RepoVisibility
+
+SCANNER_VERSION = "pa-scanner-1"
+
+REDACTED = "***REDACTED***"
+
+# --- signal dataclasses ----------------------------------------------------
+
+
+@dataclass
+class SecretHit:
+    rule: str
+    path: str
+    line: int
+    redacted: str = REDACTED
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SecretHit:
+        return cls(
+            rule=str(d["rule"]),
+            path=str(d["path"]),
+            line=int(d["line"]),
+            redacted=str(d.get("redacted", REDACTED)),
+        )
+
+
+@dataclass
+class MechanicalClaim:
+    text: str
+    category: str
+    location: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> MechanicalClaim:
+        return cls(text=str(d["text"]), category=str(d["category"]), location=str(d["location"]))
+
+
+@dataclass
+class ReadmeSignals:
+    has_readme: bool
+    length_chars: int
+    heading_count: int
+    has_install_section: bool
+    has_usage_section: bool
+    has_badges: bool
+    code_fence_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ReadmeSignals:
+        return cls(
+            has_readme=bool(d["has_readme"]),
+            length_chars=int(d["length_chars"]),
+            heading_count=int(d["heading_count"]),
+            has_install_section=bool(d["has_install_section"]),
+            has_usage_section=bool(d["has_usage_section"]),
+            has_badges=bool(d["has_badges"]),
+            code_fence_count=int(d["code_fence_count"]),
+        )
+
+
+@dataclass
+class DocsSignals:
+    has_docs_dir: bool
+    doc_file_count: int
+    has_contributing: bool
+    has_code_of_conduct: bool
+    has_changelog: bool
+    has_license_file: bool
+    license_name: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DocsSignals:
+        return cls(
+            has_docs_dir=bool(d["has_docs_dir"]),
+            doc_file_count=int(d["doc_file_count"]),
+            has_contributing=bool(d["has_contributing"]),
+            has_code_of_conduct=bool(d["has_code_of_conduct"]),
+            has_changelog=bool(d["has_changelog"]),
+            has_license_file=bool(d["has_license_file"]),
+            license_name=(None if d.get("license_name") is None else str(d["license_name"])),
+        )
+
+
+@dataclass
+class TestCiSignals:
+    has_tests: bool
+    test_file_count: int
+    has_ci: bool
+    ci_workflow_count: int
+    ci_files: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TestCiSignals:
+        return cls(
+            has_tests=bool(d["has_tests"]),
+            test_file_count=int(d["test_file_count"]),
+            has_ci=bool(d["has_ci"]),
+            ci_workflow_count=int(d["ci_workflow_count"]),
+            ci_files=[str(f) for f in d.get("ci_files", [])],
+        )
+
+
+@dataclass
+class SecuritySignals:
+    has_security_md: bool
+    has_lockfile: bool
+    lockfile_kinds: list[str]
+    dependency_manifests: list[str]
+    declared_dependency_count: int
+    pinned_dependencies: bool | None
+    secret_hits: list[SecretHit] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "has_security_md": self.has_security_md,
+            "has_lockfile": self.has_lockfile,
+            "lockfile_kinds": list(self.lockfile_kinds),
+            "dependency_manifests": list(self.dependency_manifests),
+            "declared_dependency_count": self.declared_dependency_count,
+            "pinned_dependencies": self.pinned_dependencies,
+            "secret_hits": [h.to_dict() for h in self.secret_hits],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SecuritySignals:
+        return cls(
+            has_security_md=bool(d["has_security_md"]),
+            has_lockfile=bool(d["has_lockfile"]),
+            lockfile_kinds=[str(k) for k in d.get("lockfile_kinds", [])],
+            dependency_manifests=[str(m) for m in d.get("dependency_manifests", [])],
+            declared_dependency_count=int(d["declared_dependency_count"]),
+            pinned_dependencies=(
+                None if d.get("pinned_dependencies") is None else bool(d["pinned_dependencies"])
+            ),
+            secret_hits=[SecretHit.from_dict(h) for h in d.get("secret_hits", [])],
+        )
+
+
+@dataclass
+class PackagingSignals:
+    has_dockerfile: bool
+    has_pyproject_or_setup: bool
+    has_package_json: bool
+    has_makefile: bool
+    install_commands: list[str] = field(default_factory=list)
+    entrypoints: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> PackagingSignals:
+        return cls(
+            has_dockerfile=bool(d["has_dockerfile"]),
+            has_pyproject_or_setup=bool(d["has_pyproject_or_setup"]),
+            has_package_json=bool(d["has_package_json"]),
+            has_makefile=bool(d["has_makefile"]),
+            install_commands=[str(c) for c in d.get("install_commands", [])],
+            entrypoints=[str(e) for e in d.get("entrypoints", [])],
+        )
+
+
+@dataclass
+class FreshnessSignals:
+    created_at: str
+    pushed_at: str
+    days_since_pushed: int | None
+    archived: bool
+    is_fork: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> FreshnessSignals:
+        return cls(
+            created_at=str(d["created_at"]),
+            pushed_at=str(d["pushed_at"]),
+            days_since_pushed=(
+                None if d.get("days_since_pushed") is None else int(d["days_since_pushed"])
+            ),
+            archived=bool(d["archived"]),
+            is_fork=bool(d["is_fork"]),
+        )
+
+
+@dataclass
+class RepoScan:
+    owner: str
+    name: str
+    visibility: RepoVisibility
+    description: str
+    topics: list[str]
+    default_branch: str
+    stars: int
+    forks: int
+    languages: list[str]
+    stack: list[str]
+    readme: ReadmeSignals
+    docs: DocsSignals
+    tests_ci: TestCiSignals
+    security: SecuritySignals
+    packaging: PackagingSignals
+    freshness: FreshnessSignals
+    mechanical_claims: list[MechanicalClaim]
+    scanner_version: str = SCANNER_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "owner": self.owner,
+            "name": self.name,
+            "visibility": self.visibility.value,
+            "description": self.description,
+            "topics": list(self.topics),
+            "default_branch": self.default_branch,
+            "stars": self.stars,
+            "forks": self.forks,
+            "languages": list(self.languages),
+            "stack": list(self.stack),
+            "readme": self.readme.to_dict(),
+            "docs": self.docs.to_dict(),
+            "tests_ci": self.tests_ci.to_dict(),
+            "security": self.security.to_dict(),
+            "packaging": self.packaging.to_dict(),
+            "freshness": self.freshness.to_dict(),
+            "mechanical_claims": [c.to_dict() for c in self.mechanical_claims],
+            "scanner_version": self.scanner_version,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RepoScan:
+        return cls(
+            owner=str(d["owner"]),
+            name=str(d["name"]),
+            visibility=RepoVisibility(d["visibility"]),
+            description=str(d["description"]),
+            topics=[str(t) for t in d.get("topics", [])],
+            default_branch=str(d["default_branch"]),
+            stars=int(d["stars"]),
+            forks=int(d["forks"]),
+            languages=[str(x) for x in d.get("languages", [])],
+            stack=[str(x) for x in d.get("stack", [])],
+            readme=ReadmeSignals.from_dict(d["readme"]),
+            docs=DocsSignals.from_dict(d["docs"]),
+            tests_ci=TestCiSignals.from_dict(d["tests_ci"]),
+            security=SecuritySignals.from_dict(d["security"]),
+            packaging=PackagingSignals.from_dict(d["packaging"]),
+            freshness=FreshnessSignals.from_dict(d["freshness"]),
+            mechanical_claims=[
+                MechanicalClaim.from_dict(c) for c in d.get("mechanical_claims", [])
+            ],
+            scanner_version=str(d.get("scanner_version", SCANNER_VERSION)),
+        )
+
+
+# --- detection tables ------------------------------------------------------
+
+_EXT_LANG = {
+    ".py": "Python",
+    ".js": "JavaScript",
+    ".ts": "TypeScript",
+    ".tsx": "TypeScript",
+    ".jsx": "JavaScript",
+    ".go": "Go",
+    ".rs": "Rust",
+    ".java": "Java",
+    ".rb": "Ruby",
+    ".c": "C",
+    ".h": "C",
+    ".cpp": "C++",
+    ".cc": "C++",
+    ".cs": "C#",
+    ".php": "PHP",
+    ".swift": "Swift",
+    ".kt": "Kotlin",
+    ".scala": "Scala",
+    ".sh": "Shell",
+    ".md": "Markdown",
+    ".rst": "reStructuredText",
+    ".yml": "YAML",
+    ".yaml": "YAML",
+    ".toml": "TOML",
+    ".json": "JSON",
+    ".html": "HTML",
+    ".css": "CSS",
+}
+
+_LOCKFILES = {
+    "poetry.lock",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Pipfile.lock",
+    "Cargo.lock",
+    "go.sum",
+    "composer.lock",
+    "Gemfile.lock",
+}
+
+_DEP_MANIFESTS = {
+    "requirements.txt",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "Pipfile",
+    "package.json",
+    "go.mod",
+    "Cargo.toml",
+    "pom.xml",
+    "build.gradle",
+    "Gemfile",
+    "composer.json",
+}
+
+_SECRET_RULES: list[tuple[str, re.Pattern[str]]] = [
+    ("aws_access_key_id", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("private_key_block", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+    ("github_token", re.compile(r"ghp_[A-Za-z0-9]{36}")),
+    ("github_pat", re.compile(r"github_pat_[A-Za-z0-9_]{20,}")),
+    ("slack_token", re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}")),
+    ("stripe_secret_key", re.compile(r"sk_live_[A-Za-z0-9]{16,}")),
+    (
+        "generic_secret_assignment",
+        re.compile(
+            r"""(?i)(?:api[_-]?key|secret|token|password|passwd|pwd)\s*[:=]\s*['"][A-Za-z0-9_\-]{12,}['"]"""
+        ),
+    ),
+    (
+        # Catches secrets under arbitrary *key names (awsKey, accessKey,
+        # STRIPE_KEY); the 16+ char quoted value keeps false positives on
+        # short key-named vars low.
+        "key_named_assignment",
+        re.compile(r"""(?i)\w*key\s*[:=]\s*['"][A-Za-z0-9_\-]{16,}['"]"""),
+    ),
+]
+
+_CLAIM_RULES: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "production_readiness",
+        re.compile(r"(?i)production[- ]ready|battle[- ]tested|enterprise[- ]grade"),
+    ),
+    (
+        "scale",
+        re.compile(r"(?i)infinitely scalable|scales? to|scalable|zero downtime|billions?"),
+    ),
+    ("metric", re.compile(r"\d+(?:\.\d+)?\s*%|\b\d+x\b|\b\d+\s?ms\b|\b99\.9+\b")),
+    (
+        "adoption",
+        re.compile(r"(?i)used by|trusted by|millions of (?:developers|users)|fortune\s?500"),
+    ),
+    (
+        "superlative",
+        re.compile(
+            r"(?i)state[- ]of[- ]the[- ]art|\bsota\b|best[- ]in[- ]class|"
+            r"industry[- ]leading|blazing fast"
+        ),
+    ),
+]
+
+
+def _basename(path: str) -> str:
+    return path.rsplit("/", 1)[-1]
+
+
+def _find_readme(files: dict[str, str]) -> str | None:
+    for path, content in files.items():
+        if _basename(path).lower().startswith("readme"):
+            return content
+    return None
+
+
+def detect_secrets(files: dict[str, str]) -> list[SecretHit]:
+    """Mechanical secret detection. Records rule/path/line only — never the value."""
+    hits: list[SecretHit] = []
+    for path in sorted(files):
+        content = files[path]
+        for rule, pattern in _SECRET_RULES:
+            for match in pattern.finditer(content):
+                line = content.count("\n", 0, match.start()) + 1
+                hits.append(SecretHit(rule=rule, path=path, line=line))
+    return hits
+
+
+def extract_mechanical_claims(
+    readme_text: str, location_file: str = "README.md"
+) -> list[MechanicalClaim]:
+    """Pull candidate claim sentences from a README for later accuracy grading."""
+    claims: list[MechanicalClaim] = []
+    for lineno, raw in enumerate(readme_text.splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        for category, pattern in _CLAIM_RULES:
+            if pattern.search(line):
+                claims.append(
+                    MechanicalClaim(
+                        text=line[:200], category=category, location=f"{location_file}:{lineno}"
+                    )
+                )
+    return claims
+
+
+_VERSION_OP_RE = re.compile(r"(==|>=|<=|~=|!=|===|>|<|~|\^|=)")
+
+
+def _version_part(spec: str) -> str:
+    """Strip a leading distribution name (and markers), leaving the version.
+
+    A distribution name may contain ``x``/``X`` (``lxml``, ``sphinx``,
+    ``openpyxl``); evaluating the whole ``name==version`` string for wildcard
+    characters would mis-flag exactly-pinned packages, so the version
+    specifier is isolated first.
+    """
+    spec = spec.strip().split(";", 1)[0].strip()
+    m = _VERSION_OP_RE.search(spec)
+    return spec[m.start() :].strip() if m else spec
+
+
+def _is_exact_spec(spec: str) -> bool:
+    version = _version_part(spec)
+    if not version or version in {"*", "latest", "x", "X"}:
+        return False
+    if any(op in version for op in ("^", "~", ">", "<", "*", "!", "||", " - ")):
+        return False
+    if re.search(r"(?:^|\.)[xX](?:\.|$)", version):  # wildcard version like 4.x
+        return False
+    if version.startswith("=="):
+        return True
+    return bool(re.fullmatch(r"v?\d+(?:\.\d+)*", version))
+
+
+def _python_req_specs(content: str) -> list[str]:
+    specs: list[str] = []
+    for raw in content.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            specs.append(line)
+    return specs
+
+
+def _pyproject_dep_specs(content: str) -> list[str]:
+    block = re.search(r"dependencies\s*=\s*\[(.*?)\]", content, re.DOTALL)
+    if not block:
+        return []
+    return re.findall(r"['\"]([^'\"]+)['\"]", block.group(1))
+
+
+def _package_json_deps(content: str) -> dict[str, str]:
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    deps: dict[str, str] = {}
+    for key in ("dependencies", "devDependencies"):
+        section = data.get(key)
+        if isinstance(section, dict):
+            for name, spec in section.items():
+                deps[str(name)] = str(spec)
+    return deps
+
+
+def _dependency_signals(files: dict[str, str]) -> tuple[int, bool | None]:
+    """Return (declared_dependency_count, pinned_dependencies|None)."""
+    count = 0
+    exact_flags: list[bool] = []
+    if "requirements.txt" in files:
+        specs = _python_req_specs(files["requirements.txt"])
+        count += len(specs)
+        exact_flags += [_is_exact_spec(s) for s in specs]
+    if "pyproject.toml" in files:
+        specs = _pyproject_dep_specs(files["pyproject.toml"])
+        count += len(specs)
+        exact_flags += [_is_exact_spec(s) for s in specs]
+    if "package.json" in files:
+        deps = _package_json_deps(files["package.json"])
+        count += len(deps)
+        exact_flags += [_is_exact_spec(v) for v in deps.values()]
+    pinned: bool | None = all(exact_flags) if exact_flags else None
+    return count, pinned
+
+
+_INSTALL_CMD = re.compile(
+    r"(?i)^\s*(?:\$\s*)?((?:sudo\s+)?(?:python3?\s+-m\s+pip|pip3?|pipx|npm|yarn|pnpm|poetry|"
+    r"pipenv|docker|make|cargo|go|apt-get|brew)\b.*)$"
+)
+
+
+def _install_commands(readme_text: str) -> list[str]:
+    cmds: list[str] = []
+    in_fence = False
+    for raw in readme_text.splitlines():
+        if raw.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            continue
+        m = _INSTALL_CMD.match(raw)
+        if m:
+            cmds.append(m.group(1).strip())
+    return cmds
+
+
+def _entrypoints(files: dict[str, str]) -> list[str]:
+    entry: list[str] = []
+    if "pyproject.toml" in files:
+        block = re.search(
+            r"\[project\.scripts\](.*?)(?:\n\[|\Z)", files["pyproject.toml"], re.DOTALL
+        )
+        if block:
+            entry += re.findall(r"^\s*([\w.-]+)\s*=", block.group(1), re.MULTILINE)
+    if "package.json" in files:
+        try:
+            data = json.loads(files["package.json"])
+        except (json.JSONDecodeError, ValueError):
+            data = {}
+        binsection = data.get("bin") if isinstance(data, dict) else None
+        if isinstance(binsection, dict):
+            entry += [str(k) for k in binsection]
+        elif isinstance(binsection, str):
+            entry.append(str(data.get("name", "")))
+    return [e for e in entry if e]
+
+
+def _languages(tree: list[str]) -> list[str]:
+    counts: dict[str, int] = {}
+    for path in tree:
+        base = _basename(path)
+        idx = base.rfind(".")
+        if idx <= 0:
+            continue
+        lang = _EXT_LANG.get(base[idx:].lower())
+        if lang:
+            counts[lang] = counts.get(lang, 0) + 1
+    return [lang for lang, _ in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))]
+
+
+def _stack(tree_set: set[str], languages: list[str]) -> list[str]:
+    tokens: set[str] = set()
+    if (
+        "Python" in languages
+        or {"pyproject.toml", "setup.py", "requirements.txt", "Pipfile"} & tree_set
+    ):
+        tokens.add("python")
+    if "JavaScript" in languages or "TypeScript" in languages or "package.json" in tree_set:
+        tokens.add("node")
+    if "Go" in languages or "go.mod" in tree_set:
+        tokens.add("go")
+    if "Rust" in languages or "Cargo.toml" in tree_set:
+        tokens.add("rust")
+    if "Java" in languages or {"pom.xml", "build.gradle"} & tree_set:
+        tokens.add("java")
+    if "Ruby" in languages or "Gemfile" in tree_set:
+        tokens.add("ruby")
+    if any(_basename(p) == "Dockerfile" for p in tree_set):
+        tokens.add("containerized")
+    return sorted(tokens)
+
+
+def _is_test_path(path: str) -> bool:
+    lower = path.lower()
+    if lower.startswith(("tests/", "test/")) or "/tests/" in lower or "/test/" in lower:
+        return True
+    base = _basename(lower)
+    return bool(
+        re.match(r"test_.*\.py$", base)
+        or re.match(r".*_test\.(py|go)$", base)
+        or re.match(r".*\.(test|spec)\.(js|ts|jsx|tsx)$", base)
+        or re.match(r".*test\.java$", base)
+    )
+
+
+def _ci_files(tree: list[str]) -> list[str]:
+    ci: list[str] = []
+    for path in tree:
+        lower = path.lower()
+        if (
+            (lower.startswith(".github/workflows/") and lower.endswith((".yml", ".yaml")))
+            or lower
+            in {".gitlab-ci.yml", ".circleci/config.yml", "azure-pipelines.yml", "jenkinsfile"}
+            or _basename(path) == "Jenkinsfile"
+        ):
+            ci.append(path)
+    return sorted(ci)
+
+
+def _days_since(now: str | None, pushed_at: str) -> int | None:
+    if not now:
+        return None
+    try:
+        now_dt = datetime.fromisoformat(now)
+        pushed_dt = datetime.fromisoformat(pushed_at)
+        return (now_dt - pushed_dt).days
+    except (ValueError, TypeError):
+        # Unparseable timestamp or naive/aware mismatch degrades to "unknown"
+        # rather than aborting the whole scan or reading a wall clock.
+        return None
+
+
+# --- top-level scan --------------------------------------------------------
+
+
+def scan_repository(
+    source: RepositorySource, owner: str, name: str, now: str | None = None
+) -> RepoScan:
+    """Produce mechanical signals for one repository (read-only)."""
+    meta = source.metadata(owner, name)
+    tree = source.tree(owner, name)
+    files = source.files(owner, name)
+    tree_set = set(tree)
+
+    languages = _languages(tree)
+    readme_text = _find_readme(files)
+
+    return RepoScan(
+        owner=owner,
+        name=name,
+        visibility=RepoVisibility(str(meta.get("visibility", "PUBLIC"))),
+        description=str(meta.get("description") or ""),
+        topics=[str(t) for t in meta.get("topics", [])],
+        default_branch=str(meta.get("default_branch", "main")),
+        stars=int(meta.get("stargazers_count", 0)),
+        forks=int(meta.get("forks_count", 0)),
+        languages=languages,
+        stack=_stack(tree_set, languages),
+        readme=_readme_signals(readme_text),
+        docs=_docs_signals(tree, meta),
+        tests_ci=_tests_ci_signals(tree),
+        security=_security_signals(tree_set, files),
+        packaging=_packaging_signals(tree_set, files, readme_text),
+        freshness=FreshnessSignals(
+            created_at=str(meta.get("created_at", "")),
+            pushed_at=str(meta.get("pushed_at", "")),
+            days_since_pushed=_days_since(now, str(meta.get("pushed_at", ""))),
+            archived=bool(meta.get("archived", False)),
+            is_fork=bool(meta.get("is_fork", False)),
+        ),
+        mechanical_claims=extract_mechanical_claims(readme_text) if readme_text else [],
+    )
+
+
+def scan_portfolio(source: RepositorySource, owner: str, now: str | None = None) -> list[RepoScan]:
+    """Broadly scan every discovered repository, sorted by name for determinism."""
+    return [
+        scan_repository(source, owner, name, now=now) for name in sorted(source.discover(owner))
+    ]
+
+
+def _readme_signals(readme_text: str | None) -> ReadmeSignals:
+    if not readme_text:
+        return ReadmeSignals(False, 0, 0, False, False, False, 0)
+    lowered = readme_text.lower()
+    headings = sum(1 for ln in readme_text.splitlines() if ln.lstrip().startswith("#"))
+    has_install = bool(re.search(r"(?im)^#{1,6}.*install", readme_text)) or (
+        "pip install" in lowered or "npm install" in lowered or "npm i " in lowered
+    )
+    has_usage = bool(
+        re.search(r"(?im)^#{1,6}.*(usage|example|quickstart|getting started)", readme_text)
+    )
+    return ReadmeSignals(
+        has_readme=True,
+        length_chars=len(readme_text),
+        heading_count=headings,
+        has_install_section=has_install,
+        has_usage_section=has_usage,
+        has_badges="![" in readme_text or "shields.io" in lowered,
+        code_fence_count=readme_text.count("```") // 2,
+    )
+
+
+def _docs_signals(tree: list[str], meta: dict[str, Any]) -> DocsSignals:
+    bases = {_basename(p) for p in tree}
+    license_meta = meta.get("license")
+    return DocsSignals(
+        has_docs_dir=any(p.lower().startswith("docs/") for p in tree),
+        doc_file_count=sum(1 for p in tree if p.lower().endswith((".md", ".rst"))),
+        has_contributing=any(b.upper().startswith("CONTRIBUTING") for b in bases),
+        has_code_of_conduct=any(b.upper().startswith("CODE_OF_CONDUCT") for b in bases),
+        has_changelog=any(b.upper().startswith("CHANGELOG") for b in bases),
+        has_license_file=any(b.upper().startswith(("LICENSE", "LICENCE")) for b in bases),
+        license_name=(None if license_meta in (None, "", "UNLICENSED") else str(license_meta)),
+    )
+
+
+def _tests_ci_signals(tree: list[str]) -> TestCiSignals:
+    test_files = [p for p in tree if _is_test_path(p)]
+    ci = _ci_files(tree)
+    return TestCiSignals(
+        has_tests=bool(test_files),
+        test_file_count=len(test_files),
+        has_ci=bool(ci),
+        ci_workflow_count=len(ci),
+        ci_files=ci,
+    )
+
+
+def _security_signals(tree_set: set[str], files: dict[str, str]) -> SecuritySignals:
+    bases = {_basename(p) for p in tree_set}
+    dep_count, pinned = _dependency_signals(files)
+    return SecuritySignals(
+        has_security_md=any(b.upper().startswith("SECURITY.") for b in bases),
+        has_lockfile=bool(_LOCKFILES & bases),
+        lockfile_kinds=sorted(_LOCKFILES & bases),
+        dependency_manifests=sorted(_DEP_MANIFESTS & bases),
+        declared_dependency_count=dep_count,
+        pinned_dependencies=pinned,
+        secret_hits=detect_secrets(files),
+    )
+
+
+def _packaging_signals(
+    tree_set: set[str], files: dict[str, str], readme_text: str | None
+) -> PackagingSignals:
+    bases = {_basename(p) for p in tree_set}
+    return PackagingSignals(
+        has_dockerfile="Dockerfile" in bases,
+        has_pyproject_or_setup=bool({"pyproject.toml", "setup.py", "setup.cfg"} & bases),
+        has_package_json="package.json" in bases,
+        has_makefile="Makefile" in bases,
+        install_commands=_install_commands(readme_text) if readme_text else [],
+        entrypoints=_entrypoints(files),
+    )

--- a/src/pmpe/schemas/portfolio_finding.schema.json
+++ b/src/pmpe/schemas/portfolio_finding.schema.json
@@ -19,6 +19,7 @@
     "summary": {"type": "string", "minLength": 1},
     "evidence": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "required": ["evidence_id", "kind", "origin", "reference", "content_digest"],

--- a/tests/unit/test_portfolio_models.py
+++ b/tests/unit/test_portfolio_models.py
@@ -244,3 +244,15 @@ class TestSlopGate:
             )
             is AISlopVerdict.INSUFFICIENT_EVIDENCE
         )
+
+    def test_empty_string_sole_basis_is_rejected(self) -> None:
+        # M1 review follow-up: None means "no sole basis"; an empty string is
+        # ambiguous caller input and must be rejected, not silently allowed.
+        with pytest.raises(ValueError, match="sole_basis"):
+            gate_slop_verdict(
+                AISlopVerdict.AI_SLOP,
+                confidence=95,
+                counter_evidence_reviewed=True,
+                sole_basis="",
+                policy=_SLOP_POLICY,
+            )

--- a/tests/unit/test_portfolio_policy.py
+++ b/tests/unit/test_portfolio_policy.py
@@ -147,6 +147,25 @@ class TestSchemas:
             errors = validate_finding_dict(data)
             assert any(missing in e for e in errors), f"expected error for {missing}"
 
+    def test_finding_schema_rejects_empty_evidence_list(self) -> None:
+        # M1 review follow-up: the Finding model already refuses empty
+        # evidence; the schema must agree so a schema-only validation surface
+        # can never accept an evidence-free finding (PD-PA-07).
+        data = {
+            "finding_id": "PA-F-001",
+            "repository": "acme/healthy-lib",
+            "dimension": "technical_health",
+            "summary": "s",
+            "evidence": [],
+            "confidence": 80,
+            "severity": "HIGH",
+            "affected_capability": "tests_ci_evaluations",
+            "reasoning": "r",
+            "remediation_recommendation": "m",
+        }
+        errors = validate_finding_dict(data)
+        assert any("evidence" in e for e in errors)
+
 
 class TestNoPrototypeDependency:
     def test_portfolio_package_never_imports_loop_engineering(self) -> None:

--- a/tests/unit/test_portfolio_scanner.py
+++ b/tests/unit/test_portfolio_scanner.py
@@ -15,6 +15,7 @@ import json
 from pathlib import Path
 
 import pytest
+
 from pmpe.portfolio.datasource import (
     FixtureRepositorySource,
     LiveAccessUnavailable,

--- a/tests/unit/test_portfolio_scanner.py
+++ b/tests/unit/test_portfolio_scanner.py
@@ -236,3 +236,96 @@ class _FakeSource:
 
     def files(self, owner: str, name: str) -> dict[str, str]:
         return self._files
+
+
+HOSTILE_CLAIM_SECRET = "HOSTILE_SECRET_VALUE_a1b2c3d4e5f6g7h8"
+HOSTILE_URL_TOKEN = "HOSTILE_CMD_TOKEN_x9y8z7w6v5u4t3s2"
+
+
+class TestHolisticRedaction:
+    """M2 review blockers: secrets must never leak through copy-through fields."""
+
+    def test_claim_line_secret_never_reaches_claim_text(self) -> None:
+        readme = (
+            "# X\n"
+            f'This production-ready platform uses api_key = "{HOSTILE_CLAIM_SECRET}" '
+            "internally and is blazing fast.\n"
+        )
+        s = scan_repository(_FakeSource(_source(), {"README.md": readme}), "acme", "healthy-lib")
+        assert s.mechanical_claims, "the claim patterns must still fire"
+        blob = json.dumps(s.to_dict())
+        assert HOSTILE_CLAIM_SECRET not in blob
+        assert any("***REDACTED***" in c.text for c in s.mechanical_claims)
+
+    def test_redaction_happens_before_truncation(self) -> None:
+        # Pad so the secret straddles the 200-char cut: truncating first would
+        # clip the pattern while keeping most of the value.
+        pad = "battle-tested " + "x" * 170
+        readme = f'{pad} token = "{HOSTILE_CLAIM_SECRET}"\n'
+        s = scan_repository(_FakeSource(_source(), {"README.md": readme}), "acme", "healthy-lib")
+        blob = json.dumps(s.to_dict())
+        assert HOSTILE_CLAIM_SECRET not in blob
+        assert HOSTILE_CLAIM_SECRET[:12] not in blob
+
+    def test_install_command_credentials_redacted(self) -> None:
+        readme = (
+            "# X\n```bash\n"
+            f"pip install leaky --extra-index-url https://user:{HOSTILE_URL_TOKEN}@pypi.internal\n"
+            "```\n"
+        )
+        s = scan_repository(_FakeSource(_source(), {"README.md": readme}), "acme", "healthy-lib")
+        assert s.packaging.install_commands, "the install command must still be captured"
+        blob = json.dumps(s.to_dict())
+        assert HOSTILE_URL_TOKEN not in blob
+
+    def test_description_with_secret_is_redacted(self) -> None:
+        meta = dict(_source().metadata("acme", "healthy-lib"))
+        meta["description"] = f'ships with api_key = "{HOSTILE_CLAIM_SECRET}" built in'
+        s = scan_repository(_MetaSource(_source(), meta), "acme", "healthy-lib", now=NOW)
+        assert HOSTILE_CLAIM_SECRET not in json.dumps(s.to_dict())
+
+
+class TestReviewHardening:
+    """M2 review notes: traversal containment and order-independent README pick."""
+
+    def test_datasource_rejects_traversal_names(self) -> None:
+        src = _source()
+        for owner, name in (
+            ("acme", "../../../outside"),
+            ("../evil", "healthy-lib"),
+            ("acme", "a/b"),
+            ("acme", ".."),
+            ("", "healthy-lib"),
+        ):
+            with pytest.raises(ValueError):
+                src.metadata(owner, name)
+
+    def test_readme_selection_is_order_independent(self) -> None:
+        root = "# Root readme\nblazing fast\n"
+        nested = "# Docs readme\nsomething else entirely\n"
+        a = _FakeSource(_source(), {"README.md": root, "docs/README.md": nested})
+        b = _FakeSource(_source(), {"docs/README.md": nested, "README.md": root})
+        scan_a = scan_repository(a, "acme", "healthy-lib", now=NOW)
+        scan_b = scan_repository(b, "acme", "healthy-lib", now=NOW)
+        assert json.dumps(scan_a.to_dict()) == json.dumps(scan_b.to_dict())
+        assert scan_a.readme.length_chars == len(root)
+
+
+class _MetaSource:
+    """Wraps the fixture source, overriding metadata() only."""
+
+    def __init__(self, inner: FixtureRepositorySource, meta: dict[str, object]) -> None:
+        self._inner = inner
+        self._meta = meta
+
+    def discover(self, owner: str) -> list[str]:
+        return self._inner.discover(owner)
+
+    def metadata(self, owner: str, name: str) -> dict[str, object]:
+        return self._meta
+
+    def tree(self, owner: str, name: str) -> list[str]:
+        return self._inner.tree(owner, name)
+
+    def files(self, owner: str, name: str) -> dict[str, str]:
+        return self._inner.files(owner, name)

--- a/tests/unit/test_portfolio_scanner.py
+++ b/tests/unit/test_portfolio_scanner.py
@@ -1,0 +1,237 @@
+"""Portfolio Auditor M2 — broad deterministic repository scanner (RED-first).
+
+The scanner derives *mechanical, observable* signals from repository
+snapshots: never model output, never the network, never a judgment. Planted
+fixture expectations (demo portfolio): healthy-lib (well-kept Python lib),
+slop-wrapper (claim-heavy JS with planted placeholder secrets, no tests/CI/
+lockfile), stale-fork (old fork), internal-service (PRIVATE, planted
+placeholder key, mixed pinning). Secret values must never appear anywhere in
+scanner output — only rule/path/line with a redaction marker (PD-PA-06).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pmpe.portfolio.datasource import (
+    FixtureRepositorySource,
+    LiveAccessUnavailable,
+    LiveRepositorySource,
+)
+from pmpe.portfolio.scanner import (
+    RepoScan,
+    detect_secrets,
+    extract_mechanical_claims,
+    scan_portfolio,
+    scan_repository,
+)
+
+FIXTURES = (
+    Path(__file__).resolve().parents[2]
+    / "evals"
+    / "fixtures"
+    / "portfolio_auditor"
+    / "demo-portfolio"
+)
+NOW = "2026-07-18T00:00:00+00:00"
+
+PLANTED_SECRET_VALUES = (
+    "EXAMPLE_placeholder_secret_abcdef0123",
+    "aws_secret_FAKE_placeholder_0000",
+    "EXAMPLE_placeholder_billing_secret_0002",
+)
+
+
+def _source() -> FixtureRepositorySource:
+    return FixtureRepositorySource(FIXTURES)
+
+
+def _scan(name: str) -> RepoScan:
+    return scan_repository(_source(), "acme", name, now=NOW)
+
+
+class TestDatasource:
+    def test_discover_lists_all_repos(self) -> None:
+        assert set(_source().discover("acme")) == {
+            "healthy-lib",
+            "slop-wrapper",
+            "stale-fork",
+            "internal-service",
+        }
+
+    def test_missing_repo_raises_loudly(self) -> None:
+        with pytest.raises(LiveAccessUnavailable, match="no-such-repo"):
+            _source().metadata("acme", "no-such-repo")
+
+    def test_missing_fixture_root_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            FixtureRepositorySource(tmp_path / "absent")
+
+    def test_live_source_raises_loudly_on_every_method(self) -> None:
+        live = LiveRepositorySource()
+        for call in (
+            lambda: live.discover("acme"),
+            lambda: live.metadata("acme", "x"),
+            lambda: live.tree("acme", "x"),
+            lambda: live.files("acme", "x"),
+        ):
+            with pytest.raises(LiveAccessUnavailable):
+                call()
+
+
+class TestPortfolioScan:
+    def test_scan_portfolio_scans_every_repo_sorted(self) -> None:
+        scans = scan_portfolio(_source(), "acme", now=NOW)
+        assert [s.name for s in scans] == sorted(
+            ["healthy-lib", "slop-wrapper", "stale-fork", "internal-service"]
+        )
+
+    def test_repeated_scans_are_byte_identical(self) -> None:
+        one = json.dumps([s.to_dict() for s in scan_portfolio(_source(), "acme", now=NOW)])
+        two = json.dumps([s.to_dict() for s in scan_portfolio(_source(), "acme", now=NOW)])
+        assert one == two
+
+    def test_scan_output_contains_no_verdict(self) -> None:
+        # The broad scan records signals only — no premature AI-slop or
+        # recommendation verdict may appear anywhere in its output.
+        blob = json.dumps([s.to_dict() for s in scan_portfolio(_source(), "acme", now=NOW)])
+        for token in ("AI_SLOP", "NOT_AI_SLOP", "SHOWCASE", "REBUILD", "verdict"):
+            assert token not in blob
+
+    def test_scan_records_provenance(self) -> None:
+        s = _scan("healthy-lib")
+        assert s.scanner_version
+        assert s.to_dict()["scanner_version"] == s.scanner_version
+
+
+class TestHealthyLib:
+    def test_signals(self) -> None:
+        s = _scan("healthy-lib")
+        assert "Python" in s.languages
+        assert "python" in s.stack
+        assert s.docs.has_docs_dir and s.docs.has_contributing
+        assert s.docs.license_name == "MIT"
+        assert s.tests_ci.has_ci
+        assert s.security.has_lockfile and "poetry.lock" in s.security.lockfile_kinds
+        assert s.security.pinned_dependencies is True
+        assert s.security.secret_hits == []
+        assert s.readme.has_readme
+
+    def test_round_trips(self) -> None:
+        s = _scan("healthy-lib")
+        assert RepoScan.from_dict(s.to_dict()) == s
+
+
+class TestSlopWrapper:
+    def test_secret_detection_fully_redacted(self) -> None:
+        s = _scan("slop-wrapper")
+        assert s.security.secret_hits, "planted placeholder secrets must be detected"
+        assert {h.path for h in s.security.secret_hits} == {"config.js"}
+        for h in s.security.secret_hits:
+            assert h.rule and h.line > 0
+        blob = json.dumps(s.to_dict())
+        for value in PLANTED_SECRET_VALUES:
+            assert value not in blob, "a secret value leaked into scanner output"
+
+    def test_key_named_assignment_detected(self) -> None:
+        s = _scan("slop-wrapper")
+        assert any(h.rule == "key_named_assignment" for h in s.security.secret_hits)
+
+    def test_mechanical_claims_extracted(self) -> None:
+        s = _scan("slop-wrapper")
+        categories = {c.category for c in s.mechanical_claims}
+        assert {"production_readiness", "adoption", "superlative", "scale", "metric"} <= categories
+        for c in s.mechanical_claims:
+            assert c.location.startswith("README.md:")
+
+    def test_risk_signals_without_any_judgment(self) -> None:
+        s = _scan("slop-wrapper")
+        assert not s.security.has_lockfile
+        assert not s.tests_ci.has_tests
+        assert not s.tests_ci.has_ci
+        assert s.docs.license_name is None
+
+
+class TestStaleForkAndPrivate:
+    def test_stale_fork_flags(self) -> None:
+        s = _scan("stale-fork")
+        assert s.freshness.is_fork is True
+        assert s.freshness.days_since_pushed is not None
+        assert s.freshness.days_since_pushed > 500
+
+    def test_private_visibility_recorded_and_secret_redacted(self) -> None:
+        s = _scan("internal-service")
+        assert s.visibility.value == "PRIVATE"
+        assert any(h.path == "app/settings.py" for h in s.security.secret_hits)
+        blob = json.dumps(s.to_dict())
+        assert "EXAMPLE_placeholder_billing_secret_0002" not in blob
+
+    def test_mixed_pinning_reports_not_pinned(self) -> None:
+        # internal-service requirements.txt has requests>=2.31 among exact pins.
+        s = _scan("internal-service")
+        assert s.security.pinned_dependencies is False
+
+
+class TestFreshnessClock:
+    def test_now_none_gives_no_age(self) -> None:
+        s = scan_repository(_source(), "acme", "healthy-lib", now=None)
+        assert s.freshness.days_since_pushed is None
+
+    def test_naive_now_degrades_gracefully(self) -> None:
+        s = scan_repository(_source(), "acme", "healthy-lib", now="2026-07-18T00:00:00")
+        assert s.freshness.days_since_pushed is None
+
+
+class TestDetectionHelpers:
+    def test_pinned_deps_not_fooled_by_x_named_packages(self) -> None:
+        source = _source()
+        files = {"requirements.txt": "lxml==4.9.3\nsphinx==7.0.0\nopenpyxl==3.1.2\n"}
+        fake = _FakeSource(source, files)
+        s = scan_repository(fake, "acme", "healthy-lib", now=NOW)
+        assert s.security.pinned_dependencies is True
+
+    def test_wildcard_version_is_not_pinned(self) -> None:
+        source = _source()
+        fake = _FakeSource(source, {"requirements.txt": "somepkg==4.x\n"})
+        s = scan_repository(fake, "acme", "healthy-lib", now=NOW)
+        assert s.security.pinned_dependencies is False
+
+    def test_detect_secrets_covers_aws_and_stripe_rules(self) -> None:
+        files = {
+            "cfg.py": ("AWS_ID = 'AKIA" + "A" * 16 + "'\nstripe = 'sk_live_" + "a1" * 10 + "'\n")
+        }
+        rules = {h.rule for h in detect_secrets(files)}
+        assert "aws_access_key_id" in rules
+        assert "stripe_secret_key" in rules
+
+    def test_install_commands_capture_python_m_pip(self) -> None:
+        readme = "# X\n```bash\npython -m pip install x\nnpm install\n```\n"
+        s = _FakeSource(_source(), {"README.md": readme})
+        scan = scan_repository(s, "acme", "healthy-lib", now=NOW)
+        assert any("python -m pip install x" in c for c in scan.packaging.install_commands)
+
+    def test_claims_report_line_numbers(self) -> None:
+        claims = extract_mechanical_claims("plain\n\nblazing fast engine\n")
+        assert claims and claims[0].location == "README.md:3"
+
+
+class _FakeSource:
+    """Wraps the fixture source, overriding files() for helper-focused tests."""
+
+    def __init__(self, inner: FixtureRepositorySource, files: dict[str, str]) -> None:
+        self._inner = inner
+        self._files = files
+
+    def discover(self, owner: str) -> list[str]:
+        return self._inner.discover(owner)
+
+    def metadata(self, owner: str, name: str) -> dict[str, object]:
+        return self._inner.metadata(owner, name)
+
+    def tree(self, owner: str, name: str) -> list[str]:
+        return sorted(self._files)
+
+    def files(self, owner: str, name: str) -> dict[str, str]:
+        return self._files


### PR DESCRIPTION
# Pull request

## What changed and why

Milestone 2 of the GitHub Portfolio Auditor V1: the broad, read-only, deterministic repository scanner plus the planted fixture portfolio. One concern: mechanical signal extraction — the scanner records observable facts and decides nothing (no verdict token appears anywhere in its output, test-enforced).

- `src/pmpe/portfolio/datasource.py` — `RepositorySource` protocol; `FixtureRepositorySource` over snapshot fixtures (missing snapshots raise `LiveAccessUnavailable` loudly); `LiveRepositorySource` is a fail-loud placeholder — **no network path exists in V1 builds** (PD-PA-04, PD-11).
- `src/pmpe/portfolio/scanner.py` — languages/stack, README/docs/tests/CI signals, security signals (lockfiles, manifests, declared-dep count, name-aware pinned-deps heuristic carrying the prototype-review regression fix for x-named packages, **redacted secret detection: rule/path/line only, never the value** — PD-PA-06), packaging, freshness from the injected `now` (no wall clock; unparseable → unknown), mechanical claim extraction with line locations. Repeated scans are byte-identical (AC-PA-002).
- `evals/fixtures/portfolio_auditor/demo-portfolio/` — the four-repo planted portfolio ported verbatim from the archived prototype (healthy-lib / slop-wrapper with placeholder secrets + inflated claims / stale-fork / PRIVATE internal-service): operator-approved reusable assets.
- M1 review follow-ups: finding schema `minItems: 1` on evidence; `gate_slop_verdict` rejects empty-string `sole_basis`; threat-model tense corrected for M2/M4 mitigations.

## Requirement reference

`products/portfolio-auditor/contract.json` FR-PA-002 (AC-PA-002); PD-PA-04/06; M1 review non-blocking notes 1–3 (PR #53 review record).

## Architecture impact

Additive: two new modules in `src/pmpe/portfolio/`, fixture data under `evals/fixtures/`. The only edits to M1-reviewed files are the three named review follow-ups. No new dependencies, no scheduler, no network.

## Tests added

Red-first (commit `5340ec0` lands failing tests + fixtures, `ae002d2` makes them pass): `tests/unit/test_portfolio_scanner.py` (24 tests — datasource loudness, per-repo planted expectations, full-output secret-value leak check, byte-identical repeat scans, no-verdict-token scan output, injected-clock degradation, pinned-deps regressions) plus 2 follow-up tests in the existing files. Run: `pytest tests/unit/test_portfolio_scanner.py -q`

## Risk level

low — additive and fully gated; the security-sensitive property (secret redaction) is planted-fixture-tested and adversarially probed in the independent review.

## Rollback plan

Revert this PR. Nothing outside the new files depends on the scanner yet.

## Evidence

- Full suite: **516 passed** (490 baseline + 26 new); `ruff check` + `ruff format --check` clean (158 files); `mypy --strict` clean (106 files); `bandit -r src -q --severity-level high` clean.
- Independent fresh-context read-only review: running (includes an adversarial privacy probe with hostile synthetic fixtures); verdict will be posted here. Merge only on APPROVE.
- CI: single attempt will be recorded per the runner-outage protocol (see PR #53 for the pattern).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbzWXg2FgTf5Awh5p81qqA)_