### PR TITLE
fix(backend): restore deterministic Ruff gate

### DIFF
--- a/products/pm-evals-web/backend/pyproject.toml
+++ b/products/pm-evals-web/backend/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.11"
 dependencies = ["pydantic>=2.5", "fastapi>=0.115", "python-multipart>=0.0.9", "uvicorn>=0.30"]
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "mypy>=1.8", "ruff>=0.4", "httpx>=0.27"]
+dev = ["pytest>=8", "mypy>=1.8", "ruff==0.16.0", "httpx>=0.27"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/products/pm-evals-web/backend/src/pm_evals_api/app.py
+++ b/products/pm-evals-web/backend/src/pm_evals_api/app.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.exceptions import RequestValidationError
@@ -250,8 +250,8 @@ def create_app() -> FastAPI:
 
     @app.post("/api/compare", response_model=CompareResponse, responses=validation_responses)
     async def compare(
-        baseline: UploadFile = File(...),
-        candidate: UploadFile = File(...),
+        baseline: Annotated[UploadFile, File()],
+        candidate: Annotated[UploadFile, File()],
         min_matched_traces: int | None = Form(default=None),
     ) -> CompareResponse:
         base_run, cand_run, base_digest, cand_digest = await _parse_pair(baseline, candidate)
@@ -279,8 +279,8 @@ def create_app() -> FastAPI:
         },
     )
     async def report(
-        baseline: UploadFile = File(...),
-        candidate: UploadFile = File(...),
+        baseline: Annotated[UploadFile, File()],
+        candidate: Annotated[UploadFile, File()],
         format: Literal["markdown", "json"] = Form(default="markdown"),
         min_matched_traces: int | None = Form(default=None),
     ) -> Response:

--- a/products/pm-evals-web/backend/src/pm_evals_compare/report.py
+++ b/products/pm-evals-web/backend/src/pm_evals_compare/report.py
@@ -62,11 +62,15 @@ def render_markdown(comparison: Comparison, *, generated_at: str | None = None) 
         "",
         "| | Baseline | Candidate | Net change |",
         "|---|---|---|---|",
-        f"| Pass rate | {_pct(c.baseline_pass_rate)} | {_pct(c.candidate_pass_rate)} "
-        f"| {_pct(c.net_change)} |",
+        (
+            f"| Pass rate | {_pct(c.baseline_pass_rate)} | {_pct(c.candidate_pass_rate)} "
+            f"| {_pct(c.net_change)} |"
+        ),
         "",
-        f"Matched traces: {c.matched_traces} · baseline-only: "
-        f"{len(c.baseline_only_traces)} · candidate-only: {len(c.candidate_only_traces)}",
+        (
+            f"Matched traces: {c.matched_traces} · baseline-only: "
+            f"{len(c.baseline_only_traces)} · candidate-only: {len(c.candidate_only_traces)}"
+        ),
         "",
         "## Criteria",
         "",
@@ -83,9 +87,11 @@ def render_markdown(comparison: Comparison, *, generated_at: str | None = None) 
         "",
         "## Guardrails",
         "",
-        "Policy: **baseline-authoritative** — the baseline governs each "
-        "`min_pass_rate` guardrail; a candidate may strengthen a threshold but "
-        "never weaken it.",
+        (
+            "Policy: **baseline-authoritative** — the baseline governs each "
+            "`min_pass_rate` guardrail; a candidate may strengthen a threshold but "
+            "never weaken it."
+        ),
         "",
         "| Criterion | Baseline | Candidate | Effective | Candidate effect |",
         "|---|---|---|---|---|",

--- a/products/pm-evals-web/backend/tests/test_compare.py
+++ b/products/pm-evals-web/backend/tests/test_compare.py
@@ -13,8 +13,8 @@ from typing import Any
 
 from pm_evals_compare.compare import (
     DEFAULT_MIN_PASS_RATE,
-    Comparison,
     CompareConfig,
+    Comparison,
     GuardrailGovernance,
     check_compatibility,
     compare_runs,


### PR DESCRIPTION
## Outcome

Restore the required `product-backend` lint gate without weakening Ruff or changing API/comparison/report behavior.

## Problem

CI installed unbounded `ruff==0.16.0` and reported four `B008` findings for FastAPI upload defaults, three `ISC004` report-string findings, and one `I001` import-order finding. This blocks Phase 0 PR #75 even though backend tests and strict types pass.

## What changed

- replaced `UploadFile = File(...)` defaults with FastAPI-supported `Annotated[UploadFile, File()]` metadata for both upload endpoints;
- grouped implicit report-string concatenations without changing rendered bytes;
- mechanically sorted the comparison-test import block;
- pinned backend development Ruff to exact version `0.16.0`.

## Why this direction

FastAPI's current request-file guidance prefers `Annotated` and preserves required multipart semantics, so no `B008` exception is needed. Exact pinning prevents a future CI run from silently adopting a different formatter/linter version.

## Scope

Four backend files only: API declaration, report rendering, one test import block, and backend development-tool metadata.

## Non-goals

No Phase 0 files, frontend dependencies, runtime dependency lock, lint suppression, `noqa`, ignores, unsafe fixes, or behavior changes.

## Decisions and trade-offs

- Use supported annotation syntax instead of configuring an exception.
- Pin Ruff exactly for reproducibility; upgrades become deliberate maintenance.
- Reuse existing API/OpenAPI/multipart/report/comparison regression coverage because it already observes every affected behavior.

## Acceptance criteria

- [x] Ruff 0.16.0 reports no `B008`, `ISC004`, `I001`, or other finding.
- [x] FastAPI multipart behavior and committed OpenAPI remain unchanged.
- [x] Deterministic report/comparison behavior remains unchanged.
- [x] Strict backend types pass.
- [x] Strict hash-locked dependency audit passes.
- [x] Fresh read-only complete-diff review returned `APPROVE — NO BLOCKING FINDINGS`.
- [ ] Required GitHub Actions checks pass on this exact head.

## Tests and evidence

Candidate: `e8eeaa6a592d9fd28fa70b1ccd146fd4e9499482`

Passed locally:

- `ruff 0.16.0`;
- `ruff format --check src tests`;
- `ruff check src tests`;
- strict `mypy` (6 source files);
- 84 applicable backend tests on local Python 3.14;
- `pip-audit --require-hashes -r requirements.lock --strict` — no known vulnerabilities.

The one local deselection is the existing Python 3.14-only deep-nesting parser-message assertion. The full 85-test suite runs unmodified in CI on supported workflow Python 3.11; this PR does not touch that parser/test path.

Independent read-only review of the exact four-file diff: `APPROVE — NO BLOCKING FINDINGS`.

## Risks

FastAPI declaration changes could affect required multipart/OpenAPI semantics; existing schema and transport tests cover this directly. The exact Ruff pin requires intentional future upgrades.

## Security and privacy

Upload caps, validation, in-memory processing, no-egress behavior, and strict dependency audit are unchanged.

## Rollback

Revert this PR. No data or runtime migration is involved.

Closes #78