### PR TITLE
feat(portfolio): M3 — strategic config, risk ranking, deep-scan selection

### DIFF
--- a/evals/fixtures/portfolio_auditor/demo-portfolio/strategy.json
+++ b/evals/fixtures/portfolio_auditor/demo-portfolio/strategy.json
@@ -1,0 +1,7 @@
+{
+  "strategy_version": 1,
+  "strategic_repositories": ["acme/internal-service"],
+  "marketable_repositories": ["acme/healthy-lib"],
+  "genai_authority_repositories": [],
+  "deep_scan_quota": 2
+}

--- a/src/pmpe/portfolio/__init__.py
+++ b/src/pmpe/portfolio/__init__.py
@@ -25,6 +25,14 @@ from pmpe.portfolio.models import (
 )
 from pmpe.portfolio.policy import AuditorPolicy, load_policy
 from pmpe.portfolio.scanner import RepoScan, scan_portfolio, scan_repository
+from pmpe.portfolio.selection import (
+    RepoRisk,
+    SelectionReport,
+    Strategy,
+    load_strategy,
+    rank_risks,
+    select_for_deep_scan,
+)
 
 __all__ = [
     "AISlopVerdict",
@@ -37,12 +45,18 @@ __all__ = [
     "LiveAccessUnavailable",
     "LiveRepositorySource",
     "RecommendationVerdict",
+    "RepoRisk",
     "RepoScan",
     "RepositorySource",
+    "SelectionReport",
     "Severity",
     "SlopPolicy",
+    "Strategy",
     "load_auditor_bundle",
     "load_policy",
+    "load_strategy",
+    "rank_risks",
     "scan_portfolio",
     "scan_repository",
+    "select_for_deep_scan",
 ]

--- a/src/pmpe/portfolio/selection.py
+++ b/src/pmpe/portfolio/selection.py
@@ -1,0 +1,232 @@
+"""Strategic configuration, risk ranking, and deep-scan selection (M3).
+
+The operator supplies the strategic/marketable repository list via
+configuration, never source code (PD-PA-02); an absent configuration fails
+loudly (AC-PA-003). Risk ranking is a deterministic pure function of
+broad-scan signals — it weighs *observable risk*, it renders no verdict.
+Selection composes strategy and ranking: strategy-listed repositories are
+always deep-scanned (the quota bounds only risk-based additions), every
+selection carries a traceable reason, and the selected/not-selected
+partition is complete over the inventory.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pmpe.domain.errors import ConfigError
+from pmpe.ingestion.schema import SchemaValidator
+from pmpe.portfolio.scanner import RepoScan
+
+_SCHEMA_DIR = Path(__file__).resolve().parent.parent / "schemas"
+
+#: Deterministic risk-factor weights. Secrets dominate by design: a leaked
+#: credential is an incident, not a style problem.
+_FACTOR_WEIGHTS: dict[str, float] = {
+    "secret_hits": 40.0,
+    "claim_to_evidence_gap": 25.0,
+    "no_lockfile": 8.0,
+    "unpinned_dependencies": 8.0,
+    "no_tests": 10.0,
+    "no_ci": 8.0,
+    "no_license": 4.0,
+    "stale": 10.0,
+    "archived": 6.0,
+    "fork": 5.0,
+    "private_with_secret": 15.0,
+}
+
+_STALE_DAYS = 365
+
+
+def strategy_schema_path() -> Path:
+    return _SCHEMA_DIR / "portfolio_strategy.schema.json"
+
+
+@dataclass(frozen=True)
+class Strategy:
+    """The operator's strategic configuration (PD-PA-02)."""
+
+    strategy_version: int
+    strategic_repositories: tuple[str, ...]
+    marketable_repositories: tuple[str, ...]
+    genai_authority_repositories: tuple[str, ...]
+    deep_scan_quota: int
+
+    def always_deep_scan(self) -> tuple[str, ...]:
+        """Strategy-listed repositories, deduplicated, deterministic order."""
+        seen: dict[str, None] = {}
+        for name in (
+            *self.strategic_repositories,
+            *self.marketable_repositories,
+            *self.genai_authority_repositories,
+        ):
+            seen.setdefault(name)
+        return tuple(seen)
+
+
+def load_strategy(path: Path) -> Strategy:
+    """Load and validate the operator strategy config (fail-closed)."""
+    try:
+        data: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(
+            f"cannot load strategy configuration {path}: {exc} — the operator-"
+            "supplied strategic repository list is required (PD-PA-02)"
+        ) from exc
+    errors = SchemaValidator(strategy_schema_path()).validate(data)
+    if errors:
+        raise ConfigError("strategy configuration is invalid:\n  " + "\n  ".join(errors))
+    quota = int(data["deep_scan_quota"])
+    if quota < 1:
+        raise ConfigError(f"deep_scan_quota must be >= 1, got {quota}")
+    return Strategy(
+        strategy_version=int(data["strategy_version"]),
+        strategic_repositories=tuple(str(r) for r in data["strategic_repositories"]),
+        marketable_repositories=tuple(str(r) for r in data["marketable_repositories"]),
+        genai_authority_repositories=tuple(str(r) for r in data["genai_authority_repositories"]),
+        deep_scan_quota=quota,
+    )
+
+
+@dataclass(frozen=True)
+class RepoRisk:
+    """Deterministic risk assessment for one repository — factors, no verdict."""
+
+    repository: str
+    score: float
+    factors: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repository": self.repository,
+            "score": self.score,
+            "factors": list(self.factors),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RepoRisk:
+        return cls(
+            repository=str(d["repository"]),
+            score=float(d["score"]),
+            factors=tuple(str(f) for f in d.get("factors", [])),
+        )
+
+
+def _risk_factors(scan: RepoScan) -> list[str]:
+    factors: list[str] = []
+    if scan.security.secret_hits:
+        factors.append("secret_hits")
+        if scan.visibility.value == "PRIVATE":
+            factors.append("private_with_secret")
+    if scan.mechanical_claims and not (scan.tests_ci.has_tests or scan.tests_ci.has_ci):
+        factors.append("claim_to_evidence_gap")
+    if scan.security.dependency_manifests and not scan.security.has_lockfile:
+        factors.append("no_lockfile")
+    if scan.security.pinned_dependencies is False:
+        factors.append("unpinned_dependencies")
+    if not scan.tests_ci.has_tests:
+        factors.append("no_tests")
+    if not scan.tests_ci.has_ci:
+        factors.append("no_ci")
+    if not scan.docs.license_name:
+        factors.append("no_license")
+    days = scan.freshness.days_since_pushed
+    if days is not None and days > _STALE_DAYS:
+        factors.append("stale")
+    if scan.freshness.archived:
+        factors.append("archived")
+    if scan.freshness.is_fork:
+        factors.append("fork")
+    return factors
+
+
+def rank_risks(scans: list[RepoScan]) -> list[RepoRisk]:
+    """Deterministic risk ranking: highest score first, name-tiebroken."""
+    risks = []
+    for scan in scans:
+        factors = _risk_factors(scan)
+        score = round(sum(_FACTOR_WEIGHTS[f] for f in factors), 4)
+        risks.append(
+            RepoRisk(
+                repository=f"{scan.owner}/{scan.name}",
+                score=score,
+                factors=tuple(factors),
+            )
+        )
+    return sorted(risks, key=lambda r: (-r.score, r.repository))
+
+
+@dataclass(frozen=True)
+class SelectionEntry:
+    repository: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"repository": self.repository, "reason": self.reason}
+
+
+@dataclass(frozen=True)
+class SelectionReport:
+    """The deep-scan set plus the complete not-selected remainder."""
+
+    selected: tuple[SelectionEntry, ...]
+    not_selected: tuple[str, ...]
+    quota: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "selected": [e.to_dict() for e in self.selected],
+            "not_selected": list(self.not_selected),
+            "quota": self.quota,
+        }
+
+
+def select_for_deep_scan(
+    scans: list[RepoScan], strategy: Strategy, risks: list[RepoRisk]
+) -> SelectionReport:
+    """Compose strategy and risk ranking into the deep-scan set.
+
+    Strategy-listed repositories are always selected — the quota bounds only
+    the risk-based additions. A strategy entry naming a repository absent
+    from the inventory fails loudly rather than being silently dropped.
+    """
+    inventory = {f"{s.owner}/{s.name}" for s in scans}
+    unknown = [name for name in strategy.always_deep_scan() if name not in inventory]
+    if unknown:
+        raise ConfigError(
+            "strategy names repositories absent from the scanned inventory: "
+            + ", ".join(sorted(unknown))
+            + " — fix the strategy config or the inventory before selecting"
+        )
+
+    reasons: dict[str, str] = {}
+    for name in strategy.strategic_repositories:
+        reasons.setdefault(name, "strategic repository (operator-listed)")
+    for name in strategy.marketable_repositories:
+        reasons.setdefault(name, "marketable repository (operator-listed)")
+    for name in strategy.genai_authority_repositories:
+        reasons.setdefault(name, "GenAI authority repository (operator-listed)")
+
+    slots = strategy.deep_scan_quota
+    for risk in risks:  # already highest-risk-first, deterministic
+        if slots == 0:
+            break
+        if risk.repository in reasons:
+            continue
+        if risk.score <= 0:
+            continue
+        top = ", ".join(risk.factors[:3])
+        reasons[risk.repository] = f"risk rank (score {risk.score:g}: {top})"
+        slots -= 1
+
+    selected = tuple(
+        SelectionEntry(repository=name, reason=reasons[name]) for name in sorted(reasons)
+    )
+    not_selected = tuple(sorted(inventory - set(reasons)))
+    return SelectionReport(
+        selected=selected, not_selected=not_selected, quota=strategy.deep_scan_quota
+    )

--- a/src/pmpe/schemas/portfolio_strategy.schema.json
+++ b/src/pmpe/schemas/portfolio_strategy.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "required": [
+    "strategy_version",
+    "strategic_repositories",
+    "marketable_repositories",
+    "genai_authority_repositories",
+    "deep_scan_quota"
+  ],
+  "properties": {
+    "strategy_version": {"type": "integer"},
+    "strategic_repositories": {"type": "array", "items": {"type": "string", "minLength": 3}},
+    "marketable_repositories": {"type": "array", "items": {"type": "string", "minLength": 3}},
+    "genai_authority_repositories": {"type": "array", "items": {"type": "string", "minLength": 3}},
+    "deep_scan_quota": {"type": "integer"}
+  }
+}

--- a/tests/unit/test_portfolio_selection.py
+++ b/tests/unit/test_portfolio_selection.py
@@ -1,0 +1,182 @@
+"""Portfolio Auditor M3 — strategic config, risk ranking, deep-scan selection.
+
+RED-first. The operator supplies the strategic/marketable repository list
+via configuration, never source code (PD-PA-02); an absent configuration
+fails loudly (AC-PA-003). Risk ranking is a deterministic function of
+broad-scan signals; selection is a deterministic function of (strategy,
+ranking) with a traceable reason per selected repository. No verdict of
+any kind appears in ranking or selection output.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pmpe.portfolio.selection import (
+    RepoRisk,
+    SelectionReport,
+    load_strategy,
+    rank_risks,
+    select_for_deep_scan,
+    strategy_schema_path,
+)
+
+from pmpe.domain.errors import ConfigError
+from pmpe.portfolio.datasource import FixtureRepositorySource
+from pmpe.portfolio.scanner import scan_portfolio
+
+FIXTURES = (
+    Path(__file__).resolve().parents[2]
+    / "evals"
+    / "fixtures"
+    / "portfolio_auditor"
+    / "demo-portfolio"
+)
+NOW = "2026-07-18T00:00:00+00:00"
+
+
+def _scans():  # type: ignore[no-untyped-def]
+    return scan_portfolio(FixtureRepositorySource(FIXTURES), "acme", now=NOW)
+
+
+def _strategy_data() -> dict[str, object]:
+    return json.loads((FIXTURES / "strategy.json").read_text())
+
+
+def _write(tmp_path: Path, data: dict[str, object]) -> Path:
+    p = tmp_path / "strategy.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+class TestStrategyConfig:
+    def test_demo_strategy_loads_and_validates(self) -> None:
+        strategy = load_strategy(FIXTURES / "strategy.json")
+        assert "acme/healthy-lib" in strategy.marketable_repositories
+        assert "acme/internal-service" in strategy.strategic_repositories
+        assert strategy.deep_scan_quota >= 1
+
+    def test_absent_configuration_fails_loudly(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigError, match="strategy"):
+            load_strategy(tmp_path / "missing.json")
+
+    def test_schema_file_exists_and_rejects_missing_fields(self, tmp_path: Path) -> None:
+        assert strategy_schema_path().is_file()
+        data = _strategy_data()
+        del data["deep_scan_quota"]
+        with pytest.raises(ConfigError, match="deep_scan_quota"):
+            load_strategy(_write(tmp_path, data))
+
+    def test_nonpositive_quota_fails_closed(self, tmp_path: Path) -> None:
+        data = _strategy_data()
+        data["deep_scan_quota"] = 0
+        with pytest.raises(ConfigError, match="deep_scan_quota"):
+            load_strategy(_write(tmp_path, data))
+
+
+class TestRiskRanking:
+    def test_ranking_is_deterministic_and_complete(self) -> None:
+        risks_a = rank_risks(_scans())
+        risks_b = rank_risks(_scans())
+        assert [r.to_dict() for r in risks_a] == [r.to_dict() for r in risks_b]
+        assert {r.repository for r in risks_a} == {
+            "acme/healthy-lib",
+            "acme/slop-wrapper",
+            "acme/stale-fork",
+            "acme/internal-service",
+        }
+
+    def test_planted_secret_dominates_risk(self) -> None:
+        risks = {r.repository: r for r in rank_risks(_scans())}
+        assert risks["acme/slop-wrapper"].score > risks["acme/healthy-lib"].score
+        assert risks["acme/internal-service"].score > risks["acme/healthy-lib"].score
+        assert "secret_hits" in risks["acme/slop-wrapper"].factors
+
+    def test_claim_to_evidence_gap_raises_risk(self) -> None:
+        # slop-wrapper: heavy claims, no tests, no CI → the gap factor fires.
+        risks = {r.repository: r for r in rank_risks(_scans())}
+        assert "claim_to_evidence_gap" in risks["acme/slop-wrapper"].factors
+        assert "claim_to_evidence_gap" not in risks["acme/healthy-lib"].factors
+
+    def test_staleness_and_fork_are_factors(self) -> None:
+        risks = {r.repository: r for r in rank_risks(_scans())}
+        assert "stale" in risks["acme/stale-fork"].factors
+        assert "fork" in risks["acme/stale-fork"].factors
+
+    def test_healthy_repo_scores_lowest(self) -> None:
+        ordered = rank_risks(_scans())
+        assert ordered == sorted(ordered, key=lambda r: (-r.score, r.repository))
+        assert ordered[-1].repository == "acme/healthy-lib"
+
+    def test_risk_output_contains_no_verdict(self) -> None:
+        blob = json.dumps([r.to_dict() for r in rank_risks(_scans())])
+        for token in ("AI_SLOP", "NOT_AI_SLOP", "SHOWCASE", "REBUILD", "verdict"):
+            assert token not in blob
+
+    def test_risk_round_trips(self) -> None:
+        r = rank_risks(_scans())[0]
+        assert RepoRisk.from_dict(r.to_dict()) == r
+
+
+class TestSelection:
+    def test_strategic_and_marketable_always_selected(self) -> None:
+        report = select_for_deep_scan(
+            _scans(), load_strategy(FIXTURES / "strategy.json"), rank_risks(_scans())
+        )
+        selected = {s.repository for s in report.selected}
+        assert "acme/healthy-lib" in selected  # marketable
+        assert "acme/internal-service" in selected  # strategic
+
+    def test_reasons_are_traceable(self) -> None:
+        report = select_for_deep_scan(
+            _scans(), load_strategy(FIXTURES / "strategy.json"), rank_risks(_scans())
+        )
+        for entry in report.selected:
+            assert entry.reason, f"{entry.repository} selected without a reason"
+
+    def test_quota_bounds_risk_based_selection(self, tmp_path: Path) -> None:
+        data = _strategy_data()
+        data["strategic_repositories"] = []
+        data["marketable_repositories"] = []
+        data["genai_authority_repositories"] = []
+        data["deep_scan_quota"] = 1
+        strategy = load_strategy(_write(tmp_path, data))
+        report = select_for_deep_scan(_scans(), strategy, rank_risks(_scans()))
+        assert len(report.selected) == 1
+        # highest-risk repo wins the single slot
+        assert report.selected[0].repository == rank_risks(_scans())[0].repository
+
+    def test_strategic_selection_exceeds_quota_when_needed(self, tmp_path: Path) -> None:
+        # Strategy lists always deep-scan even when the quota is tiny; the
+        # quota bounds only the risk-based additions.
+        data = _strategy_data()
+        data["deep_scan_quota"] = 1
+        strategy = load_strategy(_write(tmp_path, data))
+        report = select_for_deep_scan(_scans(), strategy, rank_risks(_scans()))
+        selected = {s.repository for s in report.selected}
+        assert {"acme/healthy-lib", "acme/internal-service"} <= selected
+
+    def test_unknown_strategy_repo_fails_loudly(self, tmp_path: Path) -> None:
+        data = _strategy_data()
+        strategic = data["strategic_repositories"]
+        assert isinstance(strategic, list)
+        strategic.append("acme/does-not-exist")
+        strategy = load_strategy(_write(tmp_path, data))
+        with pytest.raises(ConfigError, match="does-not-exist"):
+            select_for_deep_scan(_scans(), strategy, rank_risks(_scans()))
+
+    def test_selection_is_deterministic(self) -> None:
+        strategy = load_strategy(FIXTURES / "strategy.json")
+        a = select_for_deep_scan(_scans(), strategy, rank_risks(_scans()))
+        b = select_for_deep_scan(_scans(), strategy, rank_risks(_scans()))
+        assert json.dumps(a.to_dict()) == json.dumps(b.to_dict())
+
+    def test_not_selected_repos_are_recorded(self) -> None:
+        report = select_for_deep_scan(
+            _scans(), load_strategy(FIXTURES / "strategy.json"), rank_risks(_scans())
+        )
+        assert isinstance(report, SelectionReport)
+        all_repos = {s.repository for s in report.selected} | set(report.not_selected)
+        assert all_repos == {r.repository for r in rank_risks(_scans())}

--- a/tests/unit/test_portfolio_selection.py
+++ b/tests/unit/test_portfolio_selection.py
@@ -14,6 +14,10 @@ import json
 from pathlib import Path
 
 import pytest
+
+from pmpe.domain.errors import ConfigError
+from pmpe.portfolio.datasource import FixtureRepositorySource
+from pmpe.portfolio.scanner import scan_portfolio
 from pmpe.portfolio.selection import (
     RepoRisk,
     SelectionReport,
@@ -22,10 +26,6 @@ from pmpe.portfolio.selection import (
     select_for_deep_scan,
     strategy_schema_path,
 )
-
-from pmpe.domain.errors import ConfigError
-from pmpe.portfolio.datasource import FixtureRepositorySource
-from pmpe.portfolio.scanner import scan_portfolio
 
 FIXTURES = (
     Path(__file__).resolve().parents[2]


### PR DESCRIPTION
# Pull request

## What changed and why

Milestone 3 of the GitHub Portfolio Auditor V1: the operator strategy configuration, deterministic risk ranking over broad-scan signals, and deep-scan selection. One concern: deciding *which* repositories get deep inspection — still no judgment of any repository (no verdict token appears in ranking or selection output, test-enforced).

- **Strategy** (`load_strategy`): the strategic/marketable/GenAI-authority lists come from an operator-supplied config file, never source code (PD-PA-02); an absent or invalid config fails loudly (AC-PA-003); `deep_scan_quota` must be ≥ 1. Demo strategy fixture added to the fixture portfolio.
- **Risk ranking** (`rank_risks`): pure function of M2 scan signals with named factors and fixed weights — secret hits dominate by design (an exposed credential is an incident), private-with-secret compounds, claim-to-evidence gap fires when marketing claims exist without tests or CI, plus staleness/fork/archived/license/pinning factors. Highest score first, name-tiebroken.
- **Selection** (`select_for_deep_scan`): strategy-listed repositories are always deep-scanned — the quota bounds only risk-based additions; every selection carries a traceable reason; a strategy entry naming a repository absent from the inventory fails loudly instead of being silently dropped; the selected/not-selected partition is complete over the inventory.

## Requirement reference

`products/portfolio-auditor/contract.json` FR-PA-003 (AC-PA-003); PD-PA-02; prioritization policy order in `products/portfolio-auditor/policy.json`.

## Architecture impact

Additive: one new module (`selection.py`), one new schema, one fixture file; `__init__.py` gains exports only. No edits to M2-reviewed scanner/datasource code.

## Tests added

Red-first (`99c55aa` failing tests + demo strategy fixture → `34f30fd` implementation): `tests/unit/test_portfolio_selection.py` — 18 tests covering fail-loud config, schema rejection, quota bounds, factor expectations per planted fixture repo, determinism, traceable reasons, unknown-repo loud failure, complete partition. Run: `pytest tests/unit/test_portfolio_selection.py -q`

## Risk level

low — additive and fully gated; risk weights are fixed code constants (a deliberate design decision: ranking policy changes must be code-reviewed, not config-drifted).

## Rollback plan

Revert this PR. Nothing outside the new files depends on selection yet.

## Evidence

- Full suite: **540 passed** (522 + 18 new); ruff + format clean; mypy --strict clean (107 files); bandit high clean.
- Independent fresh-context review: running; verdict posted here before merge. Merge only on APPROVE.
- CI: single attempt per the runner-outage protocol; result recorded here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbzWXg2FgTf5Awh5p81qqA)_