### PR TITLE
feat(portfolio): M4 — deep inspection with honest grading + selection hardening

### DIFF
--- a/src/pmpe/portfolio/__init__.py
+++ b/src/pmpe/portfolio/__init__.py
@@ -14,6 +14,12 @@ from pmpe.portfolio.datasource import (
     LiveRepositorySource,
     RepositorySource,
 )
+from pmpe.portfolio.inspection import (
+    ClaimGrade,
+    DeepInspection,
+    inspect_repository,
+    inspect_selected,
+)
 from pmpe.portfolio.models import (
     AISlopVerdict,
     BusinessAccuracyVerdict,
@@ -39,6 +45,8 @@ __all__ = [
     "AuditorBundle",
     "AuditorPolicy",
     "BusinessAccuracyVerdict",
+    "ClaimGrade",
+    "DeepInspection",
     "EvidenceRef",
     "Finding",
     "FixtureRepositorySource",
@@ -54,6 +62,8 @@ __all__ = [
     "Strategy",
     "load_auditor_bundle",
     "load_policy",
+    "inspect_repository",
+    "inspect_selected",
     "load_strategy",
     "rank_risks",
     "scan_portfolio",

--- a/src/pmpe/portfolio/inspection.py
+++ b/src/pmpe/portfolio/inspection.py
@@ -1,0 +1,489 @@
+"""Deep repository inspection (M4): findings, claim grades, dimension scores.
+
+Everything here is a deterministic pure function of the repository snapshot
+and the digest-bound policy — mechanical proxies over observable signals,
+no model output, no network. Three locked rules:
+
+- Honesty of grades (PD-PA-03, AC-PA-004): V1 judges business claims from
+  repository evidence only. The mechanical grader therefore never emits
+  PROVEN (that demands evidence kinds like deployment proof or evaluation
+  reports) and never emits CONTRADICTED (absence is not falsehood); an
+  unsupported claim grades NOT_PROVEN or INSUFFICIENT_EVIDENCE, and a
+  LIKELY grade must carry the policy corroboration floor of independent
+  evidence origins.
+- Findings carry all seven contract-required fields, validate against the
+  finding schema, and never contain a secret value (evidence binds file
+  content by sha256 digest, never by excerpt).
+- Integrity: the inspection binds the snapshot content digest and re-reads
+  the source at the end — a snapshot that mutates mid-inspection fails
+  the run loudly rather than producing evidence about unknown content.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+from pmpe.contracts.digest import canonical_digest
+from pmpe.domain.errors import PmpeError
+from pmpe.portfolio.datasource import RepositorySource
+from pmpe.portfolio.models import (
+    BusinessAccuracyVerdict,
+    EvidenceRef,
+    Finding,
+    Severity,
+    must_surface,
+)
+from pmpe.portfolio.policy import AuditorPolicy
+from pmpe.portfolio.scanner import MechanicalClaim, RepoScan
+
+INSPECTOR_VERSION = "pa-inspector-1"
+
+#: Claim categories that V1 mechanical inspection cannot evaluate at all
+#: from repository content (external adoption, benchmarks, scale claims).
+_UNEVALUABLE_CATEGORIES = frozenset({"metric", "scale", "adoption"})
+
+
+def _sha(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _snapshot_digest(meta: dict[str, Any], tree: list[str], files: dict[str, str]) -> str:
+    return canonical_digest({"metadata": meta, "tree": sorted(tree), "files": files})
+
+
+@dataclass(frozen=True)
+class ClaimGrade:
+    """One graded business claim with its reasoning and supporting evidence."""
+
+    claim: MechanicalClaim
+    verdict: BusinessAccuracyVerdict
+    reasoning: str
+    supporting_evidence: tuple[EvidenceRef, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "claim": self.claim.to_dict(),
+            "verdict": self.verdict.value,
+            "reasoning": self.reasoning,
+            "supporting_evidence": [e.to_dict() for e in self.supporting_evidence],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ClaimGrade:
+        return cls(
+            claim=MechanicalClaim.from_dict(d["claim"]),
+            verdict=BusinessAccuracyVerdict(d["verdict"]),
+            reasoning=str(d["reasoning"]),
+            supporting_evidence=tuple(
+                EvidenceRef.from_dict(e) for e in d.get("supporting_evidence", [])
+            ),
+        )
+
+
+@dataclass
+class DeepInspection:
+    """The complete deep-inspection result for one repository."""
+
+    repository: str
+    snapshot_digest: str
+    findings: list[Finding]
+    claim_grades: list[ClaimGrade]
+    dimension_scores: dict[str, int]
+    must_surface_finding_ids: tuple[str, ...]
+    inspector_version: str = INSPECTOR_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repository": self.repository,
+            "snapshot_digest": self.snapshot_digest,
+            "findings": [f.to_dict() for f in self.findings],
+            "claim_grades": [g.to_dict() for g in self.claim_grades],
+            "dimension_scores": dict(sorted(self.dimension_scores.items())),
+            "must_surface_finding_ids": list(self.must_surface_finding_ids),
+            "inspector_version": self.inspector_version,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DeepInspection:
+        return cls(
+            repository=str(d["repository"]),
+            snapshot_digest=str(d["snapshot_digest"]),
+            findings=[Finding.from_dict(f) for f in d.get("findings", [])],
+            claim_grades=[ClaimGrade.from_dict(g) for g in d.get("claim_grades", [])],
+            dimension_scores={str(k): int(v) for k, v in d["dimension_scores"].items()},
+            must_surface_finding_ids=tuple(str(x) for x in d.get("must_surface_finding_ids", [])),
+            inspector_version=str(d.get("inspector_version", INSPECTOR_VERSION)),
+        )
+
+
+# --- findings ---------------------------------------------------------------
+
+
+def _secret_findings(repo: str, scan: RepoScan, files: dict[str, str]) -> list[Finding]:
+    by_path: dict[str, list[int]] = {}
+    for hit in scan.security.secret_hits:
+        by_path.setdefault(hit.path, []).append(hit.line)
+    findings = []
+    for idx, (path, lines) in enumerate(sorted(by_path.items()), start=1):
+        evidence = [
+            EvidenceRef(
+                evidence_id=f"EV-secret-{idx}-file",
+                kind="repo_file_line",
+                origin="source_code",
+                reference=f"{path}#L{','.join(str(ln) for ln in sorted(lines))}",
+                content_digest=_sha(files.get(path, "")),
+            ),
+            EvidenceRef(
+                evidence_id=f"EV-secret-{idx}-scan",
+                kind="executed_command",
+                origin="secret_scanner",
+                reference=f"scanner:{scan.scanner_version}:detect_secrets:{path}",
+                content_digest=_sha(
+                    ";".join(
+                        f"{h.rule}@{h.line}" for h in scan.security.secret_hits if h.path == path
+                    )
+                ),
+            ),
+        ]
+        findings.append(
+            Finding(
+                finding_id=f"PA-{scan.name}-SEC-{idx:03d}",
+                repository=repo,
+                dimension="security_dependency_integrity",
+                summary=f"secret-shaped credential committed in {path}",
+                evidence=evidence,
+                confidence=95,
+                severity=Severity.BLOCKING,
+                affected_capability="security_dependency_integrity",
+                reasoning=(
+                    f"{len(lines)} secret-shaped value(s) detected in {path} "
+                    "(values redacted; rule/path/line recorded). A committed "
+                    "credential is an incident regardless of validity: it must "
+                    "be rotated and purged from history."
+                ),
+                remediation_recommendation=(
+                    f"Rotate the credential(s), remove them from {path}, purge "
+                    "the value from git history, and load secrets from the "
+                    "environment or a secret manager."
+                ),
+            )
+        )
+    return findings
+
+
+def _claim_gap_finding(repo: str, scan: RepoScan) -> list[Finding]:
+    if not scan.mechanical_claims or scan.tests_ci.has_tests or scan.tests_ci.has_ci:
+        return []
+    claims = scan.mechanical_claims
+    evidence = [
+        EvidenceRef(
+            evidence_id="EV-claimgap-readme",
+            kind="repo_file_line",
+            origin="readme",
+            reference=";".join(c.location for c in claims[:5]),
+            content_digest=_sha("|".join(c.text for c in claims)),
+        ),
+        EvidenceRef(
+            evidence_id="EV-claimgap-signals",
+            kind="executed_command",
+            origin="scan_signals",
+            reference=f"scanner:{scan.scanner_version}:tests_ci_signals",
+            content_digest=_sha(str(scan.tests_ci.to_dict())),
+        ),
+    ]
+    return [
+        Finding(
+            finding_id=f"PA-{scan.name}-GAP-001",
+            repository=repo,
+            dimension="claim_to_evidence_integrity",
+            summary=f"{len(claims)} marketing claim(s) with no tests or CI behind them",
+            evidence=evidence,
+            confidence=90,
+            severity=Severity.HIGH,
+            affected_capability="claim_to_evidence_integrity",
+            reasoning=(
+                "The README makes strong claims while the repository contains "
+                "no test files and no CI workflow — nothing in the repository "
+                "substantiates the claims."
+            ),
+            remediation_recommendation=(
+                "Either add executable evidence (tests, CI, benchmarks) for "
+                "each claim or rewrite the README to state only what the "
+                "repository demonstrates."
+            ),
+        )
+    ]
+
+
+def _dependency_finding(repo: str, scan: RepoScan) -> list[Finding]:
+    if not scan.security.dependency_manifests or scan.security.has_lockfile:
+        return []
+    evidence = [
+        EvidenceRef(
+            evidence_id="EV-deps-manifests",
+            kind="repo_file_line",
+            origin="source_code",
+            reference=";".join(scan.security.dependency_manifests),
+            content_digest=_sha(",".join(scan.security.dependency_manifests)),
+        ),
+        EvidenceRef(
+            evidence_id="EV-deps-signals",
+            kind="executed_command",
+            origin="scan_signals",
+            reference=f"scanner:{scan.scanner_version}:security_signals",
+            content_digest=_sha(str(scan.security.to_dict())),
+        ),
+    ]
+    return [
+        Finding(
+            finding_id=f"PA-{scan.name}-DEP-001",
+            repository=repo,
+            dimension="security_dependency_integrity",
+            summary="dependency manifests without any lockfile",
+            evidence=evidence,
+            confidence=85,
+            severity=Severity.MEDIUM,
+            affected_capability="security_dependency_integrity",
+            reasoning=(
+                "Dependencies are declared but not locked, so builds are not "
+                "reproducible and dependency drift is invisible."
+            ),
+            remediation_recommendation="Commit a lockfile for the declared manifests.",
+        )
+    ]
+
+
+# --- claim grading ----------------------------------------------------------
+
+
+def _support_evidence(scan: RepoScan, files: dict[str, str]) -> list[EvidenceRef]:
+    """Independent-origin evidence that operational claims can lean on."""
+    evidence: list[EvidenceRef] = []
+    tests = [p for p in files if p.startswith(("tests/", "test/"))]
+    if scan.tests_ci.has_tests:
+        evidence.append(
+            EvidenceRef(
+                evidence_id="EV-support-tests",
+                kind="test",
+                origin="test_layout",
+                reference=";".join(tests[:5]) or "tests/",
+                content_digest=_sha(str(scan.tests_ci.test_file_count)),
+            )
+        )
+    if scan.tests_ci.has_ci:
+        evidence.append(
+            EvidenceRef(
+                evidence_id="EV-support-ci",
+                kind="ci_workflow",
+                origin="ci_config",
+                reference=";".join(scan.tests_ci.ci_files),
+                content_digest=_sha(",".join(scan.tests_ci.ci_files)),
+            )
+        )
+    if scan.security.has_lockfile:
+        evidence.append(
+            EvidenceRef(
+                evidence_id="EV-support-lockfile",
+                kind="repo_file_line",
+                origin="dependency_lockfile",
+                reference=";".join(scan.security.lockfile_kinds),
+                content_digest=_sha(",".join(scan.security.lockfile_kinds)),
+            )
+        )
+    return evidence
+
+
+def _grade_claims(scan: RepoScan, files: dict[str, str], policy: AuditorPolicy) -> list[ClaimGrade]:
+    support = _support_evidence(scan, files)
+    support_origins = {e.origin for e in support}
+    grades: list[ClaimGrade] = []
+    for claim in scan.mechanical_claims:
+        if claim.category in _UNEVALUABLE_CATEGORIES:
+            grades.append(
+                ClaimGrade(
+                    claim=claim,
+                    verdict=BusinessAccuracyVerdict.INSUFFICIENT_EVIDENCE,
+                    reasoning=(
+                        f"a {claim.category} claim cannot be evaluated from "
+                        "repository evidence alone (PD-PA-03); no external "
+                        "measurement exists in V1, and absence of proof is "
+                        "not falsehood"
+                    ),
+                )
+            )
+            continue
+        if len(support_origins) >= policy.evidence.min_origins_normal:
+            grades.append(
+                ClaimGrade(
+                    claim=claim,
+                    verdict=BusinessAccuracyVerdict.LIKELY,
+                    reasoning=(
+                        "operational discipline is observable from "
+                        f"{len(support_origins)} independent origins "
+                        f"({', '.join(sorted(support_origins))}); LIKELY is the "
+                        "ceiling for repository evidence — PROVEN would demand "
+                        "deployment or evaluation artifacts"
+                    ),
+                    supporting_evidence=tuple(support),
+                )
+            )
+        else:
+            grades.append(
+                ClaimGrade(
+                    claim=claim,
+                    verdict=BusinessAccuracyVerdict.NOT_PROVEN,
+                    reasoning=(
+                        "the repository offers fewer than "
+                        f"{policy.evidence.min_origins_normal} independent "
+                        "evidence origins for this claim (found: "
+                        f"{', '.join(sorted(support_origins)) or 'none'})"
+                    ),
+                )
+            )
+    return grades
+
+
+# --- dimension scores -------------------------------------------------------
+
+
+def _clamp(value: float) -> int:
+    return max(0, min(100, int(round(value))))
+
+
+def _dimension_scores(
+    scan: RepoScan, grades: list[ClaimGrade], policy: AuditorPolicy
+) -> dict[str, int]:
+    s = scan
+    has_secrets = bool(s.security.secret_hits)
+    tests_ci = _clamp(20 + 40 * s.tests_ci.has_tests + 40 * s.tests_ci.has_ci)
+    security = 100.0
+    if has_secrets:
+        security = 10.0
+    else:
+        if s.security.dependency_manifests and not s.security.has_lockfile:
+            security -= 25
+        if s.security.pinned_dependencies is False:
+            security -= 15
+        if not s.security.has_security_md:
+            security -= 10
+    cleanliness = _clamp(
+        25 * bool(s.docs.license_name)
+        + 20 * s.docs.has_contributing
+        + 15 * s.docs.has_changelog
+        + 25 * s.readme.has_readme
+        + 15 * (s.docs.doc_file_count >= 3)
+    )
+    usability = _clamp(
+        25 * s.readme.has_install_section
+        + 25 * s.readme.has_usage_section
+        + 10 * (s.readme.code_fence_count >= 1)
+        + 25 * (s.packaging.has_pyproject_or_setup or s.packaging.has_package_json)
+        + 15 * bool(s.packaging.entrypoints)
+    )
+    architecture = _clamp(
+        20 * s.docs.has_docs_dir
+        + 20 * (s.readme.heading_count >= 3)
+        + 20 * (s.packaging.has_pyproject_or_setup or s.packaging.has_package_json)
+        + 20 * (len(s.languages) > 0)
+        + 20 * (not s.freshness.archived)
+    )
+    reuse = _clamp(
+        30 * (s.packaging.has_pyproject_or_setup or s.packaging.has_package_json)
+        + 20 * bool(s.packaging.install_commands)
+        + 20 * bool(s.packaging.entrypoints)
+        + 10 * s.packaging.has_dockerfile
+        + 20 * bool(s.docs.license_name)
+    )
+    technical = _clamp(
+        30
+        + 20 * s.tests_ci.has_tests
+        + 15 * s.tests_ci.has_ci
+        + 10 * s.security.has_lockfile
+        + 10 * (s.security.pinned_dependencies is True)
+        + 15 * ((s.freshness.days_since_pushed or 0) <= 180)
+        - 40 * has_secrets
+    )
+    if grades:
+        likely = sum(1 for g in grades if g.verdict is BusinessAccuracyVerdict.LIKELY)
+        business = _clamp(100 * likely / len(grades))
+        integrity = _clamp(100 - 15 * (len(grades) - likely))
+    else:
+        business = 100
+        integrity = 100
+    authority = _clamp((tests_ci + security + cleanliness + usability) / 4)
+    return {
+        "technical_health": technical,
+        "architecture_quality": architecture,
+        "tests_ci_evaluations": tests_ci,
+        "security_dependency_integrity": _clamp(security),
+        "reusability_deployability": reuse,
+        "repository_cleanliness": cleanliness,
+        "product_usability_packaging": usability,
+        "business_product_accuracy": business,
+        "claim_to_evidence_integrity": integrity,
+        "authority_readiness": authority,
+    }
+
+
+# --- top level --------------------------------------------------------------
+
+
+def inspect_repository(
+    source: RepositorySource, scan: RepoScan, *, policy: AuditorPolicy
+) -> DeepInspection:
+    """Deep-inspect one repository from its snapshot (read-only, deterministic)."""
+    owner, name = scan.owner, scan.name
+    repo = f"{owner}/{name}"
+    meta = source.metadata(owner, name)
+    tree = source.tree(owner, name)
+    files = source.files(owner, name)
+    digest_before = _snapshot_digest(meta, tree, files)
+
+    findings = (
+        _secret_findings(repo, scan, files)
+        + _claim_gap_finding(repo, scan)
+        + _dependency_finding(repo, scan)
+    )
+    grades = _grade_claims(scan, files, policy)
+    scores = _dimension_scores(scan, grades, policy)
+    surfaced = tuple(
+        f.finding_id
+        for f in findings
+        if must_surface(f, high_confidence_floor=policy.scoring.high_confidence_floor)
+    )
+
+    digest_after = _snapshot_digest(
+        source.metadata(owner, name), source.tree(owner, name), source.files(owner, name)
+    )
+    if digest_after != digest_before:
+        raise PmpeError(
+            f"snapshot for {repo} mutated during inspection "
+            f"({digest_before} -> {digest_after}) — results discarded; evidence "
+            "must bind exactly one snapshot state"
+        )
+
+    return DeepInspection(
+        repository=repo,
+        snapshot_digest=digest_before,
+        findings=findings,
+        claim_grades=grades,
+        dimension_scores=scores,
+        must_surface_finding_ids=surfaced,
+    )
+
+
+def inspect_selected(
+    source: RepositorySource,
+    scans: list[RepoScan],
+    selected: list[str],
+    *,
+    policy: AuditorPolicy,
+) -> list[DeepInspection]:
+    """Deep-inspect exactly the selected repositories, in selection order."""
+    by_name = {f"{s.owner}/{s.name}": s for s in scans}
+    missing = [name for name in selected if name not in by_name]
+    if missing:
+        raise PmpeError("selection names repositories with no broad scan: " + ", ".join(missing))
+    return [inspect_repository(source, by_name[name], policy=policy) for name in selected]

--- a/src/pmpe/portfolio/selection.py
+++ b/src/pmpe/portfolio/selection.py
@@ -202,6 +202,15 @@ def select_for_deep_scan(
             + ", ".join(sorted(unknown))
             + " — fix the strategy config or the inventory before selecting"
         )
+    # The risks argument is untrusted caller input (M3 review): re-sort so a
+    # permuted list cannot redirect quota slots, and refuse risks naming
+    # repositories outside the inventory.
+    phantom = sorted({r.repository for r in risks} - inventory)
+    if phantom:
+        raise ConfigError(
+            "risk ranking names repositories outside the scanned inventory: " + ", ".join(phantom)
+        )
+    risks = sorted(risks, key=lambda r: (-r.score, r.repository))
 
     reasons: dict[str, str] = {}
     for name in strategy.strategic_repositories:

--- a/tests/unit/test_portfolio_inspection.py
+++ b/tests/unit/test_portfolio_inspection.py
@@ -1,0 +1,238 @@
+"""Portfolio Auditor M4 — deep inspection (RED-first).
+
+Deep inspection turns broad-scan signals plus repository snapshots into:
+findings (all seven contract-required fields, schema-valid, redacted),
+mechanically-honest business-claim grades, and 0-100 dimension scores.
+Locked rules: unsupported claims never grade above NOT_PROVEN and the
+mechanical grader can never emit PROVEN or CONTRADICTED (those demand
+evidence kinds V1 mechanical inspection cannot observe — PD-PA-03,
+absence != falsehood); a LIKELY grade needs the policy corroboration
+floor of independent origins (AC-PA-004); a numeric dimension score never
+buries a material high-confidence finding; inspection binds the snapshot
+content digest and fails loudly if the source mutates mid-run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pmpe.portfolio.inspection import (
+    DeepInspection,
+    inspect_repository,
+    inspect_selected,
+)
+
+from pmpe.domain.errors import PmpeError
+from pmpe.portfolio.datasource import FixtureRepositorySource
+from pmpe.portfolio.models import BusinessAccuracyVerdict, Severity, must_surface
+from pmpe.portfolio.policy import load_policy, validate_finding_dict
+from pmpe.portfolio.scanner import scan_repository
+
+FIXTURES = (
+    Path(__file__).resolve().parents[2]
+    / "evals"
+    / "fixtures"
+    / "portfolio_auditor"
+    / "demo-portfolio"
+)
+NOW = "2026-07-18T00:00:00+00:00"
+
+
+def _source() -> FixtureRepositorySource:
+    return FixtureRepositorySource(FIXTURES)
+
+
+def _inspect(name: str) -> DeepInspection:
+    source = _source()
+    scan = scan_repository(source, "acme", name, now=NOW)
+    return inspect_repository(source, scan, policy=load_policy())
+
+
+class TestFindings:
+    def test_planted_secret_yields_blocking_schema_valid_finding(self) -> None:
+        insp = _inspect("slop-wrapper")
+        secret_findings = [
+            f for f in insp.findings if f.dimension == "security_dependency_integrity"
+        ]
+        assert secret_findings, "planted secret must produce a finding"
+        blocking = [f for f in secret_findings if f.severity is Severity.BLOCKING]
+        assert blocking
+        for f in insp.findings:
+            assert validate_finding_dict(f.to_dict()) == [], f.finding_id
+
+    def test_finding_output_never_contains_secret_values(self) -> None:
+        for name in ("slop-wrapper", "internal-service"):
+            blob = json.dumps(_inspect(name).to_dict())
+            assert "EXAMPLE_placeholder" not in blob
+            assert "FAKE_placeholder" not in blob
+
+    def test_healthy_repo_has_no_blocking_findings(self) -> None:
+        insp = _inspect("healthy-lib")
+        assert [f for f in insp.findings if f.severity is Severity.BLOCKING] == []
+
+    def test_claim_gap_produces_finding_with_evidence(self) -> None:
+        insp = _inspect("slop-wrapper")
+        gap = [f for f in insp.findings if f.dimension == "claim_to_evidence_integrity"]
+        assert gap
+        for f in gap:
+            assert f.evidence and f.reasoning and f.remediation_recommendation
+
+
+class TestClaimGrading:
+    def test_unsupported_claims_never_grade_above_not_proven(self) -> None:
+        insp = _inspect("slop-wrapper")
+        assert insp.claim_grades, "planted claims must be graded"
+        for grade in insp.claim_grades:
+            assert grade.verdict in (
+                BusinessAccuracyVerdict.NOT_PROVEN,
+                BusinessAccuracyVerdict.INSUFFICIENT_EVIDENCE,
+            ), f"{grade.claim.text!r} graded {grade.verdict}"
+
+    def test_mechanical_grader_never_emits_proven_or_contradicted(self) -> None:
+        for name in ("healthy-lib", "slop-wrapper", "stale-fork", "internal-service"):
+            for grade in _inspect(name).claim_grades:
+                assert grade.verdict is not BusinessAccuracyVerdict.PROVEN
+                assert grade.verdict is not BusinessAccuracyVerdict.CONTRADICTED
+
+    def test_supported_production_claim_grades_likely_with_corroboration(self) -> None:
+        # healthy-lib has tests-in-CI, lockfile, docs; graft a production
+        # claim onto its README via a wrapper source.
+        source = _source()
+        files = dict(source.files("acme", "healthy-lib"))
+        files["README.md"] = files["README.md"] + "\nThis library is production-ready.\n"
+        wrapped = _FilesOverrideSource(source, files)
+        scan = scan_repository(wrapped, "acme", "healthy-lib", now=NOW)
+        insp = inspect_repository(wrapped, scan, policy=load_policy())
+        prod = [g for g in insp.claim_grades if g.claim.category == "production_readiness"]
+        assert prod
+        policy = load_policy()
+        for g in prod:
+            assert g.verdict is BusinessAccuracyVerdict.LIKELY
+            origins = {e.origin for e in g.supporting_evidence}
+            assert len(origins) >= policy.evidence.min_origins_normal
+
+    def test_every_grade_carries_reasoning(self) -> None:
+        for grade in _inspect("slop-wrapper").claim_grades:
+            assert grade.reasoning
+
+
+class TestDimensionScores:
+    def test_scores_cover_all_dimensions_in_range(self) -> None:
+        policy = load_policy()
+        insp = _inspect("healthy-lib")
+        assert set(insp.dimension_scores) == set(policy.assessment_dimensions)
+        for value in insp.dimension_scores.values():
+            assert 0 <= value <= 100
+
+    def test_secrets_floor_the_security_score(self) -> None:
+        assert (
+            _inspect("slop-wrapper").dimension_scores["security_dependency_integrity"]
+            < _inspect("healthy-lib").dimension_scores["security_dependency_integrity"]
+        )
+
+    def test_healthy_beats_slop_on_tests_dimension(self) -> None:
+        assert (
+            _inspect("healthy-lib").dimension_scores["tests_ci_evaluations"]
+            > _inspect("slop-wrapper").dimension_scores["tests_ci_evaluations"]
+        )
+
+    def test_material_findings_are_surfaced_regardless_of_scores(self) -> None:
+        policy = load_policy()
+        insp = _inspect("slop-wrapper")
+        expected = [
+            f.finding_id
+            for f in insp.findings
+            if must_surface(f, high_confidence_floor=policy.scoring.high_confidence_floor)
+        ]
+        assert expected, "the planted secret finding must be material"
+        assert insp.must_surface_finding_ids == tuple(expected)
+
+
+class TestIntegrityAndDeterminism:
+    def test_repeated_inspection_is_byte_identical(self) -> None:
+        a = json.dumps(_inspect("slop-wrapper").to_dict())
+        b = json.dumps(_inspect("slop-wrapper").to_dict())
+        assert a == b
+
+    def test_snapshot_digest_binds_content(self) -> None:
+        insp = _inspect("healthy-lib")
+        assert insp.snapshot_digest.startswith("sha256:")
+        source = _source()
+        files = dict(source.files("acme", "healthy-lib"))
+        files["README.md"] = files["README.md"] + "\nchanged\n"
+        wrapped = _FilesOverrideSource(source, files)
+        scan = scan_repository(wrapped, "acme", "healthy-lib", now=NOW)
+        changed = inspect_repository(wrapped, scan, policy=load_policy())
+        assert changed.snapshot_digest != insp.snapshot_digest
+
+    def test_mutating_source_fails_loudly(self) -> None:
+        source = _MutatingSource(_source())
+        scan = scan_repository(source, "acme", "healthy-lib", now=NOW)
+        with pytest.raises(PmpeError, match="mutated"):
+            inspect_repository(source, scan, policy=load_policy())
+
+    def test_inspect_selected_covers_exactly_the_selection(self) -> None:
+        source = _source()
+        scans = [
+            scan_repository(source, "acme", n, now=NOW) for n in ("healthy-lib", "slop-wrapper")
+        ]
+        results = inspect_selected(
+            source, scans, ["acme/healthy-lib", "acme/slop-wrapper"], policy=load_policy()
+        )
+        assert [r.repository for r in results] == ["acme/healthy-lib", "acme/slop-wrapper"]
+
+    def test_inspect_selected_unknown_repo_fails_loudly(self) -> None:
+        source = _source()
+        scans = [scan_repository(source, "acme", "healthy-lib", now=NOW)]
+        with pytest.raises(PmpeError, match="phantom"):
+            inspect_selected(source, scans, ["acme/phantom"], policy=load_policy())
+
+    def test_inspection_round_trips(self) -> None:
+        insp = _inspect("slop-wrapper")
+        assert DeepInspection.from_dict(insp.to_dict()).to_dict() == insp.to_dict()
+
+
+class _FilesOverrideSource:
+    """Wraps the fixture source with replacement files for one repo."""
+
+    def __init__(self, inner: FixtureRepositorySource, files: dict[str, str]) -> None:
+        self._inner = inner
+        self._files = files
+
+    def discover(self, owner: str) -> list[str]:
+        return self._inner.discover(owner)
+
+    def metadata(self, owner: str, name: str) -> dict[str, object]:
+        return self._inner.metadata(owner, name)
+
+    def tree(self, owner: str, name: str) -> list[str]:
+        return sorted(set(self._inner.tree(owner, name)) | set(self._files))
+
+    def files(self, owner: str, name: str) -> dict[str, str]:
+        return dict(self._files)
+
+
+class _MutatingSource:
+    """Hostile source whose file content changes between reads."""
+
+    def __init__(self, inner: FixtureRepositorySource) -> None:
+        self._inner = inner
+        self._reads = 0
+
+    def discover(self, owner: str) -> list[str]:
+        return self._inner.discover(owner)
+
+    def metadata(self, owner: str, name: str) -> dict[str, object]:
+        return self._inner.metadata(owner, name)
+
+    def tree(self, owner: str, name: str) -> list[str]:
+        return self._inner.tree(owner, name)
+
+    def files(self, owner: str, name: str) -> dict[str, str]:
+        self._reads += 1
+        files = dict(self._inner.files(owner, name))
+        if self._reads > 1:
+            files["README.md"] = files.get("README.md", "") + f"\ntamper {self._reads}\n"
+        return files

--- a/tests/unit/test_portfolio_selection.py
+++ b/tests/unit/test_portfolio_selection.py
@@ -180,3 +180,28 @@ class TestSelection:
         assert isinstance(report, SelectionReport)
         all_repos = {s.repository for s in report.selected} | set(report.not_selected)
         assert all_repos == {r.repository for r in rank_risks(_scans())}
+
+
+class TestSelectionInputHardening:
+    """M3 review follow-up: selection must not trust its risks argument."""
+
+    def test_selection_resorts_unordered_risks(self, tmp_path: Path) -> None:
+        # Quota 1 with an empty strategy: the single slot must go to the
+        # HIGHEST-risk repo even when the caller passes risks in reverse.
+        data = _strategy_data()
+        data["strategic_repositories"] = []
+        data["marketable_repositories"] = []
+        data["genai_authority_repositories"] = []
+        data["deep_scan_quota"] = 1
+        strategy = load_strategy(_write(tmp_path, data))
+        risks = rank_risks(_scans())
+        a = select_for_deep_scan(_scans(), strategy, risks)
+        b = select_for_deep_scan(_scans(), strategy, list(reversed(risks)))
+        assert json.dumps(a.to_dict()) == json.dumps(b.to_dict())
+        assert a.selected[0].repository == risks[0].repository
+
+    def test_selection_rejects_risks_outside_inventory(self) -> None:
+        strategy = load_strategy(FIXTURES / "strategy.json")
+        phantom = RepoRisk(repository="acme/phantom", score=999.0, factors=("no_tests",))
+        with pytest.raises(ConfigError, match="phantom"):
+            select_for_deep_scan(_scans(), strategy, [*rank_risks(_scans()), phantom])


### PR DESCRIPTION
# Pull request

## What changed and why

Milestone 4 of the GitHub Portfolio Auditor V1: deep inspection turning broad-scan signals + repository snapshots into findings, mechanically-honest business-claim grades, and 0–100 dimension scores. One concern: evidence-backed judgment about repositories under the contract's honesty rules.

- **Findings**: planted secrets become BLOCKING findings whose evidence binds file content by sha256 digest — never an excerpt, so no secret value can appear in inspection output; claim-to-evidence-gap and missing-lockfile findings carry independent-origin evidence, reasoning, and remediation. All findings validate against the finding schema with the seven contract-required fields.
- **Claim grading** (PD-PA-03, AC-PA-004): metric/scale/adoption claims grade INSUFFICIENT_EVIDENCE (unevaluable from repository evidence; absence ≠ falsehood); operational claims grade LIKELY only with ≥ policy-floor independent origins (test layout, CI config, lockfile), else NOT_PROVEN; **the mechanical grader can never emit PROVEN or CONTRADICTED** — those demand evidence kinds V1 cannot observe; every grade carries reasoning.
- **Dimension scores**: mechanical 0–100 formulas for all ten contract dimensions; secrets floor security; `must_surface_finding_ids` lists the material high-confidence findings explicitly so a numeric score never buries them.
- **Integrity**: inspection binds the snapshot content digest before/after — a source that mutates mid-run raises and discards results; `inspect_selected` covers exactly the selection and rejects unknown repos.
- **M3 review follow-up** (note 2): `select_for_deep_scan` no longer trusts its `risks` argument — internal re-sort + phantom-repo refusal, red-first regression tests.

## Requirement reference

`products/portfolio-auditor/contract.json` FR-PA-004/FR-PA-009 (AC-PA-004, AC-PA-009); PD-PA-03/06/07; M3 review record note 2 (PR #55).

## Architecture impact

Additive: one new module (`inspection.py`); `selection.py` gains only the documented hardening block; `__init__.py` exports. M2 scanner/datasource untouched.

## Tests added

Red-first (`428bb1b` → `9850c7f`): `tests/unit/test_portfolio_inspection.py` (18 tests — schema-valid blocking findings, no-secret-value sweep, grading honesty incl. PROVEN/CONTRADICTED unreachability, corroborated LIKELY, dimension coverage/ordering, must-surface guard, byte-identical repeats, digest binding, mutating-source loud failure) + 2 selection-hardening tests. Run: `pytest tests/unit/test_portfolio_inspection.py -q`

## Risk level

low — additive, fully gated; grading vocabulary deliberately restricted to the honestly-reachable subset.

## Rollback plan

Revert this PR. Nothing outside the new module depends on inspection yet.

## Evidence

- Full suite: **560 passed** (540 + 20 new); ruff + format clean; mypy --strict clean (108 files); bandit high clean.
- Independent fresh-context review: running (adversarial grading-honesty and secret-safety probes); verdict posted here. Merge only on APPROVE.
- CI: single attempt per the runner-outage protocol; result recorded here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbzWXg2FgTf5Awh5p81qqA)_