### PR TITLE
fix(ci): route product-frontend by affected paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: "23 3 * * *"
 
 permissions:
   contents: read
@@ -19,9 +21,9 @@ jobs:
           python-version: "3.11"
       - run: pip install ruff
       - name: ruff format
-        run: ruff format --check src tests/unit tests/integration tests/e2e tests/conftest.py
+        run: ruff format --check src tests/unit tests/integration tests/e2e tests/conftest.py scripts/ci/classify_frontend_ci.py
       - name: ruff lint
-        run: ruff check src tests/unit tests/integration tests/e2e tests/conftest.py
+        run: ruff check src tests/unit tests/integration tests/e2e tests/conftest.py scripts/ci/classify_frontend_ci.py
 
   types:
     runs-on: ubuntu-latest
@@ -32,7 +34,7 @@ jobs:
           python-version: "3.11"
       - run: pip install -e ".[dev]"
       - name: mypy --strict
-        run: mypy
+        run: mypy --strict src/pmpe scripts/ci/classify_frontend_ci.py
 
   tests:
     runs-on: ubuntu-latest
@@ -61,9 +63,9 @@ jobs:
           python-version: "3.11"
       - run: pip install -e ".[dev]" pip-audit
       - name: bandit (fail on high severity)
-        run: bandit -r src -q --severity-level high
+        run: bandit -r src scripts/ci/classify_frontend_ci.py -q --severity-level high
       - name: bandit full report (informational)
-        run: bandit -r src -q || true
+        run: bandit -r src scripts/ci/classify_frontend_ci.py -q || true
       - name: dependency audit
         run: pip-audit --strict || echo "::warning::pip-audit reported issues (non-blocking in V1, see SECURITY.md)"
 
@@ -98,25 +100,59 @@ jobs:
         working-directory: products/pm-evals-web/frontend
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: classify frontend impact
+        id: frontend-paths
+        continue-on-error: true
+        working-directory: .
+        run: |
+          python3 scripts/ci/classify_frontend_ci.py \
+            --event-name "${{ github.event_name }}" \
+            --base-sha "${{ github.event.pull_request.base.sha || github.event.before }}" \
+            --head-sha "${{ github.event.pull_request.head.sha || github.sha }}" \
+            --repo-root . \
+            --github-output "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
+        if: steps.frontend-paths.outcome != 'success' || steps.frontend-paths.outputs.applicable != 'false'
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: products/pm-evals-web/frontend/package-lock.json
       - name: install
+        if: steps.frontend-paths.outcome != 'success' || steps.frontend-paths.outputs.applicable != 'false'
         run: npm ci
       - name: dependency audit (high severity blocks)
+        if: steps.frontend-paths.outcome != 'success' || steps.frontend-paths.outputs.applicable != 'false'
         run: npm audit --audit-level=high
       - name: typed client is current with the committed contract
+        if: steps.frontend-paths.outcome != 'success' || steps.frontend-paths.outputs.applicable != 'false'
         run: |
           npm run generate:api-types
           git diff --exit-code src/lib/api-types.gen.ts
       - name: typecheck
+        if: steps.frontend-paths.outcome != 'success' || steps.frontend-paths.outputs.applicable != 'false'
         run: npx tsc --noEmit
       - name: unit and component tests
+        if: steps.frontend-paths.outcome != 'success' || steps.frontend-paths.outputs.applicable != 'false'
         run: npx vitest run
       - name: production build
+        if: steps.frontend-paths.outcome != 'success' || steps.frontend-paths.outputs.applicable != 'false'
         run: npx next build
+      - name: frontend CI routing result
+        if: always()
+        working-directory: .
+        env:
+          CLASSIFIER_APPLICABLE: ${{ steps.frontend-paths.outputs.applicable }}
+          CLASSIFIER_OUTCOME: ${{ steps.frontend-paths.outcome }}
+        run: |
+          if [[ "$CLASSIFIER_OUTCOME" != "success" || "$CLASSIFIER_APPLICABLE" != "false" ]]; then
+            decision="APPLICABLE — full frontend security and validation suite executed"
+          else
+            decision="NOT APPLICABLE — no frontend-affecting paths changed"
+          fi
+          echo "$decision"
+          echo "### $decision" >> "$GITHUB_STEP_SUMMARY"
 
   product-e2e:
     runs-on: ubuntu-latest

--- a/scripts/ci/classify_frontend_ci.py
+++ b/scripts/ci/classify_frontend_ci.py
@@ -19,6 +19,7 @@ _DIFF_EVENTS = frozenset({"pull_request", "push"})
 _RELEVANT_PREFIXES = (
     "products/pm-evals-web/frontend/",
     "products/pm-evals-web/e2e/",
+    "products/pm-evals-web/fixtures/",
 )
 _RELEVANT_FILES = frozenset(
     {

--- a/scripts/ci/classify_frontend_ci.py
+++ b/scripts/ci/classify_frontend_ci.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Fail-closed changed-path routing for the stable product-frontend CI job."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+APPLICABLE_LABEL = "APPLICABLE — full frontend security and validation suite executed"
+NOT_APPLICABLE_LABEL = "NOT APPLICABLE — no frontend-affecting paths changed"
+
+_SHA1 = re.compile(r"^[0-9a-fA-F]{40}$")
+_ALWAYS_APPLICABLE_EVENTS = frozenset({"schedule", "workflow_dispatch"})
+_DIFF_EVENTS = frozenset({"pull_request", "push"})
+_RELEVANT_PREFIXES = (
+    "products/pm-evals-web/frontend/",
+    "products/pm-evals-web/e2e/",
+)
+_RELEVANT_FILES = frozenset(
+    {
+        ".github/workflows/ci.yml",
+        "products/pm-evals-web/backend/openapi.json",
+        "products/pm-evals-web/backend/scripts/export_openapi.py",
+        "products/pm-evals-web/docker-compose.yml",
+        "products/pm-evals-web/scripts/preview.sh",
+        "scripts/ci/classify_frontend_ci.py",
+        "tests/unit/test_frontend_ci_classifier.py",
+        "tests/unit/test_frontend_ci_workflow.py",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Decision:
+    """Auditable applicability decision for one workflow event."""
+
+    applicable: bool
+    reason: str
+    changed_paths: tuple[str, ...] = ()
+
+    @property
+    def label(self) -> str:
+        return APPLICABLE_LABEL if self.applicable else NOT_APPLICABLE_LABEL
+
+
+def _normalize_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    return normalized[2:] if normalized.startswith("./") else normalized
+
+
+def _is_frontend_affecting(path: str) -> bool:
+    return path in _RELEVANT_FILES or path.startswith(_RELEVANT_PREFIXES)
+
+
+def classify_changed_paths(paths: Iterable[str]) -> Decision:
+    """Classify an already discovered set of repository-relative changed paths."""
+
+    changed_paths = tuple(
+        sorted({_normalize_path(path) for path in paths if _normalize_path(path)})
+    )
+    relevant_paths = tuple(path for path in changed_paths if _is_frontend_affecting(path))
+    if relevant_paths:
+        return Decision(
+            applicable=True,
+            reason=f"frontend-affecting paths changed: {', '.join(relevant_paths)}",
+            changed_paths=changed_paths,
+        )
+    return Decision(
+        applicable=False,
+        reason="no frontend-affecting paths changed",
+        changed_paths=changed_paths,
+    )
+
+
+def _valid_sha(value: str) -> bool:
+    return bool(_SHA1.fullmatch(value))
+
+
+def _git_changed_paths(base_sha: str, head_sha: str, repo_root: Path) -> tuple[str, ...]:
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--no-renames",
+            "-z",
+            base_sha,
+            head_sha,
+            "--",
+        ],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    )
+    return tuple(entry.decode("utf-8") for entry in result.stdout.split(b"\0") if entry)
+
+
+def classify_event(
+    event_name: str,
+    base_sha: str,
+    head_sha: str,
+    repo_root: Path,
+) -> Decision:
+    """Classify one Actions event, failing closed for every uncertain state."""
+
+    if event_name in _ALWAYS_APPLICABLE_EVENTS:
+        return Decision(
+            applicable=True,
+            reason=f"{event_name} always runs the full frontend suite",
+        )
+    if event_name not in _DIFF_EVENTS:
+        return Decision(
+            applicable=True,
+            reason=f"unknown event {event_name!r}; fail closed",
+        )
+    if event_name == "push" and base_sha == "0" * 40:
+        return Decision(
+            applicable=True,
+            reason="push before SHA is all zeroes; fail closed",
+        )
+    if not _valid_sha(base_sha) or not _valid_sha(head_sha):
+        return Decision(
+            applicable=True,
+            reason="missing or invalid comparison SHA; fail closed",
+        )
+
+    try:
+        changed_paths = _git_changed_paths(base_sha, head_sha, repo_root)
+        return classify_changed_paths(changed_paths)
+    except (OSError, subprocess.SubprocessError, UnicodeError) as exc:
+        return Decision(
+            applicable=True,
+            reason=f"git comparison failed; fail closed: {type(exc).__name__}",
+        )
+
+
+def _single_line(value: str) -> str:
+    return " ".join(value.splitlines())
+
+
+def _emit(decision: Decision, github_output: Path | None) -> None:
+    print(decision.label)
+    print(f"Reason: {decision.reason}")
+    if decision.changed_paths:
+        print("Changed paths:")
+        for path in decision.changed_paths:
+            print(f"- {path}")
+    if github_output is not None:
+        with github_output.open("a", encoding="utf-8") as output:
+            output.write(f"applicable={str(decision.applicable).lower()}\n")
+            output.write(f"decision={decision.label}\n")
+            output.write(f"reason={_single_line(decision.reason)}\n")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--base-sha", default="")
+    parser.add_argument("--head-sha", default="")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--github-output", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        decision = classify_event(
+            args.event_name,
+            args.base_sha,
+            args.head_sha,
+            args.repo_root,
+        )
+        _emit(decision, args.github_output)
+    except Exception as exc:
+        # A script or output-channel failure must never become NOT APPLICABLE.
+        print(APPLICABLE_LABEL)
+        print(f"Reason: classifier error; fail closed: {type(exc).__name__}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_frontend_ci_classifier.py
+++ b/tests/unit/test_frontend_ci_classifier.py
@@ -54,6 +54,7 @@ def _commit(repo: Path, path: str, content: str) -> str:
         "products/pm-evals-web/frontend/src/lib/api-types.gen.ts",
         "products/pm-evals-web/frontend/Dockerfile",
         "products/pm-evals-web/e2e/tests/journey.spec.ts",
+        "products/pm-evals-web/fixtures/baseline.json",
         "products/pm-evals-web/backend/openapi.json",
         "products/pm-evals-web/backend/scripts/export_openapi.py",
         "products/pm-evals-web/docker-compose.yml",

--- a/tests/unit/test_frontend_ci_classifier.py
+++ b/tests/unit/test_frontend_ci_classifier.py
@@ -1,0 +1,164 @@
+"""Deterministic tests for the monorepo frontend CI path classifier."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from scripts.ci.classify_frontend_ci import (
+    APPLICABLE_LABEL,
+    NOT_APPLICABLE_LABEL,
+    classify_changed_paths,
+    classify_event,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "ci-test@localhost")
+    _git(repo, "config", "user.name", "CI test")
+    return repo
+
+
+def _commit(repo: Path, path: str, content: str) -> str:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+    _git(repo, "add", path)
+    _git(repo, "commit", "-q", "-m", f"change {path}")
+    return _git(repo, "rev-parse", "HEAD")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "products/pm-evals-web/frontend/src/app/page.tsx",
+        "products/pm-evals-web/frontend/package.json",
+        "products/pm-evals-web/frontend/package-lock.json",
+        "products/pm-evals-web/frontend/src/lib/api-types.gen.ts",
+        "products/pm-evals-web/frontend/Dockerfile",
+        "products/pm-evals-web/e2e/tests/journey.spec.ts",
+        "products/pm-evals-web/backend/openapi.json",
+        "products/pm-evals-web/backend/scripts/export_openapi.py",
+        "products/pm-evals-web/docker-compose.yml",
+        "products/pm-evals-web/scripts/preview.sh",
+        ".github/workflows/ci.yml",
+        "scripts/ci/classify_frontend_ci.py",
+        "tests/unit/test_frontend_ci_classifier.py",
+    ],
+)
+def test_frontend_affecting_path_is_applicable(path: str) -> None:
+    decision = classify_changed_paths([path])
+    assert decision.applicable is True
+    assert decision.label == APPLICABLE_LABEL
+    assert decision.changed_paths == (path,)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "schemas/pmos_contract_bundle.schema.json",
+        "src/pmpe/schemas/pmos_contract_manifest.schema.json",
+        "tests/fixtures/pmos/v1/valid_bundle.json",
+        "tests/unit/test_pmos_contract_schema.py",
+        "products/pm-evals-web/backend/src/pm_evals_compare/report.py",
+        "products/pm-evals-web/backend/tests/test_compare.py",
+        "docs/TARGET-ARCHITECTURE.md",
+        "README.md",
+    ],
+)
+def test_unrelated_path_is_not_applicable(path: str) -> None:
+    decision = classify_changed_paths([path])
+    assert decision.applicable is False
+    assert decision.label == NOT_APPLICABLE_LABEL
+    assert decision.changed_paths == (path,)
+
+
+@pytest.mark.parametrize("event_name", ["schedule", "workflow_dispatch"])
+def test_non_diff_security_event_is_always_applicable(
+    event_name: str,
+    tmp_path: Path,
+) -> None:
+    decision = classify_event(event_name, "", "", tmp_path)
+    assert decision.applicable is True
+    assert decision.label == APPLICABLE_LABEL
+    assert event_name in decision.reason
+
+
+def test_unknown_event_fails_closed(tmp_path: Path) -> None:
+    decision = classify_event("repository_dispatch", "", "", tmp_path)
+    assert decision.applicable is True
+    assert decision.label == APPLICABLE_LABEL
+    assert "unknown event" in decision.reason
+
+
+@pytest.mark.parametrize(
+    ("event_name", "base_sha", "head_sha"),
+    [
+        ("pull_request", "", "a" * 40),
+        ("pull_request", "a" * 40, ""),
+        ("pull_request", "not-a-sha", "a" * 40),
+        ("push", "", "a" * 40),
+        ("push", "a" * 40, "not-a-sha"),
+        ("push", "0" * 40, "a" * 40),
+    ],
+)
+def test_missing_invalid_or_zero_comparison_data_fails_closed(
+    event_name: str,
+    base_sha: str,
+    head_sha: str,
+    tmp_path: Path,
+) -> None:
+    decision = classify_event(event_name, base_sha, head_sha, tmp_path)
+    assert decision.applicable is True
+    assert decision.label == APPLICABLE_LABEL
+    assert "fail closed" in decision.reason
+
+
+def test_pull_request_compares_base_to_head_and_can_be_not_applicable(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    base = _commit(repo, "README.md", "base\n")
+    head = _commit(repo, "schemas/pmos_contract_bundle.schema.json", "{}\n")
+
+    decision = classify_event("pull_request", base, head, repo)
+
+    assert decision.applicable is False
+    assert decision.label == NOT_APPLICABLE_LABEL
+    assert decision.changed_paths == ("schemas/pmos_contract_bundle.schema.json",)
+
+
+def test_push_compares_before_to_after_and_detects_frontend_change(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    before = _commit(repo, "README.md", "base\n")
+    after = _commit(repo, "products/pm-evals-web/frontend/src/app/page.tsx", "export {};\n")
+
+    decision = classify_event("push", before, after, repo)
+
+    assert decision.applicable is True
+    assert decision.label == APPLICABLE_LABEL
+    assert decision.changed_paths == ("products/pm-evals-web/frontend/src/app/page.tsx",)
+
+
+def test_git_error_fails_closed(tmp_path: Path) -> None:
+    decision = classify_event("pull_request", "a" * 40, "b" * 40, tmp_path)
+    assert decision.applicable is True
+    assert decision.label == APPLICABLE_LABEL
+    assert "git comparison failed" in decision.reason

--- a/tests/unit/test_frontend_ci_classifier.py
+++ b/tests/unit/test_frontend_ci_classifier.py
@@ -6,11 +6,13 @@ import subprocess
 from pathlib import Path
 
 import pytest
+
 from scripts.ci.classify_frontend_ci import (
     APPLICABLE_LABEL,
     NOT_APPLICABLE_LABEL,
     classify_changed_paths,
     classify_event,
+    main,
 )
 
 
@@ -162,3 +164,44 @@ def test_git_error_fails_closed(tmp_path: Path) -> None:
     assert decision.applicable is True
     assert decision.label == APPLICABLE_LABEL
     assert "git comparison failed" in decision.reason
+
+
+def test_rename_from_frontend_path_remains_applicable(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    old_path = "products/pm-evals-web/frontend/src/app/page.tsx"
+    base = _commit(repo, old_path, "export {};\n")
+    new_path = "archive/page.tsx"
+    (repo / new_path).parent.mkdir(parents=True)
+    _git(repo, "mv", old_path, new_path)
+    _git(repo, "commit", "-q", "-m", "move frontend file")
+    head = _git(repo, "rev-parse", "HEAD")
+
+    decision = classify_event("pull_request", base, head, repo)
+
+    assert decision.applicable is True
+    assert decision.changed_paths == (new_path, old_path)
+
+
+def test_cli_writes_stable_github_outputs(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    github_output = tmp_path / "github-output"
+    exit_code = main(
+        [
+            "--event-name",
+            "workflow_dispatch",
+            "--repo-root",
+            str(tmp_path),
+            "--github-output",
+            str(github_output),
+        ]
+    )
+
+    assert exit_code == 0
+    assert capsys.readouterr().out.splitlines()[0] == APPLICABLE_LABEL
+    assert github_output.read_text().splitlines() == [
+        "applicable=true",
+        f"decision={APPLICABLE_LABEL}",
+        "reason=workflow_dispatch always runs the full frontend suite",
+    ]

--- a/tests/unit/test_frontend_ci_workflow.py
+++ b/tests/unit/test_frontend_ci_workflow.py
@@ -1,0 +1,42 @@
+"""Static policy tests for the stable product-frontend GitHub Actions job."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+APPLICABLE_LABEL = "APPLICABLE — full frontend security and validation suite executed"
+NOT_APPLICABLE_LABEL = "NOT APPLICABLE — no frontend-affecting paths changed"
+FULL_SUITE_CONDITION = (
+    "steps.frontend-paths.outcome != 'success' || "
+    "steps.frontend-paths.outputs.applicable != 'false'"
+)
+
+
+def test_workflow_keeps_stable_job_and_all_frontend_gates() -> None:
+    workflow = CI_WORKFLOW.read_text()
+    assert "\n  product-frontend:\n" in workflow
+    assert "npm ci" in workflow
+    assert "npm audit --audit-level=high" in workflow
+    assert "npm run generate:api-types" in workflow
+    assert "git diff --exit-code src/lib/api-types.gen.ts" in workflow
+    assert "npx tsc --noEmit" in workflow
+    assert "npx vitest run" in workflow
+    assert "npx next build" in workflow
+    assert workflow.count(FULL_SUITE_CONDITION) == 7
+
+
+def test_workflow_always_starts_classifier_and_reports_exact_decision() -> None:
+    workflow = CI_WORKFLOW.read_text()
+    assert "fetch-depth: 0" in workflow
+    assert "scripts/ci/classify_frontend_ci.py" in workflow
+    assert "continue-on-error: true" in workflow
+    assert APPLICABLE_LABEL in workflow
+    assert NOT_APPLICABLE_LABEL in workflow
+    assert "paths-ignore:" not in workflow
+
+
+def test_workflow_has_daily_fail_closed_security_schedule() -> None:
+    workflow = CI_WORKFLOW.read_text()
+    assert "\n  schedule:\n" in workflow
+    assert 'cron: "23 3 * * *"' in workflow
+    assert "workflow_dispatch:" in workflow


### PR DESCRIPTION
Closes #82

Related security blocker: #80  
Unblocks unrelated implementation PR: #81

## Outcome

Keep the stable `product-frontend` check security-enforcing for frontend-affecting or uncertain changes while returning a visible successful `NOT APPLICABLE` result for unrelated monorepo changes.

## Root cause

The frontend job ran unconditionally on every pull request. Its existing high-severity dependency audit therefore blocked schema-only, backend-only, and documentation-only work outside the frontend dependency and build graph.

## What changed

- added a dependency-free, fail-closed changed-path classifier;
- routed `pull_request` and `push` events through exact Git SHA comparisons;
- made `schedule` and `workflow_dispatch` always applicable;
- added a daily `03:23 UTC` full security run;
- kept the `product-frontend` job present for every event;
- preserved all existing frontend install, high-severity audit, generated-client, type, test, and build commands;
- added unit, temporary-Git, rename, CLI-output, and static workflow-policy tests;
- included the classifier in Ruff, strict MyPy, and high-severity Bandit CI checks.

## Scope

Exactly four CI-policy/test files:

- `.github/workflows/ci.yml`
- `scripts/ci/classify_frontend_ci.py`
- `tests/unit/test_frontend_ci_classifier.py`
- `tests/unit/test_frontend_ci_workflow.py`

No frontend dependency, lockfile, source, generated client, runtime, deployment, or product code changed.

## Frontend-affecting path graph

- `products/pm-evals-web/frontend/**`
- `products/pm-evals-web/e2e/**`
- `products/pm-evals-web/fixtures/**`
- `products/pm-evals-web/backend/openapi.json`
- `products/pm-evals-web/backend/scripts/export_openapi.py`
- `products/pm-evals-web/docker-compose.yml`
- `products/pm-evals-web/scripts/preview.sh`
- `.github/workflows/ci.yml`
- the classifier and its two test modules

The paths come from the committed `generate:api-types` command and OpenAPI input/exporter, frontend package/build tree, browser suite, Docker build graph, preview build script, and routing policy itself.

## Decision rules

- PR: diff base SHA to head SHA.
- Push: diff before SHA to after SHA; an all-zero or unavailable before SHA is applicable.
- Schedule/manual dispatch: always applicable.
- Unknown event, missing/invalid SHA, Git error, Unicode decode error, classifier error, or missing classifier output: applicable/fail closed.
- Renames are diffed as delete+add so a relevant old or new path remains applicable.
- No relevant path: `NOT APPLICABLE — no frontend-affecting paths changed`.
- Otherwise: `APPLICABLE — full frontend security and validation suite executed`.

## Security decisions and non-goals

- `npm audit --audit-level=high` is unchanged.
- Issue #80 remains open and blocking for every applicable change.
- No override, exclusion, ignore, allowlist, severity reduction, canary dependency, or generator replacement is introduced.
- `NOT APPLICABLE` means only that the diff is outside the audited dependency boundary; it never means the vulnerability is resolved.

## Red-first evidence

- `930f1e375e895fb604fba0611d66597724b04b2e` added classifier tests only; collection failed because the classifier module did not exist.
- `a06d62945d6251e14a8ea96b3b75d1c67f0b682c` added workflow-policy tests only; all three failed against the unconditional workflow.
- `3b5344af9920985233c9e72a140a8c1daf4d4e3e` implemented the classifier/workflow and turned both suites green.
- `951656f7dad768e1f89ee0fc4ce8a906c0c7d1da` added the reviewer-driven browser-fixture input test and failed exactly that case.
- `354e0290fa0b92d958ada250a3d54dc5e80b80e6` added the shared fixture prefix and turned the case green.

No history was rewritten.

## Exact-head validation

Candidate: `354e0290fa0b92d958ada250a3d54dc5e80b80e6`  
Base: `b2e49d6051274706d76e5099c89c9545bbe2a0b4`

- classifier/workflow suites: PASS, 39 cases;
- PR #81 exact 85-file diff simulation: `NOT APPLICABLE`;
- issue #82 exact four-file diff simulation: `APPLICABLE`;
- schedule, manual dispatch, unknown event, invalid/missing/all-zero SHA, Git error, and rename cases: PASS/fail closed;
- Ruby YAML parse: PASS;
- root Ruff format/lint: PASS;
- strict MyPy: PASS, 101 source files;
- high-severity Bandit: PASS;
- root dependency audit: PASS, no known vulnerabilities;
- unit tests excluding the pre-existing macOS `/tmp` canonicalization assertion: PASS;
- integration and E2E suites: PASS;
- backend strict types, Ruff, and hash-locked dependency audit: PASS;
- full local backend tests: 84 PASS, 1 pre-existing Python 3.14-only nesting-message mismatch; GitHub Python 3.11 is authoritative;
- exact-head GitHub Actions run `30611391123`: nine repository jobs PASS; only the intentionally applicable `product-frontend` high-severity audit fails under #80;
- `git diff --check`: PASS.

## Review

Two fresh separate read-only complete-diff review rounds were run. Round one identified the shared browser-fixture input path; the finding was corrected through the sealed `951656f` → `354e029` RED→GREEN pair. Round two reviewed exact head `354e0290fa0b92d958ada250a3d54dc5e80b80e6` and returned `NO BLOCKING FINDINGS`. Model review is advisory evidence, not formal human approval.

## Bootstrap boundary

This workflow/classifier change correctly classifies itself as frontend-applicable, so the inherited #80 audit remains red until the routing policy reaches `main`. The repository owner’s [one-time solo-maintainer bootstrap exception](https://github.com/Abhillashjadhav/production-engineering-os/pull/83#issuecomment-5140268714) is bound to this exact reviewed head: no frontend dependency/lockfile change, no audit weakening, all classifier/security evidence passing, all nine other CI jobs green, and #80 open. No independent human approval is claimed.

## Risks

The primary risk is a false `NOT APPLICABLE`; broad path boundaries, full-history checkout, rename-as-delete/add behavior, fail-closed event/SHA/Git handling, workflow `continue-on-error` plus applicable-default conditions, and self-classification tests mitigate it.

## Rollback

Revert the focused merge commit to restore unconditional frontend execution. This may re-block unrelated work but does not reduce frontend security coverage; #80 remains the mandatory open remediation path.
