### PR TITLE
feat(portfolio): M6 — recommendation ladder, remediation backlog, renderers

### DIFF
--- a/src/pmpe/portfolio/__init__.py
+++ b/src/pmpe/portfolio/__init__.py
@@ -30,6 +30,15 @@ from pmpe.portfolio.models import (
     SlopPolicy,
 )
 from pmpe.portfolio.policy import AuditorPolicy, load_policy
+from pmpe.portfolio.reporting import (
+    BacklogItem,
+    RepoReport,
+    build_backlog,
+    build_repo_report,
+    recommend,
+    render_dashboard,
+    render_scorecard,
+)
 from pmpe.portfolio.scanner import RepoScan, scan_portfolio, scan_repository
 from pmpe.portfolio.selection import (
     RepoRisk,
@@ -50,6 +59,7 @@ __all__ = [
     "AISlopVerdict",
     "AuditorBundle",
     "AuditorPolicy",
+    "BacklogItem",
     "BusinessAccuracyVerdict",
     "ClaimGrade",
     "DeepInspection",
@@ -59,6 +69,7 @@ __all__ = [
     "LiveAccessUnavailable",
     "LiveRepositorySource",
     "RecommendationVerdict",
+    "RepoReport",
     "RepoRisk",
     "RepoScan",
     "RepositorySource",
@@ -74,8 +85,13 @@ __all__ = [
     "inspect_selected",
     "load_strategy",
     "rank_risks",
+    "recommend",
+    "render_dashboard",
+    "render_scorecard",
     "scan_portfolio",
     "scan_repository",
+    "build_backlog",
+    "build_repo_report",
     "classify_slop",
     "select_for_deep_scan",
     "verify_stability",

--- a/src/pmpe/portfolio/reporting.py
+++ b/src/pmpe/portfolio/reporting.py
@@ -1,0 +1,335 @@
+"""Recommendations, remediation backlog, scorecards, dashboard (M6).
+
+Pure functions of recorded evidence. The recommendation ladder is
+deterministic and honors the locked guard: a numeric score never
+overrides a material high-confidence finding — such a repository can
+never be SHOWCASE or KEEP_AS_IS. Every backlog entry traces to a finding
+id (AC-PA-006). Renderers take run metadata as parameters (no wall
+clock), label broad-scan-only repositories honestly instead of inventing
+verdicts, and can never contain secret values because everything they
+render is already redacted upstream.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pmpe.portfolio.inspection import DeepInspection
+from pmpe.portfolio.models import (
+    RecommendationVerdict,
+    Severity,
+    prioritization_score,
+)
+from pmpe.portfolio.policy import AuditorPolicy, load_policy
+from pmpe.portfolio.scanner import RepoScan
+from pmpe.portfolio.selection import Strategy
+from pmpe.portfolio.slop import SlopAssessment
+
+REPORTER_VERSION = "pa-reporter-1"
+
+_SEVERITY_WEIGHTS: dict[Severity, float] = {
+    Severity.BLOCKING: 5.0,
+    Severity.HIGH: 4.0,
+    Severity.MEDIUM: 3.0,
+    Severity.LOW: 2.0,
+    Severity.INFO: 1.0,
+}
+
+#: Dimensions whose findings damage authority the most.
+_HIGH_AUTHORITY_DIMENSIONS = frozenset(
+    {"security_dependency_integrity", "claim_to_evidence_integrity"}
+)
+
+#: Mechanical effort estimates by dimension (denominator of the formula).
+_EFFORT_BY_DIMENSION = {
+    "security_dependency_integrity": 2.0,
+    "claim_to_evidence_integrity": 3.0,
+}
+_DEFAULT_EFFORT = 2.0
+
+_SHOWCASE_FLOOR = 80
+_STALE_DAYS = 365
+
+
+def severity_weight(severity: Severity) -> float:
+    return _SEVERITY_WEIGHTS[severity]
+
+
+@dataclass
+class RepoReport:
+    """Everything known about one repository, honestly labeled.
+
+    ``inspection``/``assessment``/``recommendation`` are None for a
+    repository that received only the broad scan — no verdict is invented
+    for it.
+    """
+
+    repository: str
+    scan: RepoScan
+    inspection: DeepInspection | None
+    assessment: SlopAssessment | None
+    recommendation: RecommendationVerdict | None
+    recommendation_reasoning: str
+    strategic: bool = False
+    reporter_version: str = REPORTER_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repository": self.repository,
+            "scan": self.scan.to_dict(),
+            "inspection": None if self.inspection is None else self.inspection.to_dict(),
+            "assessment": None if self.assessment is None else self.assessment.to_dict(),
+            "recommendation": (None if self.recommendation is None else self.recommendation.value),
+            "recommendation_reasoning": self.recommendation_reasoning,
+            "strategic": self.strategic,
+            "reporter_version": self.reporter_version,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RepoReport:
+        return cls(
+            repository=str(d["repository"]),
+            scan=RepoScan.from_dict(d["scan"]),
+            inspection=(
+                None if d.get("inspection") is None else DeepInspection.from_dict(d["inspection"])
+            ),
+            assessment=(
+                None if d.get("assessment") is None else SlopAssessment.from_dict(d["assessment"])
+            ),
+            recommendation=(
+                None
+                if d.get("recommendation") is None
+                else RecommendationVerdict(d["recommendation"])
+            ),
+            recommendation_reasoning=str(d.get("recommendation_reasoning", "")),
+            strategic=bool(d.get("strategic", False)),
+            reporter_version=str(d.get("reporter_version", REPORTER_VERSION)),
+        )
+
+
+def recommend(
+    *,
+    scan: RepoScan,
+    inspection: DeepInspection,
+    assessment: SlopAssessment,
+    strategy: Strategy,
+    policy: AuditorPolicy,
+) -> tuple[RecommendationVerdict, str]:
+    """The deterministic recommendation ladder.
+
+    Order is product law: (1) an AI_SLOP verdict with multiple material
+    findings means the artifact damages authority as-is — REBUILD; (2) any
+    material high-confidence finding forces FIX — no score can override it
+    (the locked guard); (3) a stale fork consolidates; (4) a clean repo at
+    showcase-grade authority readiness is SHOWCASE; (5) otherwise
+    KEEP_AS_IS.
+    """
+    material = [f for f in inspection.findings if f.is_high_impact]
+    surfaced = inspection.must_surface_finding_ids
+    if assessment.verdict.value == "AI_SLOP" and len(material) >= 2:
+        return (
+            RecommendationVerdict.REBUILD,
+            f"classified AI_SLOP with {len(material)} material findings "
+            f"({', '.join(f.finding_id for f in material)}) — repairing in place "
+            "would keep the misleading surface; rebuild from the honest core",
+        )
+    if surfaced:
+        return (
+            RecommendationVerdict.FIX,
+            f"{len(surfaced)} material high-confidence finding(s) "
+            f"({', '.join(surfaced)}) must be fixed first — no numeric score "
+            "overrides a material finding",
+        )
+    days = scan.freshness.days_since_pushed
+    if scan.freshness.is_fork and days is not None and days > _STALE_DAYS:
+        return (
+            RecommendationVerdict.CONSOLIDATE,
+            f"a fork untouched for {days} days adds noise, not authority — "
+            "archive it or fold anything valuable into an owned repository",
+        )
+    authority = inspection.dimension_scores.get("authority_readiness", 0)
+    if not inspection.findings and authority >= _SHOWCASE_FLOOR:
+        return (
+            RecommendationVerdict.SHOWCASE,
+            f"zero findings and authority readiness {authority} >= "
+            f"{_SHOWCASE_FLOOR} — worth featuring",
+        )
+    return (
+        RecommendationVerdict.KEEP_AS_IS,
+        f"no material findings; authority readiness {authority} below the "
+        f"showcase floor {_SHOWCASE_FLOOR} — fine as it is, not featured",
+    )
+
+
+def build_repo_report(
+    *,
+    scan: RepoScan,
+    inspection: DeepInspection,
+    assessment: SlopAssessment,
+    strategy: Strategy,
+    policy: AuditorPolicy,
+) -> RepoReport:
+    verdict, reasoning = recommend(
+        scan=scan,
+        inspection=inspection,
+        assessment=assessment,
+        strategy=strategy,
+        policy=policy,
+    )
+    return RepoReport(
+        repository=inspection.repository,
+        scan=scan,
+        inspection=inspection,
+        assessment=assessment,
+        recommendation=verdict,
+        recommendation_reasoning=reasoning,
+        strategic=inspection.repository in strategy.always_deep_scan(),
+    )
+
+
+@dataclass(frozen=True)
+class BacklogItem:
+    finding_id: str
+    repository: str
+    dimension: str
+    severity: str
+    priority: float
+    remediation: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "finding_id": self.finding_id,
+            "repository": self.repository,
+            "dimension": self.dimension,
+            "severity": self.severity,
+            "priority": self.priority,
+            "remediation": self.remediation,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BacklogItem:
+        return cls(
+            finding_id=str(d["finding_id"]),
+            repository=str(d["repository"]),
+            dimension=str(d["dimension"]),
+            severity=str(d["severity"]),
+            priority=float(d["priority"]),
+            remediation=str(d["remediation"]),
+        )
+
+
+def build_backlog(
+    reports: list[RepoReport], *, policy: AuditorPolicy, strategy: Strategy | None = None
+) -> list[BacklogItem]:
+    """Prioritized remediation backlog: one traceable entry per finding.
+
+    Priority uses the contract formula (strategic importance x severity x
+    authority impact x confidence / effort). Every finding is included —
+    must-surface findings can never fall out of the backlog by score.
+    """
+    items: list[BacklogItem] = []
+    for report in reports:
+        if report.inspection is None:
+            continue
+        strategic = (
+            2.0
+            if report.strategic
+            or (strategy is not None and report.repository in strategy.always_deep_scan())
+            else 1.0
+        )
+        for finding in report.inspection.findings:
+            priority = prioritization_score(
+                strategic_importance=strategic,
+                severity_weight=severity_weight(finding.severity),
+                authority_impact=(2.0 if finding.dimension in _HIGH_AUTHORITY_DIMENSIONS else 1.0),
+                confidence=finding.confidence,
+                remediation_effort=_EFFORT_BY_DIMENSION.get(finding.dimension, _DEFAULT_EFFORT),
+            )
+            items.append(
+                BacklogItem(
+                    finding_id=finding.finding_id,
+                    repository=report.repository,
+                    dimension=finding.dimension,
+                    severity=finding.severity.value,
+                    priority=round(priority, 4),
+                    remediation=finding.remediation_recommendation,
+                )
+            )
+    return sorted(items, key=lambda b: (-b.priority, b.finding_id))
+
+
+def render_scorecard(report: RepoReport, *, run: dict[str, str]) -> str:
+    """One repository's markdown scorecard (deep-inspected repos only)."""
+    if report.inspection is None or report.assessment is None:
+        raise ValueError(
+            f"{report.repository} received a broad scan only — a scorecard "
+            "would invent judgments no inspection supports"
+        )
+    insp = report.inspection
+    lines = [
+        f"# Scorecard — {report.repository}",
+        "",
+        f"- run: {run['run_id']} · generated: {run['generated_at']}",
+        f"- snapshot: {insp.snapshot_digest}",
+        f"- recommendation: **{report.recommendation.value if report.recommendation else ''}**"
+        f" — {report.recommendation_reasoning}",
+        f"- AI-slop verdict: **{report.assessment.verdict.value}** "
+        f"(confidence {report.assessment.confidence}, counter-evidence review recorded)",
+        "",
+        "## Dimension scores",
+        "",
+    ]
+    lines += [f"- {dim}: {score}" for dim, score in sorted(insp.dimension_scores.items())]
+    lines += ["", "## Findings", ""]
+    if insp.findings:
+        for f in insp.findings:
+            lines.append(
+                f"- `{f.finding_id}` [{f.severity.value}] {f.summary} — "
+                f"{f.remediation_recommendation}"
+            )
+    else:
+        lines.append("- none")
+    if insp.claim_grades:
+        lines += ["", "## Business claims", ""]
+        lines += [
+            f"- {g.verdict.value}: {g.claim.text} ({g.claim.location})" for g in insp.claim_grades
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def render_dashboard(
+    reports: list[RepoReport], *, backlog: list[BacklogItem], run: dict[str, str]
+) -> str:
+    """The portfolio dashboard (markdown, deterministic, honestly labeled)."""
+    policy = load_policy()
+    lines = [
+        "# Portfolio dashboard",
+        "",
+        f"- run: {run['run_id']} · generated: {run['generated_at']}",
+        f"- policy digest: {policy.digest}",
+        f"- repositories: {len(reports)} · backlog items: {len(backlog)}",
+        "",
+        "| repository | slop verdict | recommendation | authority | findings |",
+        "|---|---|---|---|---|",
+    ]
+    for r in sorted(reports, key=lambda x: x.repository):
+        if r.inspection is None or r.assessment is None:
+            lines.append(f"| {r.repository} | broad scan only | — | — | — |")
+            continue
+        lines.append(
+            f"| {r.repository} | {r.assessment.verdict.value} | "
+            f"{r.recommendation.value if r.recommendation else '—'} | "
+            f"{r.inspection.dimension_scores.get('authority_readiness', 0)} | "
+            f"{len(r.inspection.findings)} |"
+        )
+    lines += ["", "## Remediation backlog (highest priority first)", ""]
+    if backlog:
+        lines += [
+            f"1. `{b.finding_id}` ({b.repository}, {b.severity}, priority {b.priority:g}) "
+            f"— {b.remediation}"
+            for b in backlog
+        ]
+    else:
+        lines.append("- empty")
+    return "\n".join(lines) + "\n"

--- a/tests/unit/test_portfolio_reporting.py
+++ b/tests/unit/test_portfolio_reporting.py
@@ -1,0 +1,239 @@
+"""Portfolio Auditor M6 — recommendation, backlog, scorecards, dashboard.
+
+RED-first. The recommendation ladder is deterministic and honors the
+locked guard: a numeric score never overrides a material high-confidence
+finding — a repository with one can never be SHOWCASE or KEEP_AS_IS.
+Every backlog entry traces to a finding id (AC-PA-006), must-surface
+findings are always in the backlog regardless of score, and all renderers
+are pure functions of recorded evidence: byte-identical repeats, no wall
+clock (run metadata is a parameter), no secret values, honest labeling of
+repositories that received only a broad scan.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pmpe.portfolio.reporting import (
+    BacklogItem,
+    RepoReport,
+    build_backlog,
+    build_repo_report,
+    recommend,
+    render_dashboard,
+    render_scorecard,
+)
+
+from pmpe.portfolio.datasource import FixtureRepositorySource
+from pmpe.portfolio.inspection import DeepInspection, inspect_repository
+from pmpe.portfolio.models import RecommendationVerdict, Severity
+from pmpe.portfolio.policy import load_policy
+from pmpe.portfolio.scanner import scan_repository
+from pmpe.portfolio.selection import load_strategy
+from pmpe.portfolio.slop import classify_slop
+
+FIXTURES = (
+    Path(__file__).resolve().parents[2]
+    / "evals"
+    / "fixtures"
+    / "portfolio_auditor"
+    / "demo-portfolio"
+)
+NOW = "2026-07-18T00:00:00+00:00"
+RUN_META = {"run_id": "pa-demo-001", "generated_at": NOW}
+
+
+def _report(name: str) -> RepoReport:
+    source = FixtureRepositorySource(FIXTURES)
+    scan = scan_repository(source, "acme", name, now=NOW)
+    inspection = inspect_repository(source, scan, policy=load_policy())
+    assessment = classify_slop(scan, inspection, policy=load_policy())
+    return build_repo_report(
+        scan=scan,
+        inspection=inspection,
+        assessment=assessment,
+        strategy=load_strategy(FIXTURES / "strategy.json"),
+        policy=load_policy(),
+    )
+
+
+def _all_reports() -> list[RepoReport]:
+    return [_report(n) for n in ("healthy-lib", "internal-service", "slop-wrapper", "stale-fork")]
+
+
+class TestRecommendationLadder:
+    def test_slop_wrapper_is_rebuild(self) -> None:
+        assert _report("slop-wrapper").recommendation is RecommendationVerdict.REBUILD
+
+    def test_internal_service_is_fix(self) -> None:
+        # material high-confidence secret finding forces at least FIX
+        assert _report("internal-service").recommendation is RecommendationVerdict.FIX
+
+    def test_healthy_lib_is_showcase(self) -> None:
+        assert _report("healthy-lib").recommendation is RecommendationVerdict.SHOWCASE
+
+    def test_stale_fork_is_consolidate(self) -> None:
+        assert _report("stale-fork").recommendation is RecommendationVerdict.CONSOLIDATE
+
+    def test_every_recommendation_carries_reasoning(self) -> None:
+        for r in _all_reports():
+            assert r.recommendation_reasoning
+
+    def test_material_finding_never_showcase_or_keep(self) -> None:
+        # The locked guard, probed directly: perfect scores plus one material
+        # high-confidence finding must never yield SHOWCASE or KEEP_AS_IS.
+        base = _report("internal-service")
+        perfect = DeepInspection.from_dict(base.inspection.to_dict())
+        perfect.dimension_scores = dict.fromkeys(perfect.dimension_scores, 100)
+        verdict = recommend(
+            scan=base.scan,
+            inspection=perfect,
+            assessment=base.assessment,
+            strategy=load_strategy(FIXTURES / "strategy.json"),
+            policy=load_policy(),
+        )[0]
+        assert verdict not in (
+            RecommendationVerdict.SHOWCASE,
+            RecommendationVerdict.KEEP_AS_IS,
+        )
+
+    def test_plain_repo_without_findings_is_keep_as_is(self) -> None:
+        # stale-fork stripped of its fork flag becomes an ordinary quiet
+        # repo: no material findings, not showcase-grade, nothing to fix.
+        base = _report("stale-fork")
+        scan_dict = base.scan.to_dict()
+        scan_dict["freshness"]["is_fork"] = False
+        scan_dict["freshness"]["days_since_pushed"] = 30
+        from pmpe.portfolio.scanner import RepoScan
+
+        verdict = recommend(
+            scan=RepoScan.from_dict(scan_dict),
+            inspection=base.inspection,
+            assessment=base.assessment,
+            strategy=load_strategy(FIXTURES / "strategy.json"),
+            policy=load_policy(),
+        )[0]
+        assert verdict is RecommendationVerdict.KEEP_AS_IS
+
+
+class TestBacklog:
+    def test_every_entry_traces_to_a_finding(self) -> None:
+        reports = _all_reports()
+        backlog = build_backlog(reports, policy=load_policy())
+        all_finding_ids = {f.finding_id for r in reports for f in r.inspection.findings}
+        assert backlog, "planted findings must produce backlog entries"
+        for item in backlog:
+            assert item.finding_id in all_finding_ids
+            assert item.repository and item.remediation and item.priority > 0
+
+    def test_must_surface_findings_always_in_backlog(self) -> None:
+        reports = _all_reports()
+        backlog_ids = {b.finding_id for b in build_backlog(reports, policy=load_policy())}
+        for r in reports:
+            for fid in r.inspection.must_surface_finding_ids:
+                assert fid in backlog_ids
+
+    def test_backlog_sorted_by_priority_then_id(self) -> None:
+        backlog = build_backlog(_all_reports(), policy=load_policy())
+        keys = [(-b.priority, b.finding_id) for b in backlog]
+        assert keys == sorted(keys)
+
+    def test_blocking_secret_outranks_medium_dependency_hygiene(self) -> None:
+        backlog = build_backlog(_all_reports(), policy=load_policy())
+        by_id = {b.finding_id: b for b in backlog}
+        sec = next(b for i, b in by_id.items() if "-SEC-" in i)
+        dep = next((b for i, b in by_id.items() if "-DEP-" in i), None)
+        if dep is not None:
+            assert sec.priority > dep.priority
+
+    def test_strategic_repo_findings_get_multiplier(self) -> None:
+        # internal-service is strategic; its secret finding must outrank an
+        # identical-severity finding on a non-strategic repo.
+        backlog = build_backlog(_all_reports(), policy=load_policy())
+        strategic_sec = next(
+            b
+            for b in backlog
+            if b.repository == "acme/internal-service" and "-SEC-" in b.finding_id
+        )
+        plain_sec = next(
+            b for b in backlog if b.repository == "acme/slop-wrapper" and "-SEC-" in b.finding_id
+        )
+        assert strategic_sec.priority > plain_sec.priority
+
+    def test_backlog_round_trips(self) -> None:
+        item = build_backlog(_all_reports(), policy=load_policy())[0]
+        assert BacklogItem.from_dict(item.to_dict()) == item
+
+
+class TestRenderers:
+    def test_scorecard_contains_verdicts_scores_and_finding_ids(self) -> None:
+        r = _report("slop-wrapper")
+        card = render_scorecard(r, run=RUN_META)
+        assert "acme/slop-wrapper" in card
+        assert "AI_SLOP" in card and "REBUILD" in card
+        for f in r.inspection.findings:
+            assert f.finding_id in card
+        assert r.inspection.snapshot_digest in card
+
+    def test_scorecard_never_contains_secret_values(self) -> None:
+        for name in ("slop-wrapper", "internal-service"):
+            card = render_scorecard(_report(name), run=RUN_META)
+            assert "EXAMPLE_placeholder" not in card
+            assert "FAKE_placeholder" not in card
+
+    def test_dashboard_covers_every_report_with_provenance(self) -> None:
+        reports = _all_reports()
+        board = render_dashboard(
+            reports, backlog=build_backlog(reports, policy=load_policy()), run=RUN_META
+        )
+        for r in reports:
+            assert r.repository in board
+        assert RUN_META["run_id"] in board
+        assert load_policy().digest in board
+
+    def test_dashboard_is_byte_identical_across_runs(self) -> None:
+        reports = _all_reports()
+        backlog = build_backlog(reports, policy=load_policy())
+        a = render_dashboard(reports, backlog=backlog, run=RUN_META)
+        b = render_dashboard(_all_reports(), backlog=backlog, run=RUN_META)
+        assert a == b
+
+    def test_dashboard_run_metadata_is_injected_not_read(self) -> None:
+        reports = _all_reports()
+        backlog = build_backlog(reports, policy=load_policy())
+        board = render_dashboard(
+            reports, backlog=backlog, run={"run_id": "other", "generated_at": "2020-01-01"}
+        )
+        assert "other" in board and "2020-01-01" in board
+
+    def test_report_round_trips(self) -> None:
+        r = _report("healthy-lib")
+        assert RepoReport.from_dict(r.to_dict()).to_dict() == r.to_dict()
+
+    def test_reports_include_broad_scan_only_honesty(self) -> None:
+        # A repo without inspection/assessment renders honestly as
+        # broad-scan-only: no slop verdict, no recommendation invented.
+        source = FixtureRepositorySource(FIXTURES)
+        scan = scan_repository(source, "acme", "stale-fork", now=NOW)
+        broad_only = RepoReport(
+            repository="acme/stale-fork",
+            scan=scan,
+            inspection=None,
+            assessment=None,
+            recommendation=None,
+            recommendation_reasoning="",
+        )
+        board = render_dashboard([broad_only], backlog=[], run=RUN_META)
+        assert "broad scan only" in board.lower()
+        with pytest.raises(ValueError, match="broad"):
+            render_scorecard(broad_only, run=RUN_META)
+
+
+class TestSeverityWeights:
+    def test_severity_weight_order_matches_rank(self) -> None:
+        from pmpe.portfolio.reporting import severity_weight
+
+        weights = [severity_weight(s) for s in Severity]
+        assert weights == sorted(weights, reverse=True)
+        assert severity_weight(Severity.BLOCKING) > severity_weight(Severity.HIGH)


### PR DESCRIPTION
# Pull request

## What changed and why

Milestone 6 of the GitHub Portfolio Auditor V1: the recommendation ladder, the prioritized remediation backlog, and the deterministic scorecard/dashboard renderers. One concern: turning recorded evidence into the operator-facing deliverables.

- **Recommendation ladder** (`recommend`): deterministic product law — AI_SLOP with multiple material findings → REBUILD; any must-surface finding → FIX (**the locked guard: no numeric score overrides a material high-confidence finding**, probed directly with perfect scores in the red suite); stale fork → CONSOLIDATE; zero findings at showcase-grade authority → SHOWCASE; else KEEP_AS_IS. Every verdict carries reasoning naming the finding ids it rests on. All five verdicts exercised: planted fixtures produce REBUILD/FIX/SHOWCASE/CONSOLIDATE; a synthetic quiet repo produces KEEP_AS_IS.
- **Backlog** (`build_backlog`): one traceable entry per finding (AC-PA-006), priced by the contract formula (strategic importance × severity weight × authority impact × confidence ÷ effort); strategic repositories carry the multiplier; deterministic priority-then-id order; must-surface findings can never fall out.
- **Renderers**: markdown from recorded evidence only; run metadata injected (no wall clock); snapshot and policy digests as provenance; broad-scan-only repositories labeled honestly — the dashboard says "broad scan only" and the scorecard refuses rather than inventing a verdict.

## Requirement reference

`products/portfolio-auditor/contract.json` FR-PA-006 (AC-PA-006); prioritization formula in `policy.json`; PD-PA-06/07.

## Architecture impact

Additive: one new module (`reporting.py`); `__init__.py` exports only. No prior module changed.

## Tests added

Red-first (`9fd5e85` → `5b578e3`): `tests/unit/test_portfolio_reporting.py` (21 tests — full ladder incl. the guard probe, backlog traceability/ordering/multipliers, renderer honesty, byte-identical dashboards, injected run metadata, secret-value sweep, severity-weight ordering). Run: `pytest tests/unit/test_portfolio_reporting.py -q`

## Risk level

low — additive, fully gated, renders only upstream-redacted evidence.

## Rollback plan

Revert this PR. Nothing outside the new module depends on reporting yet.

## Evidence

- Full suite: **603 passed** (582 + 21 new); ruff + format clean at the committed head (tree clean); mypy --strict clean (110 files); bandit high clean.
- Independent fresh-context review: running (guard/backlog/renderer probes); verdict posted here. Merge only on APPROVE.
- CI: single attempt per the runner-outage protocol; result recorded here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbzWXg2FgTf5Awh5p81qqA)_