### PR TITLE
feat(portfolio): M5 — gated AI-slop classifier, stability check, M4 follow-ups

### DIFF
--- a/src/pmpe/portfolio/__init__.py
+++ b/src/pmpe/portfolio/__init__.py
@@ -39,6 +39,12 @@ from pmpe.portfolio.selection import (
     rank_risks,
     select_for_deep_scan,
 )
+from pmpe.portfolio.slop import (
+    SlopAssessment,
+    StabilityReport,
+    classify_slop,
+    verify_stability,
+)
 
 __all__ = [
     "AISlopVerdict",
@@ -58,6 +64,8 @@ __all__ = [
     "RepositorySource",
     "SelectionReport",
     "Severity",
+    "SlopAssessment",
+    "StabilityReport",
     "SlopPolicy",
     "Strategy",
     "load_auditor_bundle",
@@ -68,5 +76,7 @@ __all__ = [
     "rank_risks",
     "scan_portfolio",
     "scan_repository",
+    "classify_slop",
     "select_for_deep_scan",
+    "verify_stability",
 ]

--- a/src/pmpe/portfolio/inspection.py
+++ b/src/pmpe/portfolio/inspection.py
@@ -25,7 +25,6 @@ import hashlib
 from dataclasses import dataclass
 from typing import Any
 
-from pmpe.contracts.digest import canonical_digest
 from pmpe.domain.errors import PmpeError
 from pmpe.portfolio.datasource import RepositorySource
 from pmpe.portfolio.models import (
@@ -36,21 +35,17 @@ from pmpe.portfolio.models import (
     must_surface,
 )
 from pmpe.portfolio.policy import AuditorPolicy
-from pmpe.portfolio.scanner import MechanicalClaim, RepoScan
+from pmpe.portfolio.scanner import MechanicalClaim, RepoScan, snapshot_digest
 
 INSPECTOR_VERSION = "pa-inspector-1"
 
 #: Claim categories that V1 mechanical inspection cannot evaluate at all
 #: from repository content (external adoption, benchmarks, scale claims).
-_UNEVALUABLE_CATEGORIES = frozenset({"metric", "scale", "adoption"})
+_UNEVALUABLE_CATEGORIES = frozenset({"metric", "scale", "adoption", "superlative"})
 
 
 def _sha(text: str) -> str:
     return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
-
-
-def _snapshot_digest(meta: dict[str, Any], tree: list[str], files: dict[str, str]) -> str:
-    return canonical_digest({"metadata": meta, "tree": sorted(tree), "files": files})
 
 
 @dataclass(frozen=True)
@@ -439,7 +434,13 @@ def inspect_repository(
     meta = source.metadata(owner, name)
     tree = source.tree(owner, name)
     files = source.files(owner, name)
-    digest_before = _snapshot_digest(meta, tree, files)
+    digest_before = snapshot_digest(meta, tree, files)
+    if scan.snapshot_digest and scan.snapshot_digest != digest_before:
+        raise PmpeError(
+            f"scan for {repo} was taken from a different snapshot "
+            f"({scan.snapshot_digest} != {digest_before}) — the snapshot mutated "
+            "between scan and inspection; re-scan before inspecting"
+        )
 
     findings = (
         _secret_findings(repo, scan, files)
@@ -454,7 +455,7 @@ def inspect_repository(
         if must_surface(f, high_confidence_floor=policy.scoring.high_confidence_floor)
     )
 
-    digest_after = _snapshot_digest(
+    digest_after = snapshot_digest(
         source.metadata(owner, name), source.tree(owner, name), source.files(owner, name)
     )
     if digest_after != digest_before:

--- a/src/pmpe/portfolio/scanner.py
+++ b/src/pmpe/portfolio/scanner.py
@@ -21,10 +21,21 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any
 
+from pmpe.contracts.digest import canonical_digest
 from pmpe.portfolio.datasource import RepositorySource
 from pmpe.portfolio.models import RepoVisibility
 
 SCANNER_VERSION = "pa-scanner-1"
+
+
+def snapshot_digest(meta: dict[str, Any], tree: list[str], files: dict[str, str]) -> str:
+    """Canonical content digest of one repository snapshot.
+
+    Shared by the scanner and the deep inspector so a scan and an
+    inspection provably describe the same snapshot (M4 review, TOCTOU).
+    """
+    return canonical_digest({"metadata": meta, "tree": sorted(tree), "files": files})
+
 
 REDACTED = "***REDACTED***"
 
@@ -242,6 +253,7 @@ class RepoScan:
     packaging: PackagingSignals
     freshness: FreshnessSignals
     mechanical_claims: list[MechanicalClaim]
+    snapshot_digest: str = ""
     scanner_version: str = SCANNER_VERSION
 
     def to_dict(self) -> dict[str, Any]:
@@ -263,6 +275,7 @@ class RepoScan:
             "packaging": self.packaging.to_dict(),
             "freshness": self.freshness.to_dict(),
             "mechanical_claims": [c.to_dict() for c in self.mechanical_claims],
+            "snapshot_digest": self.snapshot_digest,
             "scanner_version": self.scanner_version,
         }
 
@@ -288,6 +301,7 @@ class RepoScan:
             mechanical_claims=[
                 MechanicalClaim.from_dict(c) for c in d.get("mechanical_claims", [])
             ],
+            snapshot_digest=str(d.get("snapshot_digest", "")),
             scanner_version=str(d.get("scanner_version", SCANNER_VERSION)),
         )
 
@@ -706,6 +720,7 @@ def scan_repository(
             is_fork=bool(meta.get("is_fork", False)),
         ),
         mechanical_claims=extract_mechanical_claims(readme_text) if readme_text else [],
+        snapshot_digest=snapshot_digest(meta, tree, files),
     )
 
 

--- a/src/pmpe/portfolio/slop.py
+++ b/src/pmpe/portfolio/slop.py
@@ -1,0 +1,233 @@
+"""AI-slop classifier with counter-evidence review and stability check (M5).
+
+The verdict applies to the repository artifact and its observable evidence
+discipline — never to the person who created it (PD-PA-01). The classifier
+uses only evidence-quality signals; the six forbidden bases (writing
+style, disclosed AI assistance, commit volume, repository size,
+generated-file count, lack of popularity) are not signals at all, so no
+verdict can rest on them, solely or otherwise.
+
+Gating (locked): a hard verdict requires >= 3 distinct signals on its own
+side, zero findings on the opposing side, the policy confidence floor, and
+a completed counter-evidence review — the review is the opposing-side
+search itself, and its searched categories and findings are recorded on
+the assessment. Anything less is INSUFFICIENT_EVIDENCE; uncertainty is
+always expressible and never penalized.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pmpe.portfolio.inspection import DeepInspection
+from pmpe.portfolio.models import AISlopVerdict, BusinessAccuracyVerdict, gate_slop_verdict
+from pmpe.portfolio.policy import AuditorPolicy
+from pmpe.portfolio.scanner import RepoScan
+
+CLASSIFIER_VERSION = "pa-slop-1"
+
+#: Signals suggesting slop (evidence-discipline absences and incidents).
+SLOP_SIGNAL_NAMES = (
+    "claims_without_evidence",
+    "no_tests",
+    "no_ci",
+    "missing_lockfile",
+    "unpinned_dependencies",
+    "committed_secret",
+    "no_license",
+)
+
+#: Exculpatory signals (observable engineering discipline).
+EXCULPATORY_SIGNAL_NAMES = (
+    "tests_present",
+    "ci_present",
+    "lockfile_present",
+    "dependencies_pinned",
+    "license_present",
+    "docs_dir_present",
+)
+
+_HARD_VERDICT_MIN_SIGNALS = 3
+
+
+def _slop_signals(scan: RepoScan, inspection: DeepInspection) -> tuple[str, ...]:
+    signals: list[str] = []
+    ungrounded = [
+        g for g in inspection.claim_grades if g.verdict is not BusinessAccuracyVerdict.LIKELY
+    ]
+    if ungrounded:
+        signals.append("claims_without_evidence")
+    if not scan.tests_ci.has_tests:
+        signals.append("no_tests")
+    if not scan.tests_ci.has_ci:
+        signals.append("no_ci")
+    if scan.security.dependency_manifests and not scan.security.has_lockfile:
+        signals.append("missing_lockfile")
+    if scan.security.pinned_dependencies is False:
+        signals.append("unpinned_dependencies")
+    if scan.security.secret_hits:
+        signals.append("committed_secret")
+    if not scan.docs.license_name:
+        signals.append("no_license")
+    return tuple(signals)
+
+
+def _exculpatory_signals(scan: RepoScan) -> tuple[str, ...]:
+    signals: list[str] = []
+    if scan.tests_ci.has_tests:
+        signals.append("tests_present")
+    if scan.tests_ci.has_ci:
+        signals.append("ci_present")
+    if scan.security.has_lockfile:
+        signals.append("lockfile_present")
+    if scan.security.pinned_dependencies is True:
+        signals.append("dependencies_pinned")
+    if scan.docs.license_name:
+        signals.append("license_present")
+    if scan.docs.has_docs_dir:
+        signals.append("docs_dir_present")
+    return tuple(signals)
+
+
+@dataclass(frozen=True)
+class SlopAssessment:
+    """The gated AI-slop verdict for one repository artifact."""
+
+    repository: str
+    verdict: AISlopVerdict
+    confidence: int
+    signals: tuple[str, ...]
+    counter_evidence_reviewed: bool
+    counter_evidence_searched: tuple[str, ...]
+    counter_evidence_found: tuple[str, ...]
+    reasoning: str
+    snapshot_digest: str
+    classifier_version: str = CLASSIFIER_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repository": self.repository,
+            "verdict": self.verdict.value,
+            "confidence": self.confidence,
+            "signals": list(self.signals),
+            "counter_evidence_reviewed": self.counter_evidence_reviewed,
+            "counter_evidence_searched": list(self.counter_evidence_searched),
+            "counter_evidence_found": list(self.counter_evidence_found),
+            "reasoning": self.reasoning,
+            "snapshot_digest": self.snapshot_digest,
+            "classifier_version": self.classifier_version,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SlopAssessment:
+        return cls(
+            repository=str(d["repository"]),
+            verdict=AISlopVerdict(d["verdict"]),
+            confidence=int(d["confidence"]),
+            signals=tuple(str(s) for s in d.get("signals", [])),
+            counter_evidence_reviewed=bool(d["counter_evidence_reviewed"]),
+            counter_evidence_searched=tuple(str(s) for s in d.get("counter_evidence_searched", [])),
+            counter_evidence_found=tuple(str(s) for s in d.get("counter_evidence_found", [])),
+            reasoning=str(d["reasoning"]),
+            snapshot_digest=str(d["snapshot_digest"]),
+            classifier_version=str(d.get("classifier_version", CLASSIFIER_VERSION)),
+        )
+
+
+def classify_slop(
+    scan: RepoScan, inspection: DeepInspection, *, policy: AuditorPolicy
+) -> SlopAssessment:
+    """Classify one repository artifact, counter-evidence review included."""
+    slop = _slop_signals(scan, inspection)
+    exculpatory = _exculpatory_signals(scan)
+    searched: tuple[str, ...]
+    found: tuple[str, ...]
+
+    if len(slop) >= _HARD_VERDICT_MIN_SIGNALS and not exculpatory:
+        proposed = AISlopVerdict.AI_SLOP
+        confidence = min(60 + 5 * len(slop), 95)
+        searched, found = EXCULPATORY_SIGNAL_NAMES, exculpatory
+        reasoning = (
+            f"{len(slop)} independent evidence-discipline signals "
+            f"({', '.join(slop)}) with zero exculpatory engineering signals "
+            f"after searching all {len(EXCULPATORY_SIGNAL_NAMES)} categories; "
+            "the verdict describes the repository artifact only"
+        )
+    elif len(exculpatory) >= _HARD_VERDICT_MIN_SIGNALS and len(slop) <= 1:
+        proposed = AISlopVerdict.NOT_AI_SLOP
+        confidence = min(60 + 5 * len(exculpatory), 95)
+        searched, found = SLOP_SIGNAL_NAMES, slop
+        reasoning = (
+            f"{len(exculpatory)} independent engineering-discipline signals "
+            f"({', '.join(exculpatory)}) with at most one slop signal after "
+            f"searching all {len(SLOP_SIGNAL_NAMES)} slop categories; the "
+            "verdict describes the repository artifact only"
+        )
+    else:
+        proposed = AISlopVerdict.INSUFFICIENT_EVIDENCE
+        confidence = 50
+        searched = SLOP_SIGNAL_NAMES + EXCULPATORY_SIGNAL_NAMES
+        found = slop + exculpatory
+        reasoning = (
+            f"mixed evidence — {len(slop)} slop signal(s) ({', '.join(slop) or 'none'}) "
+            f"against {len(exculpatory)} exculpatory signal(s) "
+            f"({', '.join(exculpatory) or 'none'}); neither side clears the "
+            f"{_HARD_VERDICT_MIN_SIGNALS}-signal hard-verdict floor, so the honest "
+            "answer is uncertainty"
+        )
+
+    verdict = gate_slop_verdict(
+        proposed,
+        confidence=confidence,
+        counter_evidence_reviewed=True,
+        sole_basis=None,
+        policy=policy.slop,
+    )
+    return SlopAssessment(
+        repository=inspection.repository,
+        verdict=verdict,
+        confidence=confidence,
+        signals=slop,
+        counter_evidence_reviewed=True,
+        counter_evidence_searched=searched,
+        counter_evidence_found=found,
+        reasoning=reasoning,
+        snapshot_digest=inspection.snapshot_digest,
+    )
+
+
+@dataclass(frozen=True)
+class StabilityReport:
+    """Cross-run verdict agreement: any flip is a HOLD (quality guardrail)."""
+
+    status: str  # "OK" | "HOLD"
+    runs: int
+    disagreements: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "runs": self.runs,
+            "disagreements": list(self.disagreements),
+        }
+
+
+def verify_stability(runs: list[list[SlopAssessment]]) -> StabilityReport:
+    """Compare repeated classification runs; a verdict flip is a HOLD."""
+    if len(runs) < 2:
+        raise ValueError("stability needs at least two runs to compare")
+    baseline = {a.repository: a.verdict for a in runs[0]}
+    disagreements: list[str] = []
+    for idx, run in enumerate(runs[1:], start=2):
+        seen = {a.repository: a.verdict for a in run}
+        if set(seen) != set(baseline):
+            missing = sorted(set(baseline) ^ set(seen))
+            disagreements.append(f"run {idx} coverage differs: {', '.join(missing)}")
+        for repo in sorted(set(seen) & set(baseline)):
+            if seen[repo] is not baseline[repo]:
+                disagreements.append(
+                    f"{repo}: run 1 said {baseline[repo].value}, run {idx} said {seen[repo].value}"
+                )
+    status = "HOLD" if disagreements else "OK"
+    return StabilityReport(status=status, runs=len(runs), disagreements=tuple(disagreements))

--- a/src/pmpe/portfolio/slop.py
+++ b/src/pmpe/portfolio/slop.py
@@ -8,11 +8,14 @@ generated-file count, lack of popularity) are not signals at all, so no
 verdict can rest on them, solely or otherwise.
 
 Gating (locked): a hard verdict requires >= 3 distinct signals on its own
-side, zero findings on the opposing side, the policy confidence floor, and
-a completed counter-evidence review — the review is the opposing-side
-search itself, and its searched categories and findings are recorded on
-the assessment. Anything less is INSUFFICIENT_EVIDENCE; uncertainty is
-always expressible and never penalized.
+side, the policy confidence floor, and a completed counter-evidence
+review — the review is the opposing-side search itself, and its searched
+categories and findings are recorded on the assessment. The accusatory
+verdict (AI_SLOP) additionally demands ZERO exculpatory evidence, while
+NOT_AI_SLOP tolerates at most one slop signal — the asymmetry runs in the
+subject-protective direction and is disclosed in each assessment's
+reasoning. Anything less is INSUFFICIENT_EVIDENCE; uncertainty is always
+expressible and never penalized.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_portfolio_inspection.py
+++ b/tests/unit/test_portfolio_inspection.py
@@ -18,14 +18,14 @@ import json
 from pathlib import Path
 
 import pytest
+
+from pmpe.domain.errors import PmpeError
+from pmpe.portfolio.datasource import FixtureRepositorySource
 from pmpe.portfolio.inspection import (
     DeepInspection,
     inspect_repository,
     inspect_selected,
 )
-
-from pmpe.domain.errors import PmpeError
-from pmpe.portfolio.datasource import FixtureRepositorySource
 from pmpe.portfolio.models import BusinessAccuracyVerdict, Severity, must_surface
 from pmpe.portfolio.policy import load_policy, validate_finding_dict
 from pmpe.portfolio.scanner import scan_repository

--- a/tests/unit/test_portfolio_slop.py
+++ b/tests/unit/test_portfolio_slop.py
@@ -19,11 +19,6 @@ import json
 from pathlib import Path
 
 import pytest
-from pmpe.portfolio.slop import (
-    SlopAssessment,
-    classify_slop,
-    verify_stability,
-)
 
 from pmpe.domain.errors import PmpeError
 from pmpe.portfolio.datasource import FixtureRepositorySource
@@ -31,6 +26,11 @@ from pmpe.portfolio.inspection import inspect_repository
 from pmpe.portfolio.models import AISlopVerdict, BusinessAccuracyVerdict
 from pmpe.portfolio.policy import load_policy
 from pmpe.portfolio.scanner import scan_repository
+from pmpe.portfolio.slop import (
+    SlopAssessment,
+    classify_slop,
+    verify_stability,
+)
 
 FIXTURES = (
     Path(__file__).resolve().parents[2]

--- a/tests/unit/test_portfolio_slop.py
+++ b/tests/unit/test_portfolio_slop.py
@@ -1,0 +1,232 @@
+"""Portfolio Auditor M5 — AI-slop classifier, counter-evidence review, stability.
+
+RED-first. The classifier judges the repository artifact only (PD-PA-01)
+from observable evidence-discipline signals. Locked gating: a hard verdict
+(AI_SLOP or NOT_AI_SLOP) requires confidence >= the policy floor AND a
+completed counter-evidence review; uncertainty defaults to
+INSUFFICIENT_EVIDENCE; the six forbidden bases never appear among the
+classifier's signals, and disclosed AI assistance is never penalized.
+Stability: equivalent inputs (permuted snapshot orderings, repeated runs)
+must produce byte-identical assessments; the stability checker reports
+HOLD on any verdict flip. Also closes two M4 review notes: RepoScan now
+carries the snapshot digest that inspect_repository verifies (TOCTOU), and
+superlative claims join the unevaluable categories.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pmpe.portfolio.slop import (
+    SlopAssessment,
+    classify_slop,
+    verify_stability,
+)
+
+from pmpe.domain.errors import PmpeError
+from pmpe.portfolio.datasource import FixtureRepositorySource
+from pmpe.portfolio.inspection import inspect_repository
+from pmpe.portfolio.models import AISlopVerdict, BusinessAccuracyVerdict
+from pmpe.portfolio.policy import load_policy
+from pmpe.portfolio.scanner import scan_repository
+
+FIXTURES = (
+    Path(__file__).resolve().parents[2]
+    / "evals"
+    / "fixtures"
+    / "portfolio_auditor"
+    / "demo-portfolio"
+)
+NOW = "2026-07-18T00:00:00+00:00"
+
+FORBIDDEN = {
+    "writing_style",
+    "disclosed_ai_assistance",
+    "commit_volume",
+    "repository_size",
+    "generated_file_count",
+    "lack_of_popularity",
+}
+
+
+def _source() -> FixtureRepositorySource:
+    return FixtureRepositorySource(FIXTURES)
+
+
+def _assess(name: str, source=None) -> SlopAssessment:  # type: ignore[no-untyped-def]
+    src = source or _source()
+    scan = scan_repository(src, "acme", name, now=NOW)
+    inspection = inspect_repository(src, scan, policy=load_policy())
+    return classify_slop(scan, inspection, policy=load_policy())
+
+
+class TestPlantedVerdicts:
+    def test_slop_wrapper_is_ai_slop_with_gated_confidence(self) -> None:
+        a = _assess("slop-wrapper")
+        assert a.verdict is AISlopVerdict.AI_SLOP
+        assert a.confidence >= load_policy().slop.hard_verdict_min_confidence
+        assert a.counter_evidence_reviewed is True
+
+    def test_healthy_lib_is_not_ai_slop(self) -> None:
+        a = _assess("healthy-lib")
+        assert a.verdict is AISlopVerdict.NOT_AI_SLOP
+        assert a.confidence >= load_policy().slop.hard_verdict_min_confidence
+        assert a.counter_evidence_reviewed is True
+
+    def test_stale_fork_is_honestly_uncertain(self) -> None:
+        assert _assess("stale-fork").verdict is AISlopVerdict.INSUFFICIENT_EVIDENCE
+
+    def test_internal_service_mixed_discipline_is_uncertain(self) -> None:
+        # tests + CI (exculpatory) but committed secret + unpinned deps:
+        # neither branch clears its floor — honest uncertainty.
+        assert _assess("internal-service").verdict is AISlopVerdict.INSUFFICIENT_EVIDENCE
+
+
+class TestCounterEvidenceReview:
+    def test_review_always_runs_and_is_recorded(self) -> None:
+        for name in ("healthy-lib", "slop-wrapper", "stale-fork", "internal-service"):
+            a = _assess(name)
+            assert a.counter_evidence_reviewed is True
+            assert a.counter_evidence_searched, "the searched categories must be recorded"
+
+    def test_slop_wrapper_counter_evidence_found_is_empty(self) -> None:
+        assert _assess("slop-wrapper").counter_evidence_found == ()
+
+    def test_healthy_lib_counter_evidence_lists_exculpatory_signals(self) -> None:
+        a = _assess("healthy-lib")
+        assert a.verdict is AISlopVerdict.NOT_AI_SLOP
+        # for a NOT_AI_SLOP proposal the counter-evidence search looks for
+        # slop-indicating signals; finding none is the recorded outcome
+        assert a.counter_evidence_found == ()
+
+    def test_every_assessment_carries_reasoning(self) -> None:
+        for name in ("healthy-lib", "slop-wrapper", "stale-fork", "internal-service"):
+            assert _assess(name).reasoning
+
+
+class TestFairnessRules:
+    def test_forbidden_bases_never_appear_as_signals(self) -> None:
+        for name in ("healthy-lib", "slop-wrapper", "stale-fork", "internal-service"):
+            a = _assess(name)
+            assert not (set(a.signals) & FORBIDDEN)
+            assert not (set(a.counter_evidence_found) & FORBIDDEN)
+
+    def test_disclosed_ai_assistance_is_never_penalized(self) -> None:
+        source = _source()
+        files = dict(source.files("acme", "healthy-lib"))
+        files["README.md"] = files["README.md"] + (
+            "\n## Credits\nBuilt with Claude and GitHub Copilot assistance.\n"
+        )
+        wrapped = _FilesOverrideSource(source, files)
+        a = _assess("healthy-lib", source=wrapped)
+        assert a.verdict is AISlopVerdict.NOT_AI_SLOP
+        assert not (set(a.signals) & FORBIDDEN)
+
+    def test_verdict_is_about_the_artifact_only(self) -> None:
+        d = _assess("slop-wrapper").to_dict()
+        assert d["repository"] == "acme/slop-wrapper"
+        assert "owner_identity" not in d and "author" not in d
+
+
+class TestGatingIntegration:
+    def test_low_confidence_never_yields_hard_verdict(self) -> None:
+        # stale-fork and internal-service sit below both branch floors; the
+        # gate guarantees no hard verdict escapes without the confidence floor.
+        for name in ("stale-fork", "internal-service"):
+            a = _assess(name)
+            if a.verdict is not AISlopVerdict.INSUFFICIENT_EVIDENCE:
+                assert a.confidence >= load_policy().slop.hard_verdict_min_confidence
+
+    def test_assessment_round_trips(self) -> None:
+        a = _assess("slop-wrapper")
+        assert SlopAssessment.from_dict(a.to_dict()).to_dict() == a.to_dict()
+
+    def test_no_secret_values_in_assessment(self) -> None:
+        blob = json.dumps(_assess("slop-wrapper").to_dict())
+        assert "EXAMPLE_placeholder" not in blob
+
+
+class TestStability:
+    def test_repeated_assessment_is_byte_identical(self) -> None:
+        assert json.dumps(_assess("slop-wrapper").to_dict()) == json.dumps(
+            _assess("slop-wrapper").to_dict()
+        )
+
+    def test_permuted_snapshot_order_gives_identical_assessment(self) -> None:
+        source = _source()
+        files = source.files("acme", "slop-wrapper")
+        permuted = dict(reversed(list(files.items())))
+        a = _assess("slop-wrapper")
+        b = _assess("slop-wrapper", source=_FilesOverrideSource(source, permuted))
+        assert json.dumps(a.to_dict()) == json.dumps(b.to_dict())
+
+    def test_verify_stability_ok_on_agreeing_runs(self) -> None:
+        run = [_assess("healthy-lib"), _assess("slop-wrapper")]
+        report = verify_stability([run, run])
+        assert report.status == "OK"
+        assert report.disagreements == ()
+
+    def test_verify_stability_holds_on_verdict_flip(self) -> None:
+        a = _assess("slop-wrapper")
+        flipped = SlopAssessment.from_dict(
+            {**a.to_dict(), "verdict": AISlopVerdict.NOT_AI_SLOP.value}
+        )
+        report = verify_stability([[a], [flipped]])
+        assert report.status == "HOLD"
+        assert any("acme/slop-wrapper" in d for d in report.disagreements)
+
+    def test_verify_stability_requires_at_least_two_runs(self) -> None:
+        with pytest.raises(ValueError, match="two"):
+            verify_stability([[_assess("healthy-lib")]])
+
+
+class TestM4ReviewFollowUps:
+    def test_repo_scan_carries_snapshot_digest(self) -> None:
+        scan = scan_repository(_source(), "acme", "healthy-lib", now=NOW)
+        assert scan.snapshot_digest.startswith("sha256:")
+
+    def test_inspection_rejects_scan_from_different_snapshot(self) -> None:
+        # The M4 reviewer's TOCTOU PoC: scan sees one snapshot, inspection
+        # another. The digest carried on the scan must close the window.
+        source = _source()
+        scan = scan_repository(source, "acme", "healthy-lib", now=NOW)
+        files = dict(source.files("acme", "healthy-lib"))
+        files["README.md"] = files["README.md"] + "\nphase flip\n"
+        flipped = _FilesOverrideSource(source, files)
+        with pytest.raises(PmpeError, match="snapshot"):
+            inspect_repository(flipped, scan, policy=load_policy())
+
+    def test_superlative_claims_are_unevaluable(self) -> None:
+        # Even a fully-supported repo cannot substantiate "state-of-the-art".
+        source = _source()
+        files = dict(source.files("acme", "healthy-lib"))
+        files["README.md"] = files["README.md"] + "\nState-of-the-art parsing engine.\n"
+        wrapped = _FilesOverrideSource(source, files)
+        scan = scan_repository(wrapped, "acme", "healthy-lib", now=NOW)
+        insp = inspect_repository(wrapped, scan, policy=load_policy())
+        superlatives = [g for g in insp.claim_grades if g.claim.category == "superlative"]
+        assert superlatives
+        for g in superlatives:
+            assert g.verdict is BusinessAccuracyVerdict.INSUFFICIENT_EVIDENCE
+
+
+class _FilesOverrideSource:
+    """Wraps the fixture source with replacement files for one repo."""
+
+    def __init__(self, inner: FixtureRepositorySource, files: dict[str, str]) -> None:
+        self._inner = inner
+        self._files = files
+
+    def discover(self, owner: str) -> list[str]:
+        return self._inner.discover(owner)
+
+    def metadata(self, owner: str, name: str) -> dict[str, object]:
+        return self._inner.metadata(owner, name)
+
+    def tree(self, owner: str, name: str) -> list[str]:
+        return sorted(set(self._inner.tree(owner, name)) | set(self._files))
+
+    def files(self, owner: str, name: str) -> dict[str, str]:
+        return dict(self._files)


### PR DESCRIPTION
# Pull request

## What changed and why

Milestone 5 of the GitHub Portfolio Auditor V1: the AI-slop classifier with its counter-evidence review and stability check, plus the two follow-ups carried from the M4 review record. One concern: the repository-level AI-slop verdict under the contract's fairness rules.

- **Classifier** (`slop.py`): judges the repository artifact only (PD-PA-01) from evidence-discipline signals. The six forbidden bases (writing style, disclosed AI assistance, commit volume, repository size, generated-file count, lack of popularity) **are not signals at all** — structurally absent, so no verdict can rest on them and disclosed AI assistance is never penalized (test-enforced). A hard verdict requires ≥ 3 distinct same-side signals, zero-or-one opposing findings (zero for AI_SLOP), the policy confidence floor, and a completed counter-evidence review — the review is the opposing-side search itself, with searched categories and findings recorded on every assessment. Everything else is INSUFFICIENT_EVIDENCE.
- **Planted outcomes**: slop-wrapper → AI_SLOP (95, counter-evidence search found nothing exculpatory); healthy-lib → NOT_AI_SLOP (90); stale-fork and internal-service → honestly INSUFFICIENT_EVIDENCE (borderline cases never get a hard verdict).
- **Stability check**: `verify_stability` compares repeated classification runs; any verdict flip or coverage change is a HOLD naming the repository (quality guardrail `repeated_audit_consistency`).
- **M4 follow-ups**: `RepoScan` now carries the snapshot content digest and `inspect_repository` refuses a scan taken from a different snapshot — the M4 reviewer's TOCTOU phase-flip PoC is a regression test; `superlative` claims join the unevaluable categories.

## Requirement reference

`products/portfolio-auditor/contract.json` FR-PA-005 (AC-PA-005); `policy.json` ai_slop_policy; PD-PA-01/07; M4 review record notes 1–2 (PR #56).

## Architecture impact

Additive: one new module (`slop.py`); scanner gains one additive field + shared digest helper; inspection gains the TOCTOU check and one category constant; exports. No grading/scoring logic changed.

## Tests added

Red-first (`1d773e8` → `2c0d80e`): `tests/unit/test_portfolio_slop.py` (22 tests — planted verdicts, counter-evidence recording, forbidden-basis absence, AI-disclosure non-penalization, gating floor, stability OK/HOLD/arity, byte-identical + permuted-order determinism, TOCTOU regression, superlative regression). Run: `pytest tests/unit/test_portfolio_slop.py -q`

## Risk level

medium — this milestone produces the reputationally-sensitive verdict; mitigations are the structural fairness rules, the hard-verdict floors, and the adversarial independent review.

## Rollback plan

Revert this PR. The TOCTOU check is self-contained (empty digest skips it for old serialized scans).

## Evidence

- Full suite: **582 passed** (560 + 22 new); ruff + format clean; mypy --strict clean (109 files); bandit high clean.
- Independent fresh-context review: running (fairness/branch-boundary/TOCTOU probes); verdict posted here. Merge only on APPROVE.
- CI: single attempt per the runner-outage protocol; result recorded here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbzWXg2FgTf5Awh5p81qqA)_