### PR TITLE
Compile PMOS contracts without loss

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,15 @@ description = "PM Production Engineering OS — converts approved PM OS MVP spec
 requires-python = ">=3.11"
 license = "MIT"
 authors = [{ name = "Abhillash Jadhav" }]
-dependencies = ["PyYAML>=6.0"]
+dependencies = ["PyYAML>=6.0", "jsonschema==4.25.1", "rfc8785==0.1.4"]
 
 [project.optional-dependencies]
 dev = [
   "pytest>=8",
-  "jsonschema==4.25.1",
   "ruff>=0.5",
   "mypy>=1.10",
   "bandit>=1.7",
+  "types-jsonschema==4.25.1.20251009",
   "types-PyYAML",
 ]
 

--- a/src/pmpe/contracts/adapters.py
+++ b/src/pmpe/contracts/adapters.py
@@ -1,0 +1,356 @@
+"""Explicit, loss-aware adapters for the repository's PMOS V1, V2, and V3 shapes."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Protocol
+
+
+class SourceFormat(StrEnum):
+    PMOS_V1 = "PMOS_V1"
+    PMOS_V2 = "PMOS_V2"
+    PMOS_V3 = "PMOS_V3"
+
+
+@dataclass(frozen=True)
+class AdapterDiagnostic:
+    code: str
+    source_path: str
+    target_path: str
+    message: str
+    blocking: bool = True
+    source_value: Any = None
+    preserves_source_value: bool = False
+
+
+class AdapterConversionError(ValueError):
+    def __init__(self, diagnostic: AdapterDiagnostic) -> None:
+        self.diagnostic = diagnostic
+        super().__init__(diagnostic.message)
+
+
+@dataclass
+class AdapterOutput:
+    mapped_sections: dict[str, Any] = field(default_factory=dict)
+    source_identity_mappings: dict[str, Any] = field(default_factory=dict)
+    mapped_source_paths: set[str] = field(default_factory=set)
+    diagnostics: list[AdapterDiagnostic] = field(default_factory=list)
+
+
+class SourceAdapter(Protocol):
+    source_format: SourceFormat
+    source_version: str
+    rule_version: str
+    known_top_level_fields: frozenset[str]
+
+    def adapt(self, source: dict[str, Any]) -> AdapterOutput: ...
+
+
+_CANONICAL_TARGETS = {
+    "acceptance_criteria": "/acceptance_criteria",
+    "accessibility_requirements": "/ux/accessibility",
+    "api_contracts": "/api_contracts",
+    "approved_at": "/approvals",
+    "approved_by": "/approvals",
+    "approved_product_decisions": "/product_decisions",
+    "assumptions": "/assumptions",
+    "backend_capabilities": "/backend_capabilities",
+    "binary_release_gates": "/quality_assurance/release_gates",
+    "business_outcome": "/product/outcome/business_outcome",
+    "constraints": "/technical_constraints",
+    "contract_id": "/bundle_id",
+    "contract_status": "/contract_status",
+    "contract_version": "/provenance/source_version",
+    "data_entities": "/data/entities",
+    "dependencies": "/dependencies",
+    "deployment_target": "/release/deployment_target",
+    "desired_outcome": "/product/outcome/customer_outcome",
+    "entities": "/data/entities",
+    "functional_requirements": "/functional_requirements",
+    "golden_cases": "/quality_assurance/golden_cases",
+    "guardrails": "/guardrails",
+    "hypothesis": "/product/hypothesis",
+    "known_risks": "/risks",
+    "leading_metrics": "/metrics/leading",
+    "non_functional_requirements": "/non_functional_requirements",
+    "non_goals": "/scope/non_goals",
+    "north_star_metric": "/metrics/north_stars",
+    "out_of_scope": "/scope/non_goals",
+    "preferred_stack": "/technical_constraints",
+    "primary_journey": "/ux/primary_journey",
+    "priority": "/product/priority",
+    "problem": "/product/problem/statement",
+    "problem_statement": "/product/problem/statement",
+    "product_name": "/product/product_name",
+    "required_approvals": "/required_approvals",
+    "responsive_requirements": "/ux/responsive_requirements",
+    "risks": "/risks",
+    "scope": "/scope/in_scope",
+    "scored_eval_rubric": "/quality_assurance/evaluation_rubrics",
+    "screens": "/ux/screens",
+    "source_digest": "/provenance/source_digest",
+    "spec_version": "/provenance/source_version",
+    "success_metrics": "/metrics/success",
+    "target_platform": "/product/target_platform",
+    "target_user": "/product/target_customers",
+    "ui_states": "/ux/ui_states",
+    "unresolved_questions": "/open_questions",
+    "user_outcome": "/product/outcome/customer_outcome",
+    "user_stories": "/ux/user_stories",
+}
+
+
+def _safe_id(prefix: str, source_id: str) -> str:
+    normalized = re.sub(r"[^A-Z0-9]+", "-", source_id.upper()).strip("-")
+    if not normalized:
+        raise AdapterConversionError(
+            AdapterDiagnostic(
+                code="SOURCE_ID_INVALID",
+                source_path="",
+                target_path="",
+                message="source identifier cannot produce a stable canonical identifier",
+            )
+        )
+    return f"{prefix}-{normalized}"
+
+
+def _insert_identity(
+    target: dict[str, Any],
+    canonical_id: str,
+    value: dict[str, Any],
+    *,
+    source_path: str,
+) -> None:
+    if canonical_id in target:
+        raise AdapterConversionError(
+            AdapterDiagnostic(
+                code="SOURCE_ID_COLLISION",
+                source_path=source_path,
+                target_path=f"/{canonical_id}",
+                message="multiple source identifiers map to one canonical identifier",
+            )
+        )
+    target[canonical_id] = value
+
+
+def _preserve_unmapped(
+    source: dict[str, Any],
+    output: AdapterOutput,
+) -> None:
+    for key in sorted(source):
+        pointer = f"/{key}"
+        if pointer in output.mapped_source_paths:
+            continue
+        output.diagnostics.append(
+            AdapterDiagnostic(
+                code="SOURCE_FIELD_UNMAPPED",
+                source_path=pointer,
+                target_path=_CANONICAL_TARGETS.get(key, ""),
+                message="supplied source truth has no exact mapping in the canonical core",
+                source_value=source[key],
+                preserves_source_value=True,
+            )
+        )
+
+
+class V1Adapter:
+    source_format = SourceFormat.PMOS_V1
+    source_version = "1.0"
+    rule_version = "PMOS-V1-1.0-TO-CANONICAL-1.0.0"
+    known_top_level_fields = frozenset(
+        {
+            "spec_version",
+            "product_name",
+            "problem_statement",
+            "target_user",
+            "user_outcome",
+            "business_outcome",
+            "hypothesis",
+            "scope",
+            "non_goals",
+            "user_stories",
+            "acceptance_criteria",
+            "functional_requirements",
+            "entities",
+            "non_functional_requirements",
+            "success_metrics",
+            "north_star_metric",
+            "leading_metrics",
+            "guardrails",
+            "constraints",
+            "assumptions",
+            "dependencies",
+            "risks",
+            "priority",
+            "target_platform",
+            "preferred_stack",
+            "deployment_target",
+        }
+    )
+
+    def adapt(self, source: dict[str, Any]) -> AdapterOutput:
+        output = AdapterOutput()
+        output.mapped_sections["scope"] = {
+            "in_scope": list(source["scope"]),
+            "non_goals": list(source["non_goals"]),
+        }
+        output.mapped_source_paths.update({"/scope", "/non_goals", "/spec_version"})
+        _preserve_unmapped(source, output)
+        return output
+
+
+class V2Adapter:
+    source_format = SourceFormat.PMOS_V2
+    source_version = "1"
+    rule_version = "PMOS-V2-1-TO-CANONICAL-1.0.0"
+    known_top_level_fields = frozenset(
+        {
+            "contract_version",
+            "contract_id",
+            "contract_status",
+            "approved_at",
+            "approved_by",
+            "source_digest",
+            "product_name",
+            "problem",
+            "target_user",
+            "desired_outcome",
+            "scope",
+            "out_of_scope",
+            "functional_requirements",
+            "acceptance_criteria",
+            "binary_release_gates",
+            "scored_eval_rubric",
+            "golden_cases",
+            "north_star_metric",
+            "leading_metrics",
+            "guardrails",
+            "non_functional_requirements",
+            "known_risks",
+            "approved_product_decisions",
+            "unresolved_questions",
+            "required_approvals",
+        }
+    )
+
+    def adapt(self, source: dict[str, Any]) -> AdapterOutput:
+        output = AdapterOutput()
+        output.mapped_sections["scope"] = {
+            "in_scope": list(source["scope"]),
+            "non_goals": list(source["out_of_scope"]),
+        }
+        output.mapped_source_paths.update(
+            {"/scope", "/out_of_scope", "/contract_id", "/contract_version"}
+        )
+        output.source_identity_mappings["SOURCE-MAP-CONTRACT"] = {
+            "canonical_pointer": "/bundle_id",
+            "source_id": source["contract_id"],
+            "source_pointer": "/contract_id",
+            "source_version": source["contract_version"],
+        }
+        approvals: dict[str, Any] = {}
+        for index, item in enumerate(source["required_approvals"], start=1):
+            approvals[f"APPROVAL-REQ-{index:03d}"] = {
+                "purpose": item["for"],
+                "role": item["role"],
+            }
+        output.mapped_sections["required_approvals"] = approvals
+        output.mapped_source_paths.add("/required_approvals")
+        _preserve_unmapped(source, output)
+        return output
+
+
+class V3Adapter:
+    source_format = SourceFormat.PMOS_V3
+    source_version = "1"
+    rule_version = "PMOS-V3-1-TO-CANONICAL-1.0.0"
+    known_top_level_fields = frozenset(
+        {
+            "contract_version",
+            "contract_id",
+            "contract_status",
+            "approved_at",
+            "approved_by",
+            "product_name",
+            "problem",
+            "target_user",
+            "primary_journey",
+            "screens",
+            "ui_states",
+            "backend_capabilities",
+            "data_entities",
+            "api_contracts",
+            "accessibility_requirements",
+            "responsive_requirements",
+            "binary_release_gates",
+            "guardrails",
+            "deployment_target",
+            "out_of_scope",
+            "unresolved_questions",
+            "required_approvals",
+        }
+    )
+
+    def adapt(self, source: dict[str, Any]) -> AdapterOutput:
+        output = AdapterOutput()
+        output.mapped_source_paths.update({"/contract_id", "/contract_version"})
+        output.source_identity_mappings["SOURCE-MAP-CONTRACT"] = {
+            "canonical_pointer": "/bundle_id",
+            "source_id": source["contract_id"],
+            "source_pointer": "/contract_id",
+            "source_version": source["contract_version"],
+        }
+        capabilities: dict[str, Any] = {}
+        for index, item in enumerate(source["backend_capabilities"]):
+            canonical_id = _safe_id("CAPABILITY", item["capability_id"])
+            _insert_identity(
+                capabilities,
+                canonical_id,
+                {"description": item["description"]},
+                source_path=f"/backend_capabilities/{index}/capability_id",
+            )
+            output.source_identity_mappings[f"SOURCE-MAP-{canonical_id}"] = {
+                "canonical_pointer": f"/backend_capabilities/{canonical_id}",
+                "source_id": item["capability_id"],
+                "source_pointer": f"/backend_capabilities/{index}",
+            }
+        output.mapped_sections["backend_capabilities"] = capabilities
+        output.mapped_source_paths.add("/backend_capabilities")
+        apis: dict[str, Any] = {}
+        for index, item in enumerate(source["api_contracts"]):
+            normalized_source_id = item["api_id"]
+            if normalized_source_id.upper().startswith("API-"):
+                normalized_source_id = normalized_source_id[4:]
+            canonical_id = _safe_id("API", normalized_source_id)
+            _insert_identity(
+                apis,
+                canonical_id,
+                {
+                    "method": item["method"],
+                    "path": item["path"],
+                    "purpose": item["purpose"],
+                },
+                source_path=f"/api_contracts/{index}/api_id",
+            )
+            output.source_identity_mappings[f"SOURCE-MAP-{canonical_id}"] = {
+                "canonical_pointer": f"/api_contracts/{canonical_id}",
+                "source_id": item["api_id"],
+                "source_pointer": f"/api_contracts/{index}",
+            }
+        output.mapped_sections["api_contracts"] = apis
+        output.mapped_source_paths.add("/api_contracts")
+        _preserve_unmapped(source, output)
+        return output
+
+
+class AdapterRegistry:
+    def __init__(self, adapters: tuple[SourceAdapter, ...] | None = None) -> None:
+        registered = adapters or (V1Adapter(), V2Adapter(), V3Adapter())
+        self._adapters = {
+            (adapter.source_format, adapter.source_version): adapter for adapter in registered
+        }
+
+    def get(self, source_format: SourceFormat, source_version: str) -> SourceAdapter | None:
+        return self._adapters.get((source_format, source_version))

--- a/src/pmpe/contracts/canonical.py
+++ b/src/pmpe/contracts/canonical.py
@@ -1,0 +1,195 @@
+"""Strict JSON/YAML admission and RFC 8785 canonicalization for PMOS intake."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from decimal import Decimal
+from typing import Any, NoReturn
+
+import rfc8785
+import yaml
+
+MAX_INTEROPERABLE_INTEGER = 2**53 - 1
+MAX_STRUCTURE_DEPTH = 128
+MAX_STRUCTURE_NODES = 100_000
+
+
+class CanonicalInputError(ValueError):
+    """A safe, classified failure raised before contract format detection."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(message)
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CanonicalInputError("DUPLICATE_OBJECT_KEY", "duplicate object member")
+        result[key] = value
+    return result
+
+
+def _reject_constant(_value: str) -> NoReturn:
+    raise CanonicalInputError("NON_JSON_NUMBER", "non-JSON numeric constant")
+
+
+def _parse_float(token: str) -> float:
+    value = float(token)
+    if not math.isfinite(value):
+        raise CanonicalInputError("NON_JSON_NUMBER", "non-finite numeric value")
+    exact = Decimal(token)
+    if exact == exact.to_integral_value() and abs(exact) > MAX_INTEROPERABLE_INTEGER:
+        raise CanonicalInputError(
+            "NON_JSON_NUMBER",
+            "integer-valued number exceeds the interoperable IEEE-754 range",
+        )
+    return value
+
+
+def _parse_int(token: str) -> int:
+    value = int(token)
+    if abs(value) > MAX_INTEROPERABLE_INTEGER:
+        raise CanonicalInputError(
+            "NON_JSON_NUMBER",
+            "integer exceeds the interoperable IEEE-754 range",
+        )
+    return value
+
+
+def _admit_unicode(
+    value: Any,
+    *,
+    depth: int = 0,
+    nodes: list[int] | None = None,
+) -> Any:
+    budget = nodes if nodes is not None else [0]
+    budget[0] += 1
+    if depth > MAX_STRUCTURE_DEPTH or budget[0] > MAX_STRUCTURE_NODES:
+        raise CanonicalInputError(
+            "INPUT_COMPLEXITY_EXCEEDED",
+            "contract structure exceeds the admitted complexity bound",
+        )
+    if isinstance(value, str):
+        try:
+            normalized = value.encode("utf-16-le", "surrogatepass").decode("utf-16-le")
+        except UnicodeDecodeError as exc:
+            raise CanonicalInputError("INVALID_UNICODE", "unpaired Unicode surrogate") from exc
+        if any(
+            0xFDD0 <= ord(character) <= 0xFDEF or ord(character) & 0xFFFF in {0xFFFE, 0xFFFF}
+            for character in normalized
+        ):
+            raise CanonicalInputError("INVALID_UNICODE", "Unicode noncharacter")
+        return normalized
+    if isinstance(value, dict):
+        normalized_object: dict[str, Any] = {}
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise CanonicalInputError("MALFORMED_SOURCE", "object member names must be strings")
+            normalized_key = _admit_unicode(
+                key,
+                depth=depth + 1,
+                nodes=budget,
+            )
+            if normalized_key in normalized_object:
+                raise CanonicalInputError(
+                    "DUPLICATE_OBJECT_KEY",
+                    "duplicate object member after Unicode normalization",
+                )
+            normalized_object[normalized_key] = _admit_unicode(
+                child,
+                depth=depth + 1,
+                nodes=budget,
+            )
+        return normalized_object
+    if isinstance(value, list):
+        return [_admit_unicode(child, depth=depth + 1, nodes=budget) for child in value]
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    raise CanonicalInputError(
+        "MALFORMED_SOURCE", f"unsupported YAML value type: {type(value).__name__}"
+    )
+
+
+class _DuplicateAwareSafeLoader(yaml.SafeLoader):
+    pass
+
+
+def _construct_mapping(
+    loader: _DuplicateAwareSafeLoader,
+    node: yaml.MappingNode,
+    deep: bool = False,
+) -> dict[str, Any]:
+    loader.flatten_mapping(node)
+    result: dict[str, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if not isinstance(key, str):
+            raise CanonicalInputError(
+                "MALFORMED_SOURCE", "YAML object member names must be strings"
+            )
+        if key in result:
+            raise CanonicalInputError("DUPLICATE_OBJECT_KEY", "duplicate YAML object member")
+        result[key] = loader.construct_object(value_node, deep=deep)
+    return result
+
+
+_DuplicateAwareSafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping,
+)
+
+
+def strict_loads(payload: bytes, content_type: str = "application/json") -> dict[str, Any]:
+    """Parse duplicate-aware JSON/YAML into the RFC 8785 interoperable domain."""
+
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CanonicalInputError("INVALID_UNICODE", "source must be UTF-8") from exc
+    try:
+        if content_type == "application/json":
+            value = json.loads(
+                text,
+                object_pairs_hook=_reject_duplicate_pairs,
+                parse_constant=_reject_constant,
+                parse_float=_parse_float,
+                parse_int=_parse_int,
+            )
+        elif content_type in {"application/yaml", "application/x-yaml"}:
+            value = yaml.load(text, Loader=_DuplicateAwareSafeLoader)
+        else:
+            raise CanonicalInputError("CONTENT_TYPE_REJECTED", "unsupported contract content type")
+    except CanonicalInputError:
+        raise
+    except (json.JSONDecodeError, yaml.YAMLError, RecursionError) as exc:
+        raise CanonicalInputError("MALFORMED_SOURCE", "malformed contract source") from exc
+    try:
+        value = _admit_unicode(value)
+    except RecursionError as exc:
+        raise CanonicalInputError(
+            "INPUT_COMPLEXITY_EXCEEDED",
+            "contract structure exceeds the admitted complexity bound",
+        ) from exc
+    if not isinstance(value, dict):
+        raise CanonicalInputError("MALFORMED_SOURCE", "contract source must be an object")
+    try:
+        canonical_json_bytes(value)
+    except rfc8785.CanonicalizationError as exc:
+        raise CanonicalInputError(
+            "NON_JSON_NUMBER", "source is outside the RFC 8785 interoperable domain"
+        ) from exc
+    return value
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Return RFC 8785 bytes using the pinned, dependency-free implementation."""
+
+    return rfc8785.dumps(value)
+
+
+def canonical_digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json_bytes(value)).hexdigest()

--- a/src/pmpe/contracts/compiler.py
+++ b/src/pmpe/contracts/compiler.py
@@ -1,0 +1,510 @@
+"""Deterministic, loss-aware PMOS legacy compiler and manifest emitter."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from pmpe.config import packaged_schema_dir
+from pmpe.contracts.adapters import (
+    AdapterConversionError,
+    AdapterDiagnostic,
+    AdapterRegistry,
+    SourceAdapter,
+    SourceFormat,
+)
+from pmpe.contracts.canonical import (
+    CanonicalInputError,
+    canonical_digest,
+    canonical_json_bytes,
+    strict_loads,
+)
+
+BUNDLE_SCHEMA_ID = (
+    "https://github.com/Abhillashjadhav/production-engineering-os/"
+    "schemas/pmos_contract_bundle.schema.json"
+)
+MANIFEST_SCHEMA_ID = (
+    "https://github.com/Abhillashjadhav/production-engineering-os/"
+    "schemas/pmos_contract_manifest.schema.json"
+)
+COMPILER_ID = "pmpe-pmos-compiler"
+COMPILER_VERSION = "1.0.0"
+RULE_VERSION = "1.0.0"
+CANONICAL_VERSION = "1.0.0"
+
+_COMPLETE_SECTIONS = {
+    "acceptance_criteria",
+    "api_contracts",
+    "approvals",
+    "assumptions",
+    "backend_capabilities",
+    "data",
+    "dependencies",
+    "extensions",
+    "functional_requirements",
+    "guardrails",
+    "integrations",
+    "metrics",
+    "non_functional_requirements",
+    "observability",
+    "open_questions",
+    "privacy",
+    "product",
+    "product_decisions",
+    "quality_assurance",
+    "release",
+    "required_approvals",
+    "risks",
+    "rollback",
+    "scope",
+    "security",
+    "technical_constraints",
+    "ux",
+}
+
+
+@dataclass(frozen=True)
+class CompilationDiagnostic:
+    code: str
+    source_path: str
+    target_path: str
+    message: str
+    blocking: bool = True
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "blocking": self.blocking,
+            "code": self.code,
+            "message": self.message,
+            "source_path": self.source_path,
+            "target_path": self.target_path,
+        }
+
+
+@dataclass(frozen=True)
+class CompilationResult:
+    source_format: SourceFormat
+    source_version: str
+    bundle: dict[str, Any]
+    manifest: dict[str, Any]
+    bundle_bytes: bytes
+    manifest_bytes: bytes
+    bundle_digest: str
+    manifest_digest: str
+    diagnostics: tuple[CompilationDiagnostic, ...]
+    evidence: dict[str, Any]
+    blocked: bool
+
+    @classmethod
+    def from_artifacts(
+        cls,
+        bundle: dict[str, Any],
+        manifest: dict[str, Any],
+        evidence: dict[str, Any],
+    ) -> CompilationResult:
+        diagnostics = tuple(
+            CompilationDiagnostic(
+                code=item["code"],
+                source_path=item["source_path"],
+                target_path=item["target_path"],
+                message=item["message"],
+                blocking=bool(item["blocking"]),
+            )
+            for item in evidence["diagnostics"]
+        )
+        return cls(
+            source_format=SourceFormat(evidence["source_format"]),
+            source_version=str(evidence["source_version"]),
+            bundle=bundle,
+            manifest=manifest,
+            bundle_bytes=canonical_json_bytes(bundle),
+            manifest_bytes=canonical_json_bytes(manifest),
+            bundle_digest=evidence["bundle_digest"],
+            manifest_digest=evidence["manifest_digest"],
+            diagnostics=diagnostics,
+            evidence=evidence,
+            blocked=bool(diagnostics),
+        )
+
+
+class CompilationBlockedError(ValueError):
+    def __init__(
+        self,
+        diagnostics: list[CompilationDiagnostic],
+        *,
+        bundle: dict[str, Any] | None = None,
+    ) -> None:
+        self.diagnostics = tuple(diagnostics)
+        self.bundle = bundle
+        super().__init__("PMOS compilation blocked: " + "; ".join(d.code for d in diagnostics))
+
+
+def _detect_format(source: dict[str, Any]) -> SourceFormat:
+    if "spec_version" in source and "contract_version" in source:
+        raise CompilationBlocked(
+            [
+                CompilationDiagnostic(
+                    code="AMBIGUOUS_SOURCE_FORMAT",
+                    source_path="",
+                    target_path="",
+                    message="source carries markers from multiple PMOS formats",
+                )
+            ]
+        )
+    markers: list[SourceFormat] = []
+    if "spec_version" in source:
+        markers.append(SourceFormat.PMOS_V1)
+    if "contract_version" in source:
+        v2_markers = {"desired_outcome", "functional_requirements", "scored_eval_rubric"}
+        v3_markers = {"primary_journey", "screens", "api_contracts"}
+        if v2_markers & source.keys():
+            markers.append(SourceFormat.PMOS_V2)
+        if v3_markers & source.keys():
+            markers.append(SourceFormat.PMOS_V3)
+    if len(set(markers)) != 1:
+        raise CompilationBlocked(
+            [
+                CompilationDiagnostic(
+                    code="AMBIGUOUS_SOURCE_FORMAT",
+                    source_path="",
+                    target_path="",
+                    message="source format cannot be selected unambiguously",
+                )
+            ]
+        )
+    return markers[0]
+
+
+def _source_version(source_format: SourceFormat, source: dict[str, Any]) -> str:
+    if source_format is SourceFormat.PMOS_V1:
+        return str(source.get("spec_version", ""))
+    return str(source.get("contract_version", ""))
+
+
+def _load_schema(name: str) -> dict[str, Any]:
+    loaded: dict[str, Any] = json.loads((packaged_schema_dir() / name).read_text())
+    return loaded
+
+
+def _pointer(parts: list[Any]) -> str:
+    if not parts:
+        return ""
+    escaped = [str(part).replace("~", "~0").replace("/", "~1") for part in parts]
+    return "/" + "/".join(escaped)
+
+
+def _unknown_paths(value: Any, schema: Any, parts: list[Any] | None = None) -> list[str]:
+    path = parts or []
+    unknown: list[str] = []
+    if isinstance(value, dict) and isinstance(schema, dict):
+        properties = schema.get("properties")
+        if isinstance(properties, dict):
+            for key in value:
+                if key not in properties:
+                    unknown.append(_pointer([*path, key]))
+            for key in value.keys() & properties.keys():
+                unknown.extend(_unknown_paths(value[key], properties[key], [*path, key]))
+    elif isinstance(value, list) and isinstance(schema, dict):
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(value):
+                unknown.extend(_unknown_paths(item, item_schema, [*path, index]))
+    return unknown
+
+
+def _source_schema(source_format: SourceFormat) -> dict[str, Any]:
+    names = {
+        SourceFormat.PMOS_V1: "mvp_spec.schema.json",
+        SourceFormat.PMOS_V2: "product_decision_contract.schema.json",
+        SourceFormat.PMOS_V3: "fullstack_product_contract.schema.json",
+    }
+    return _load_schema(names[source_format])
+
+
+def _validate_source(
+    source: dict[str, Any],
+    source_format: SourceFormat,
+    adapter: SourceAdapter,
+) -> None:
+    unknown = [_pointer([key]) for key in sorted(set(source) - set(adapter.known_top_level_fields))]
+    schema = _source_schema(source_format)
+    unknown.extend(path for path in _unknown_paths(source, schema) if path not in unknown)
+    if unknown:
+        raise CompilationBlocked(
+            [
+                CompilationDiagnostic(
+                    code="SOURCE_FIELD_UNKNOWN",
+                    source_path=path,
+                    target_path="",
+                    message="source contains a field outside the supported versioned shape",
+                )
+                for path in sorted(set(unknown))
+            ]
+        )
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(source),
+        key=lambda error: list(error.absolute_path),
+    )
+    if errors:
+        raise CompilationBlocked(
+            [
+                CompilationDiagnostic(
+                    code="SOURCE_SCHEMA_INVALID",
+                    source_path=_pointer(list(error.absolute_path)),
+                    target_path="",
+                    message=f"source violates the supported schema rule {error.validator}",
+                )
+                for error in errors
+            ]
+        )
+
+
+def _safe_fragment(value: str) -> str:
+    normalized = re.sub(r"[^A-Z0-9]+", "-", value.upper()).strip("-")
+    return normalized or "SOURCE"
+
+
+def _unresolved(
+    adapter_diagnostics: list[AdapterDiagnostic],
+    mapped_sections: dict[str, Any],
+) -> tuple[dict[str, Any], tuple[CompilationDiagnostic, ...]]:
+    registry: dict[str, Any] = {}
+    diagnostics: list[CompilationDiagnostic] = []
+    for source_index, item in enumerate(adapter_diagnostics, start=1):
+        record: dict[str, Any] = {
+            "blocking": True,
+            "question": "PMOS must approve an exact canonical mapping for this supplied truth.",
+            "reason_code": item.code,
+            "source_pointer": item.source_path,
+            "source_value": copy.deepcopy(item.source_value),
+        }
+        if item.target_path:
+            record["target_pointer"] = item.target_path
+        registry[f"UNRESOLVED-SOURCE-{source_index:03d}"] = record
+        diagnostics.append(
+            CompilationDiagnostic(
+                code=item.code,
+                source_path=item.source_path,
+                target_path=item.target_path,
+                message=item.message,
+            )
+        )
+    for absent_index, section in enumerate(
+        sorted(_COMPLETE_SECTIONS - mapped_sections.keys()),
+        start=1,
+    ):
+        target = f"/{section}"
+        registry[f"UNRESOLVED-ABSENT-{absent_index:03d}"] = {
+            "blocking": True,
+            "question": f"PMOS must supply required canonical product truth for {target}.",
+            "reason_code": "REQUIRED_PRODUCT_TRUTH_ABSENT",
+            "target_pointer": target,
+        }
+        diagnostics.append(
+            CompilationDiagnostic(
+                code="REQUIRED_PRODUCT_TRUTH_ABSENT",
+                source_path="",
+                target_path=target,
+                message="required canonical product truth is absent from the legacy source",
+            )
+        )
+    return registry, tuple(diagnostics)
+
+
+class CanonicalCompiler:
+    def __init__(self, adapters: AdapterRegistry | None = None) -> None:
+        self.adapters = adapters or AdapterRegistry()
+        self._bundle_schema = _load_schema("pmos_contract_bundle.schema.json")
+        self._manifest_schema = _load_schema("pmos_contract_manifest.schema.json")
+
+    def compile(
+        self,
+        payload: bytes,
+        *,
+        content_type: str,
+        received_at: str,
+        source_name: str,
+    ) -> CompilationResult:
+        del source_name
+        try:
+            source = strict_loads(payload, content_type)
+        except CanonicalInputError as exc:
+            raise CompilationBlocked(
+                [
+                    CompilationDiagnostic(
+                        code=exc.code,
+                        source_path="",
+                        target_path="",
+                        message=str(exc),
+                    )
+                ]
+            ) from exc
+        source_format = _detect_format(source)
+        source_version = _source_version(source_format, source)
+        adapter = self.adapters.get(source_format, source_version)
+        if adapter is None:
+            raise CompilationBlocked(
+                [
+                    CompilationDiagnostic(
+                        code="UNSUPPORTED_SOURCE_VERSION",
+                        source_path=(
+                            "/spec_version"
+                            if source_format is SourceFormat.PMOS_V1
+                            else "/contract_version"
+                        ),
+                        target_path="/schema_version",
+                        message="source version has no registered adapter or migration path",
+                    )
+                ]
+            )
+        _validate_source(source, source_format, adapter)
+        source_digest = canonical_digest(source)
+        try:
+            adapted = adapter.adapt(source)
+        except AdapterConversionError as exc:
+            item = exc.diagnostic
+            raise CompilationBlocked(
+                [
+                    CompilationDiagnostic(
+                        code=item.code,
+                        source_path=item.source_path,
+                        target_path=item.target_path,
+                        message=item.message,
+                    )
+                ]
+            ) from exc
+        unresolved, diagnostics = _unresolved(
+            adapted.diagnostics,
+            adapted.mapped_sections,
+        )
+        source_id = str(
+            source.get("contract_id")
+            or f"SOURCE-V1-{source_digest.removeprefix('sha256:')[:16].upper()}"
+        )
+        bundle_fragment = _safe_fragment(source_id)
+        bundle_id = f"BUNDLE-{bundle_fragment}-{source_digest.removeprefix('sha256:')[:12].upper()}"
+        published_at = str(source.get("approved_at") or received_at)
+        source_version_value = source[
+            "spec_version" if source_format is SourceFormat.PMOS_V1 else "contract_version"
+        ]
+        provenance: dict[str, Any] = {
+            "compiler_provenance": {
+                "compiler_id": COMPILER_ID,
+                "compiler_version": COMPILER_VERSION,
+                "input_digest": source_digest,
+            },
+            "published_at": published_at,
+            "source_digest": source_digest,
+            "source_id": source_id,
+            "source_system": "PM_AGENT_OS",
+            "source_version": source_version_value,
+        }
+        if source.get("approved_by"):
+            provenance["source_approved_by"] = source["approved_by"]
+        bundle: dict[str, Any] = {
+            **copy.deepcopy(adapted.mapped_sections),
+            "bundle_id": bundle_id,
+            "bundle_version": CANONICAL_VERSION,
+            "canonical_json_profile": "RFC8785",
+            "contract_status": "DRAFT",
+            "provenance": provenance,
+            "schema_id": BUNDLE_SCHEMA_ID,
+            "schema_version": CANONICAL_VERSION,
+            "source_identity_mappings": copy.deepcopy(adapted.source_identity_mappings),
+            "unresolved_product_truth": unresolved,
+        }
+        self._ensure_valid(bundle, self._bundle_schema, "CANONICAL_BUNDLE_INVALID")
+        bundle_digest = canonical_digest(bundle)
+        manifest: dict[str, Any] = {
+            "approval_digest": canonical_digest(bundle.get("approvals", {})),
+            "approval_digest_scope": "CANONICAL_BUNDLE_APPROVALS_RFC8785",
+            "bundle": {
+                "bundle_id": bundle_id,
+                "bundle_version": CANONICAL_VERSION,
+                "content_digest": bundle_digest,
+                "media_type": "application/json",
+                "member_id": "MEMBER-CANONICAL-BUNDLE",
+                "schema_id": BUNDLE_SCHEMA_ID,
+                "schema_version": CANONICAL_VERSION,
+            },
+            "canonical_json_profile": "RFC8785",
+            "created_at": received_at,
+            "manifest_id": ("MANIFEST-" + source_digest.removeprefix("sha256:")[:20].upper()),
+            "manifest_version": CANONICAL_VERSION,
+            "members": {},
+            "provenance": copy.deepcopy(provenance),
+            "schema_id": MANIFEST_SCHEMA_ID,
+            "schema_version": CANONICAL_VERSION,
+        }
+        manifest["manifest_digest"] = canonical_digest(manifest)
+        self._ensure_valid(manifest, self._manifest_schema, "CANONICAL_MANIFEST_INVALID")
+        evidence = {
+            "bundle_digest": bundle_digest,
+            "compiler_id": COMPILER_ID,
+            "compiler_version": COMPILER_VERSION,
+            "diagnostics": [diagnostic.as_dict() for diagnostic in diagnostics],
+            "manifest_digest": manifest["manifest_digest"],
+            "mapped_source_paths": sorted(adapted.mapped_source_paths),
+            "migration_path": [adapter.rule_version],
+            "rule_version": RULE_VERSION,
+            "source_digest": source_digest,
+            "source_format": source_format.value,
+            "source_version": source_version,
+            "source_version_value": source_version_value,
+        }
+        return CompilationResult(
+            source_format=source_format,
+            source_version=source_version,
+            bundle=bundle,
+            manifest=manifest,
+            bundle_bytes=canonical_json_bytes(bundle),
+            manifest_bytes=canonical_json_bytes(manifest),
+            bundle_digest=bundle_digest,
+            manifest_digest=manifest["manifest_digest"],
+            diagnostics=diagnostics,
+            evidence=evidence,
+            blocked=True,
+        )
+
+    @staticmethod
+    def _ensure_valid(instance: dict[str, Any], schema: dict[str, Any], code: str) -> None:
+        errors = sorted(
+            Draft202012Validator(schema).iter_errors(instance),
+            key=lambda error: (
+                tuple(str(part) for part in error.absolute_path),
+                str(error.validator),
+                error.message,
+            ),
+        )
+        if errors:
+            raise CompilationBlocked(
+                [
+                    CompilationDiagnostic(
+                        code=code,
+                        source_path="",
+                        target_path=_pointer(list(error.absolute_path)),
+                        message=(
+                            f"compiler emitted data outside canonical schema rule {error.validator}"
+                        ),
+                    )
+                    for error in errors
+                ]
+            )
+
+
+CompilationBlocked = CompilationBlockedError
+
+
+__all__ = [
+    "CanonicalCompiler",
+    "CompilationBlocked",
+    "CompilationDiagnostic",
+    "CompilationResult",
+    "SourceFormat",
+]

--- a/src/pmpe/contracts/intake.py
+++ b/src/pmpe/contracts/intake.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 import fcntl
 import hashlib
+import hmac
 import json
 import os
 import re
@@ -18,12 +19,14 @@ import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, replace
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 from pmpe.contracts.canonical import CanonicalInputError, strict_loads
 
 _SAFE_HANDLE = re.compile(r"^[A-Z][A-Z0-9-]{0,127}$")
+_SAFE_METADATA = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$")
 _SECRET_PATTERNS = (
     re.compile(rb"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
     re.compile(rb"\bAKIA[0-9A-Z]{16}\b"),
@@ -43,6 +46,12 @@ class IdProvider(Protocol):
     def new_id(self, kind: str) -> str: ...
 
 
+@dataclass(frozen=True)
+class KeyedFingerprint:
+    key_version: str
+    value: str
+
+
 @runtime_checkable
 class KeyedFingerprintProvider(Protocol):
     """Provider boundary for a non-exportable, versioned keyed digest."""
@@ -50,6 +59,12 @@ class KeyedFingerprintProvider(Protocol):
     key_version: str
 
     def fingerprint(self, domain: str, payload: bytes) -> str: ...
+
+    def candidate_fingerprints(
+        self,
+        domain: str,
+        payload: bytes,
+    ) -> tuple[KeyedFingerprint, ...]: ...
 
 
 @dataclass(frozen=True)
@@ -115,6 +130,8 @@ class IntakeReservation:
     publisher: str
     channel: str
     retry_fingerprint: str
+    retry_key_version: str
+    expires_at: str
     correction_reference: CorrectionReference | None = None
     correction_state: str = "NONE"
     possible_duplicate: bool = False
@@ -209,10 +226,44 @@ class ReconciliationReport:
     blocked_attempt_ids: tuple[str, ...]
 
 
+class IntakeConflictError(RuntimeError):
+    """A retry attempts to change an immutable intake identity."""
+
+
 def _safe_id(value: str, label: str) -> str:
     if not _SAFE_HANDLE.fullmatch(value):
         raise ValueError(f"{label} must be an opaque uppercase identifier")
     return value
+
+
+def _safe_metadata(value: str, label: str) -> str:
+    encoded = value.encode("utf-8", errors="strict")
+    if (
+        not _SAFE_METADATA.fullmatch(value)
+        or any(pattern.search(encoded) for pattern in _SECRET_PATTERNS)
+        or any(pattern.search(encoded) for pattern in _PRIVACY_PATTERNS)
+    ):
+        raise ValueError(f"{label} must be a bounded safe metadata identifier")
+    return value
+
+
+def _parse_utc(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() != timedelta(0):
+        raise ValueError("clock must return an RFC 3339 UTC instant")
+    return parsed.astimezone(UTC)
+
+
+def _after(value: str, seconds: int) -> str:
+    return (
+        (_parse_utc(value) + timedelta(seconds=seconds))
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _expired(expires_at: str, now: str) -> bool:
+    return _parse_utc(now) >= _parse_utc(expires_at)
 
 
 def _decode_correction(value: Any) -> CorrectionReference | None:
@@ -275,12 +326,13 @@ class FileQuarantineStore:
         path = self._path(handle)
         if path.exists():
             raise FileExistsError(f"quarantine object already exists for {handle}")
-        ordinary_digest = str(
-            metadata.get("ordinary_digest") or hashlib.sha256(payload).hexdigest()
-        )
+        ordinary_digest = hashlib.sha256(payload).hexdigest()
         envelope = {
             "cipher_key_version": self.cipher.key_version,
-            "metadata": {**metadata, "ordinary_digest": ordinary_digest},
+            "metadata": {
+                **{key: value for key, value in metadata.items() if key != "ordinary_digest"},
+                "ordinary_digest": ordinary_digest,
+            },
             "payload": base64.b64encode(payload).decode("ascii"),
         }
         cleartext = json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode()
@@ -292,7 +344,14 @@ class FileQuarantineStore:
         encoded = envelope.get("payload")
         if not isinstance(encoded, str):
             raise ValueError("quarantine envelope is malformed")
-        return base64.b64decode(encoded, validate=True)
+        payload = base64.b64decode(encoded, validate=True)
+        ordinary_digest = envelope.get("metadata", {}).get("ordinary_digest")
+        if not isinstance(ordinary_digest, str) or not hmac.compare_digest(
+            ordinary_digest,
+            hashlib.sha256(payload).hexdigest(),
+        ):
+            raise ValueError("quarantine envelope failed its digest binding")
+        return payload
 
     def delete(self, handle: str) -> bool:
         path = self._path(handle)
@@ -320,11 +379,15 @@ class FileIntakeLedger:
         clock: Clock,
         id_provider: IdProvider,
         fingerprint_provider: KeyedFingerprintProvider,
+        reservation_ttl_seconds: int = 300,
     ) -> None:
+        if reservation_ttl_seconds <= 0:
+            raise ValueError("reservation_ttl_seconds must be positive")
         self.root = Path(root)
         self.clock = clock
         self.id_provider = id_provider
         self.fingerprint_provider = fingerprint_provider
+        self.reservation_ttl_seconds = reservation_ttl_seconds
         for name in (
             "reservations",
             "receipts",
@@ -350,14 +413,30 @@ class FileIntakeLedger:
     def _path(self, collection: str, identifier: str) -> Path:
         return self.root / collection / f"{_safe_id(identifier, collection)}.json"
 
-    def _retry_id(self, retry_key: str) -> str:
-        fingerprint = self.fingerprint_provider.fingerprint(
+    def _retry_candidates(
+        self,
+        retry_key: str,
+    ) -> tuple[tuple[KeyedFingerprint, str], ...]:
+        candidates = self.fingerprint_provider.candidate_fingerprints(
             "retry-key",
             retry_key.encode("utf-8"),
         )
-        if not re.fullmatch(r"[0-9a-fA-F]{32,}", fingerprint):
-            raise ValueError("retry-key fingerprint provider returned an unsafe identifier")
-        return f"RETRY-{fingerprint.upper()}"
+        if not candidates:
+            raise ValueError("fingerprint provider returned no governed key versions")
+        values: list[tuple[KeyedFingerprint, str]] = []
+        seen_versions: set[str] = set()
+        for candidate in candidates:
+            if candidate.key_version in seen_versions:
+                raise ValueError("fingerprint provider returned a duplicate key version")
+            if not _SAFE_METADATA.fullmatch(candidate.key_version) or not re.fullmatch(
+                r"[0-9a-fA-F]{32,}", candidate.value
+            ):
+                raise ValueError("fingerprint provider returned unsafe metadata")
+            seen_versions.add(candidate.key_version)
+            values.append((candidate, f"RETRY-{candidate.value.upper()}"))
+        if self.fingerprint_provider.key_version not in seen_versions:
+            raise ValueError("current fingerprint key version is not governed")
+        return tuple(values)
 
     @staticmethod
     def _reservation_from_dict(value: dict[str, Any]) -> IntakeReservation:
@@ -369,6 +448,8 @@ class FileIntakeLedger:
             publisher=value["publisher"],
             channel=value["channel"],
             retry_fingerprint=value["retry_fingerprint"],
+            retry_key_version=value["retry_key_version"],
+            expires_at=value["expires_at"],
             correction_reference=_decode_correction(value.get("correction_reference")),
             correction_state=value.get("correction_state", "NONE"),
             possible_duplicate=bool(value.get("possible_duplicate", False)),
@@ -434,26 +515,53 @@ class FileIntakeLedger:
         channel: str,
         correction_reference: CorrectionReference | None,
     ) -> IntakeReservation:
-        if not retry_key or not publisher or not channel:
-            raise ValueError("retry key, publisher, and channel are required")
-        retry_fingerprint = self._retry_id(retry_key)
-        retry_path = self._path("retry-index", retry_fingerprint)
+        if not retry_key or len(retry_key.encode("utf-8")) > 512:
+            raise ValueError("retry key must be non-empty and bounded")
+        publisher = _safe_metadata(publisher, "publisher safe metadata")
+        channel = _safe_metadata(channel, "channel safe metadata")
+        candidates = self._retry_candidates(retry_key)
+        current_candidate, retry_fingerprint = next(
+            item
+            for item in candidates
+            if item[0].key_version == self.fingerprint_provider.key_version
+        )
         with self._locked():
-            if retry_path.exists():
-                index = json.loads(retry_path.read_text())
-                existing = self.reservation_by_attempt(index["attempt_id"])
+            indexed_attempt_ids = {
+                json.loads(self._path("retry-index", identifier).read_text())["attempt_id"]
+                for _candidate, identifier in candidates
+                if self._path("retry-index", identifier).exists()
+            }
+            if len(indexed_attempt_ids) > 1:
+                raise RuntimeError("retry fingerprints resolve to multiple reservations")
+            if indexed_attempt_ids:
+                existing = self.reservation_by_attempt(indexed_attempt_ids.pop())
                 if existing is None:
                     raise RuntimeError("retry index references a missing reservation")
+                for _candidate, identifier in candidates:
+                    path = self._path("retry-index", identifier)
+                    if not path.exists():
+                        _atomic_json(path, {"attempt_id": existing.attempt_id})
                 return existing
             recovered = [
                 reservation
                 for reservation in self.reservations()
-                if reservation.retry_fingerprint == retry_fingerprint
+                if any(
+                    reservation.retry_key_version == candidate.key_version
+                    and hmac.compare_digest(
+                        reservation.retry_fingerprint,
+                        identifier,
+                    )
+                    for candidate, identifier in candidates
+                )
             ]
             if len(recovered) > 1:
                 raise RuntimeError("retry fingerprint resolves to multiple reservations")
             if recovered:
-                _atomic_json(retry_path, {"attempt_id": recovered[0].attempt_id})
+                for _candidate, identifier in candidates:
+                    _atomic_json(
+                        self._path("retry-index", identifier),
+                        {"attempt_id": recovered[0].attempt_id},
+                    )
                 return recovered[0]
 
             lineage_id: str
@@ -503,11 +611,13 @@ class FileIntakeLedger:
                         and predecessor_disposition.terminal
                         and predecessor_deletion is not None
                         and predecessor_deletion.deleted
+                        and not predecessor.reconciliation_required
                     ):
                         correction_state = "VALID"
                     else:
                         correction_state = "BLOCKED"
 
+            reserved_at = self.clock.now()
             reservation = IntakeReservation(
                 lineage_id=lineage_id,
                 attempt_id=_safe_id(
@@ -518,10 +628,15 @@ class FileIntakeLedger:
                     self.id_provider.new_id("quarantine"),
                     "quarantine handle",
                 ),
-                reserved_at=self.clock.now(),
+                reserved_at=reserved_at,
                 publisher=publisher,
                 channel=channel,
                 retry_fingerprint=retry_fingerprint,
+                retry_key_version=current_candidate.key_version,
+                expires_at=_after(
+                    reserved_at,
+                    self.reservation_ttl_seconds,
+                ),
                 correction_reference=safe_correction_reference,
                 correction_state=correction_state,
                 possible_duplicate=possible_duplicate,
@@ -535,15 +650,20 @@ class FileIntakeLedger:
                 reservation_path,
                 reservation.as_dict(),
             )
-            _atomic_json(retry_path, {"attempt_id": reservation.attempt_id})
+            for _candidate, identifier in candidates:
+                _atomic_json(
+                    self._path("retry-index", identifier),
+                    {"attempt_id": reservation.attempt_id},
+                )
             return reservation
 
     def reservation_for_retry_key(self, retry_key: str) -> IntakeReservation | None:
-        retry_path = self._path("retry-index", self._retry_id(retry_key))
-        if not retry_path.exists():
-            return None
-        value = json.loads(retry_path.read_text())
-        return self.reservation_by_attempt(value["attempt_id"])
+        for _candidate, identifier in self._retry_candidates(retry_key):
+            retry_path = self._path("retry-index", identifier)
+            if retry_path.exists():
+                value = json.loads(retry_path.read_text())
+                return self.reservation_by_attempt(value["attempt_id"])
+        return None
 
     def reservation_by_attempt(self, attempt_id: str) -> IntakeReservation | None:
         path = self._path("reservations", attempt_id)
@@ -577,40 +697,54 @@ class FileIntakeLedger:
         fingerprint: str,
         key_version: str,
     ) -> IntakeReservation:
-        reservation = self.reservation_by_attempt(attempt_id)
-        if reservation is None:
-            raise KeyError(attempt_id)
-        if reservation.payload_fingerprint is not None:
-            if (
-                reservation.payload_fingerprint != fingerprint
-                or reservation.fingerprint_key_version != key_version
-            ):
-                raise RuntimeError("retry key is already bound to a different payload")
-            return reservation
-        updated = replace(
-            reservation,
-            payload_fingerprint=fingerprint,
-            fingerprint_key_version=key_version,
-        )
-        self._update_reservation(updated)
-        return updated
+        if not re.fullmatch(r"[0-9a-fA-F]{32,}", fingerprint) or not _SAFE_METADATA.fullmatch(
+            key_version
+        ):
+            raise ValueError("payload fingerprint metadata is unsafe")
+        with self._locked():
+            reservation = self.reservation_by_attempt(attempt_id)
+            if reservation is None:
+                raise KeyError(attempt_id)
+            if reservation.payload_fingerprint is not None:
+                if (
+                    not hmac.compare_digest(
+                        reservation.payload_fingerprint,
+                        fingerprint,
+                    )
+                    or reservation.fingerprint_key_version != key_version
+                ):
+                    raise IntakeConflictError("retry key is already bound to a different payload")
+                return reservation
+            updated = replace(
+                reservation,
+                payload_fingerprint=fingerprint,
+                fingerprint_key_version=key_version,
+            )
+            self._update_reservation(updated)
+            return updated
 
     def prepare_receipt(self, receipt: IntakeReceipt) -> None:
-        reservation = self.reservation_by_attempt(receipt.attempt_id)
-        if reservation is None:
-            raise KeyError(receipt.attempt_id)
-        self._update_reservation(replace(reservation, pending_receipt=receipt.as_dict()))
+        with self._locked():
+            reservation = self.reservation_by_attempt(receipt.attempt_id)
+            if reservation is None:
+                raise KeyError(receipt.attempt_id)
+            self._update_reservation(replace(reservation, pending_receipt=receipt.as_dict()))
 
     def finalize_receipt(self, receipt: IntakeReceipt) -> None:
-        path = self._path("receipts", receipt.attempt_id)
-        if path.exists():
-            existing = self._receipt_from_dict(json.loads(path.read_text()))
-            if existing != receipt:
-                raise RuntimeError("attempt already has a different intake receipt")
-            return
-        _atomic_json(path, receipt.as_dict())
-        reservation = self.reservation_by_attempt(receipt.attempt_id)
-        if reservation is not None:
+        with self._locked():
+            path = self._path("receipts", receipt.attempt_id)
+            if path.exists():
+                existing = self._receipt_from_dict(json.loads(path.read_text()))
+                if existing != receipt:
+                    raise RuntimeError("attempt already has a different intake receipt")
+                reservation = self.reservation_by_attempt(receipt.attempt_id)
+                if reservation is not None and reservation.pending_receipt is not None:
+                    self._update_reservation(replace(reservation, pending_receipt=None))
+                return
+            reservation = self.reservation_by_attempt(receipt.attempt_id)
+            if reservation is None or reservation.pending_receipt != receipt.as_dict():
+                raise RuntimeError("receipt was not prepared under its reservation")
+            _atomic_json(path, receipt.as_dict())
             self._update_reservation(replace(reservation, pending_receipt=None))
 
     def receipt(self, attempt_id: str) -> IntakeReceipt | None:
@@ -620,21 +754,37 @@ class FileIntakeLedger:
         return self._receipt_from_dict(json.loads(path.read_text()))
 
     def prepare_disposition(self, disposition: IntakeDisposition) -> None:
-        reservation = self.reservation_by_attempt(disposition.attempt_id)
-        if reservation is None:
-            raise KeyError(disposition.attempt_id)
-        self._update_reservation(replace(reservation, pending_disposition=disposition.as_dict()))
+        with self._locked():
+            reservation = self.reservation_by_attempt(disposition.attempt_id)
+            if reservation is None:
+                raise KeyError(disposition.attempt_id)
+            self._update_reservation(
+                replace(
+                    reservation,
+                    pending_disposition=disposition.as_dict(),
+                )
+            )
 
     def write_disposition(self, disposition: IntakeDisposition) -> None:
-        path = self._path("dispositions", disposition.attempt_id)
-        if path.exists():
-            existing = self._disposition_from_dict(json.loads(path.read_text()))
-            if existing != disposition:
-                raise RuntimeError("attempt already has a different terminal disposition")
-            return
-        _atomic_json(path, disposition.as_dict())
-        reservation = self.reservation_by_attempt(disposition.attempt_id)
-        if reservation is not None:
+        with self._locked():
+            path = self._path("dispositions", disposition.attempt_id)
+            if path.exists():
+                existing = self._disposition_from_dict(json.loads(path.read_text()))
+                if existing != disposition:
+                    raise RuntimeError("attempt already has a different terminal disposition")
+                reservation = self.reservation_by_attempt(disposition.attempt_id)
+                if reservation is not None and reservation.pending_disposition is not None:
+                    self._update_reservation(replace(reservation, pending_disposition=None))
+                return
+            reservation = self.reservation_by_attempt(disposition.attempt_id)
+            if reservation is None:
+                raise KeyError(disposition.attempt_id)
+            if (
+                reservation.payload_fingerprint is not None
+                and self.receipt(disposition.attempt_id) is None
+            ):
+                raise RuntimeError("terminal disposition requires a durable intake receipt")
+            _atomic_json(path, disposition.as_dict())
             self._update_reservation(replace(reservation, pending_disposition=None))
 
     def disposition(self, attempt_id: str) -> IntakeDisposition | None:
@@ -644,13 +794,14 @@ class FileIntakeLedger:
         return self._disposition_from_dict(json.loads(path.read_text()))
 
     def write_deletion_attestation(self, attestation: DeletionAttestation) -> None:
-        path = self._path("deletions", attestation.attempt_id)
-        if path.exists():
-            existing = self._deletion_from_dict(json.loads(path.read_text()))
-            if existing != attestation:
-                raise RuntimeError("attempt already has a different deletion attestation")
-            return
-        _atomic_json(path, attestation.as_dict())
+        with self._locked():
+            path = self._path("deletions", attestation.attempt_id)
+            if path.exists():
+                existing = self._deletion_from_dict(json.loads(path.read_text()))
+                if existing != attestation:
+                    raise RuntimeError("attempt already has a different deletion attestation")
+                return
+            _atomic_json(path, attestation.as_dict())
 
     def deletion_attestation(self, attempt_id: str) -> DeletionAttestation | None:
         path = self._path("deletions", attempt_id)
@@ -659,34 +810,49 @@ class FileIntakeLedger:
         return self._deletion_from_dict(json.loads(path.read_text()))
 
     def mark_reconciliation(self, attempt_id: str, reason: str) -> IntakeReservation:
-        reservation = self.reservation_by_attempt(attempt_id)
-        if reservation is None:
-            raise KeyError(attempt_id)
-        updated = replace(
-            reservation,
-            reconciliation_required=True,
-            reconciliation_reason=reason,
-        )
-        self._update_reservation(updated)
-        return updated
+        with self._locked():
+            reservation = self.reservation_by_attempt(attempt_id)
+            if reservation is None:
+                raise KeyError(attempt_id)
+            updated = replace(
+                reservation,
+                reconciliation_required=True,
+                reconciliation_reason=reason,
+            )
+            self._update_reservation(updated)
+            return updated
 
     def clear_reconciliation(self, attempt_id: str) -> IntakeReservation:
-        reservation = self.reservation_by_attempt(attempt_id)
-        if reservation is None:
-            raise KeyError(attempt_id)
-        updated = replace(
-            reservation,
-            reconciliation_required=False,
-            reconciliation_reason=None,
-            pending_receipt=None,
-            pending_disposition=None,
-        )
-        self._update_reservation(updated)
-        return updated
+        with self._locked():
+            reservation = self.reservation_by_attempt(attempt_id)
+            if reservation is None:
+                raise KeyError(attempt_id)
+            updated = replace(
+                reservation,
+                reconciliation_required=False,
+                reconciliation_reason=None,
+                pending_receipt=None,
+                pending_disposition=None,
+            )
+            self._update_reservation(updated)
+            return updated
 
 
 def _finding(code: str, message: str) -> IntakeFinding:
     return IntakeFinding(code=code, message=message)
+
+
+def _contains_pattern(value: Any, patterns: tuple[re.Pattern[bytes], ...]) -> bool:
+    if isinstance(value, str):
+        return any(pattern.search(value.encode("utf-8")) for pattern in patterns)
+    if isinstance(value, dict):
+        return any(
+            _contains_pattern(key, patterns) or _contains_pattern(child, patterns)
+            for key, child in value.items()
+        )
+    if isinstance(value, list):
+        return any(_contains_pattern(child, patterns) for child in value)
+    return False
 
 
 class IntakeCoordinator:
@@ -718,17 +884,73 @@ class IntakeCoordinator:
             channel=request.channel,
             correction_reference=request.correction_reference,
         )
-        payload_fingerprint = self.fingerprint_provider.fingerprint(
+        fingerprint_candidates = self.fingerprint_provider.candidate_fingerprints(
             "payload",
             request.payload,
         )
-        if reservation.payload_fingerprint is not None and (
-            reservation.payload_fingerprint != payload_fingerprint
-            or reservation.fingerprint_key_version != self.fingerprint_provider.key_version
-        ):
+        by_key_version = {
+            candidate.key_version: candidate.value for candidate in fingerprint_candidates
+        }
+        if reservation.payload_fingerprint is None:
+            payload_key_version = self.fingerprint_provider.key_version
+            payload_fingerprint = by_key_version[payload_key_version]
+        else:
+            payload_key_version = reservation.fingerprint_key_version or ""
+            candidate_value = by_key_version.get(payload_key_version)
+            payload_fingerprint = reservation.payload_fingerprint
+            if candidate_value is None or not hmac.compare_digest(
+                payload_fingerprint,
+                candidate_value,
+            ):
+                finding = _finding(
+                    "RETRY_KEY_PAYLOAD_MISMATCH",
+                    "retry key is already bound to different contract bytes",
+                )
+                return IntakeOutcome(
+                    status="SECURITY_BLOCKED",
+                    reservation=reservation,
+                    receipt=self.ledger.receipt(reservation.attempt_id),
+                    disposition=self._disposition(
+                        reservation,
+                        "SECURITY_BLOCKED",
+                        (finding,),
+                    ),
+                    deletion_attestation=self.ledger.deletion_attestation(reservation.attempt_id),
+                    findings=(finding,),
+                    admitted_payload=None,
+                    quarantine_retained=self.quarantine.exists(reservation.quarantine_handle),
+                    replayed=True,
+                )
+        if reservation.reconciliation_required:
             finding = _finding(
-                "RETRY_KEY_PAYLOAD_MISMATCH",
-                "retry key is already bound to different contract bytes",
+                "INTAKE_RECONCILIATION_REQUIRED",
+                "intake cannot resume until reconciliation completes",
+            )
+            return IntakeOutcome(
+                status="SECURITY_BLOCKED",
+                reservation=reservation,
+                receipt=self.ledger.receipt(reservation.attempt_id),
+                disposition=self._disposition(
+                    reservation,
+                    "SECURITY_BLOCKED",
+                    (finding,),
+                ),
+                deletion_attestation=self.ledger.deletion_attestation(reservation.attempt_id),
+                findings=(finding,),
+                admitted_payload=None,
+                quarantine_retained=self.quarantine.exists(reservation.quarantine_handle),
+                replayed=True,
+            )
+        deletion = self.ledger.deletion_attestation(reservation.attempt_id)
+        existing_disposition = self.ledger.disposition(reservation.attempt_id)
+        if deletion is not None and existing_disposition is None:
+            finding = _finding(
+                "TERMINAL_DISPOSITION_MISSING",
+                "deletion completed without a durable terminal disposition",
+            )
+            reservation = self.ledger.mark_reconciliation(
+                reservation.attempt_id,
+                finding.code,
             )
             return IntakeOutcome(
                 status="SECURITY_BLOCKED",
@@ -749,7 +971,28 @@ class IntakeCoordinator:
             reservation = self.ledger.bind_payload(
                 reservation.attempt_id,
                 fingerprint=payload_fingerprint,
-                key_version=self.fingerprint_provider.key_version,
+                key_version=payload_key_version,
+            )
+        except IntakeConflictError:
+            finding = _finding(
+                "RETRY_KEY_PAYLOAD_MISMATCH",
+                "retry key is already bound to different contract bytes",
+            )
+            current = self.ledger.reservation_by_attempt(reservation.attempt_id) or reservation
+            return IntakeOutcome(
+                status="SECURITY_BLOCKED",
+                reservation=current,
+                receipt=self.ledger.receipt(current.attempt_id),
+                disposition=self._disposition(
+                    current,
+                    "SECURITY_BLOCKED",
+                    (finding,),
+                ),
+                deletion_attestation=self.ledger.deletion_attestation(current.attempt_id),
+                findings=(finding,),
+                admitted_payload=None,
+                quarantine_retained=self.quarantine.exists(current.quarantine_handle),
+                replayed=True,
             )
         except Exception:
             return self._block_before_receipt(
@@ -759,14 +1002,43 @@ class IntakeCoordinator:
                     "durable retry-key payload binding failed and requires reconciliation",
                 ),
             )
-        existing_disposition = self.ledger.disposition(reservation.attempt_id)
         if existing_disposition is not None and existing_disposition.terminal:
+            durable_receipt = self.ledger.receipt(reservation.attempt_id)
+            durable_deletion = self.ledger.deletion_attestation(reservation.attempt_id)
+            if (
+                (reservation.payload_fingerprint is not None and durable_receipt is None)
+                or durable_deletion is None
+                or not durable_deletion.deleted
+            ):
+                finding = _finding(
+                    "TERMINAL_EVIDENCE_INCOMPLETE",
+                    "terminal intake evidence requires reconciliation",
+                )
+                reservation = self.ledger.mark_reconciliation(
+                    reservation.attempt_id,
+                    finding.code,
+                )
+                return IntakeOutcome(
+                    status="SECURITY_BLOCKED",
+                    reservation=reservation,
+                    receipt=durable_receipt,
+                    disposition=self._disposition(
+                        reservation,
+                        "SECURITY_BLOCKED",
+                        (finding,),
+                    ),
+                    deletion_attestation=durable_deletion,
+                    findings=(finding,),
+                    admitted_payload=None,
+                    quarantine_retained=self.quarantine.exists(reservation.quarantine_handle),
+                    replayed=True,
+                )
             return IntakeOutcome(
                 status=existing_disposition.status,
                 reservation=reservation,
-                receipt=self.ledger.receipt(reservation.attempt_id),
+                receipt=durable_receipt,
                 disposition=existing_disposition,
-                deletion_attestation=self.ledger.deletion_attestation(reservation.attempt_id),
+                deletion_attestation=durable_deletion,
                 findings=existing_disposition.findings,
                 admitted_payload=None,
                 quarantine_retained=self.quarantine.exists(reservation.quarantine_handle),
@@ -789,10 +1061,10 @@ class IntakeCoordinator:
                     "correction predecessor lacks proven deletion and terminal disposition",
                 ),
             )
-            receipt = self._receipt(
-                request,
+            receipt = self.ledger.receipt(reservation.attempt_id) or self._receipt(
                 reservation,
                 payload_fingerprint,
+                payload_key_version,
             )
             return self._complete_without_payload(
                 reservation,
@@ -821,14 +1093,15 @@ class IntakeCoordinator:
                     ),
                 )
 
-        receipt = self._receipt(
-            request,
+        receipt = self.ledger.receipt(reservation.attempt_id) or self._receipt(
             reservation,
             payload_fingerprint,
+            payload_key_version,
         )
         try:
-            self.ledger.prepare_receipt(receipt)
-            self.ledger.finalize_receipt(receipt)
+            if self.ledger.receipt(reservation.attempt_id) is None:
+                self.ledger.prepare_receipt(receipt)
+                self.ledger.finalize_receipt(receipt)
         except Exception:
             blocked = _finding(
                 "RECEIPT_FINALIZATION_FAILED",
@@ -901,7 +1174,7 @@ class IntakeCoordinator:
                     )
             if not findings:
                 try:
-                    strict_loads(request.payload, request.content_type)
+                    parsed = strict_loads(request.payload, request.content_type)
                 except CanonicalInputError:
                     findings.append(
                         _finding(
@@ -909,31 +1182,104 @@ class IntakeCoordinator:
                             "input failed strict structural admission",
                         )
                     )
+                else:
+                    if _contains_pattern(parsed, _SECRET_PATTERNS):
+                        findings.append(
+                            _finding(
+                                "SECRET_DETECTED",
+                                "decoded input matched a prohibited secret pattern",
+                            )
+                        )
+                    elif _contains_pattern(parsed, _PRIVACY_PATTERNS):
+                        findings.append(
+                            _finding(
+                                "PRIVACY_PATTERN_DETECTED",
+                                "decoded input matched a privacy-sensitive pattern",
+                            )
+                        )
 
-        status = "REJECTED" if findings else "ADMITTED"
-        return self._finalize(
+        if findings:
+            return self._finalize(
+                reservation,
+                receipt,
+                "REJECTED",
+                tuple(findings),
+                admitted_payload=None,
+            )
+        pending_disposition = self._disposition(
             reservation,
-            receipt,
-            status,
-            tuple(findings),
-            admitted_payload=request.payload if status == "ADMITTED" else None,
+            "VALIDATED_PENDING_COMPILATION",
+            (),
+            terminal=False,
+        )
+        return IntakeOutcome(
+            status="VALIDATED_PENDING_COMPILATION",
+            reservation=reservation,
+            receipt=receipt,
+            disposition=pending_disposition,
+            deletion_attestation=None,
+            findings=(),
+            admitted_payload=request.payload,
+            quarantine_retained=True,
+        )
+
+    def load_validated_payload(self, outcome: IntakeOutcome) -> bytes:
+        if (
+            outcome.status != "VALIDATED_PENDING_COMPILATION"
+            or outcome.receipt is None
+            or self.ledger.receipt(outcome.reservation.attempt_id) != outcome.receipt
+        ):
+            raise RuntimeError("intake outcome is not a durable validated handoff")
+        payload = self.quarantine.read(outcome.reservation.quarantine_handle)
+        candidates = self.fingerprint_provider.candidate_fingerprints(
+            "payload",
+            payload,
+        )
+        candidate = next(
+            (item for item in candidates if item.key_version == outcome.receipt.key_version),
+            None,
+        )
+        if candidate is None or not hmac.compare_digest(
+            candidate.value,
+            outcome.receipt.fingerprint,
+        ):
+            self.ledger.mark_reconciliation(
+                outcome.reservation.attempt_id,
+                "QUARANTINE_FINGERPRINT_MISMATCH",
+            )
+            raise RuntimeError("validated quarantine handoff failed fingerprint binding")
+        return payload
+
+    def finalize_admission(self, outcome: IntakeOutcome) -> IntakeOutcome:
+        if (
+            outcome.status != "VALIDATED_PENDING_COMPILATION"
+            or outcome.receipt is None
+            or self.ledger.receipt(outcome.reservation.attempt_id) != outcome.receipt
+        ):
+            raise RuntimeError("only a durable validated handoff can be admitted")
+        return self._finalize(
+            outcome.reservation,
+            outcome.receipt,
+            "ADMITTED",
+            (),
+            admitted_payload=None,
         )
 
     def _receipt(
         self,
-        request: IntakeRequest,
         reservation: IntakeReservation,
         payload_fingerprint: str,
+        payload_key_version: str,
     ) -> IntakeReceipt:
         return IntakeReceipt(
             lineage_id=reservation.lineage_id,
             attempt_id=reservation.attempt_id,
             received_at=self.clock.now(),
-            publisher=request.publisher,
-            channel=request.channel,
+            publisher=reservation.publisher,
+            channel=reservation.channel,
             correction_reference=reservation.correction_reference,
             quarantine_handle=reservation.quarantine_handle,
-            key_version=self.fingerprint_provider.key_version,
+            key_version=payload_key_version,
             fingerprint=payload_fingerprint,
         )
 
@@ -942,6 +1288,8 @@ class IntakeCoordinator:
         reservation: IntakeReservation,
         status: str,
         findings: tuple[IntakeFinding, ...],
+        *,
+        terminal: bool = True,
     ) -> IntakeDisposition:
         return IntakeDisposition(
             lineage_id=reservation.lineage_id,
@@ -949,6 +1297,7 @@ class IntakeCoordinator:
             status=status,
             recorded_at=self.clock.now(),
             findings=findings,
+            terminal=terminal,
         )
 
     def _complete_without_payload(
@@ -959,8 +1308,9 @@ class IntakeCoordinator:
         findings: tuple[IntakeFinding, ...],
     ) -> IntakeOutcome:
         try:
-            self.ledger.prepare_receipt(receipt)
-            self.ledger.finalize_receipt(receipt)
+            if self.ledger.receipt(reservation.attempt_id) is None:
+                self.ledger.prepare_receipt(receipt)
+                self.ledger.finalize_receipt(receipt)
         except Exception:
             blocked = _finding(
                 "RECEIPT_FINALIZATION_FAILED",
@@ -970,6 +1320,21 @@ class IntakeCoordinator:
             reservation = self.ledger.mark_reconciliation(
                 reservation.attempt_id,
                 blocked.code,
+            )
+            return IntakeOutcome(
+                status="SECURITY_BLOCKED",
+                reservation=reservation,
+                receipt=receipt,
+                disposition=self._disposition(
+                    reservation,
+                    "SECURITY_BLOCKED",
+                    findings,
+                    terminal=False,
+                ),
+                deletion_attestation=None,
+                findings=findings,
+                admitted_payload=None,
+                quarantine_retained=self.quarantine.exists(reservation.quarantine_handle),
             )
         return self._finalize(
             reservation,
@@ -1117,20 +1482,53 @@ class IntakeReconciler:
         blocked: list[str] = []
         for reservation in self.ledger.reservations():
             disposition = self.ledger.disposition(reservation.attempt_id)
-            if disposition is not None and disposition.terminal:
+            receipt = self.ledger.receipt(reservation.attempt_id)
+            deletion = self.ledger.deletion_attestation(reservation.attempt_id)
+            invariants_complete = bool(
+                disposition is not None
+                and disposition.terminal
+                and deletion is not None
+                and deletion.deleted
+                and (reservation.payload_fingerprint is None or receipt is not None)
+            )
+            if invariants_complete:
                 if reservation.reconciliation_required:
                     self.ledger.clear_reconciliation(reservation.attempt_id)
                 continue
+            unsafe_terminal = disposition is not None and disposition.terminal
+            if (
+                not reservation.reconciliation_required
+                and not unsafe_terminal
+                and not _expired(reservation.expires_at, self.clock.now())
+            ):
+                continue
             try:
-                if reservation.pending_receipt is not None:
+                if receipt is None and reservation.pending_receipt is not None:
                     self.ledger.finalize_receipt(
                         self.ledger._receipt_from_dict(reservation.pending_receipt)
                     )
+                elif (
+                    receipt is None
+                    and reservation.payload_fingerprint is not None
+                    and reservation.fingerprint_key_version is not None
+                ):
+                    recovered_receipt = IntakeReceipt(
+                        lineage_id=reservation.lineage_id,
+                        attempt_id=reservation.attempt_id,
+                        received_at=reservation.reserved_at,
+                        publisher=reservation.publisher,
+                        channel=reservation.channel,
+                        quarantine_handle=reservation.quarantine_handle,
+                        key_version=reservation.fingerprint_key_version,
+                        fingerprint=reservation.payload_fingerprint,
+                        correction_reference=reservation.correction_reference,
+                    )
+                    self.ledger.prepare_receipt(recovered_receipt)
+                    self.ledger.finalize_receipt(recovered_receipt)
                 deleted = self.quarantine.delete(reservation.quarantine_handle)
                 if not deleted:
                     raise OSError("quarantine deletion remains unresolved")
-                attestation = self.ledger.deletion_attestation(reservation.attempt_id)
-                if attestation is None:
+                if deletion is None:
                     self.ledger.write_deletion_attestation(
                         DeletionAttestation(
                             lineage_id=reservation.lineage_id,
@@ -1140,24 +1538,39 @@ class IntakeReconciler:
                             deleted_at=self.clock.now(),
                         )
                     )
-                pending = reservation.pending_disposition
-                if pending is None:
-                    finding = _finding(
-                        "INTAKE_RECONCILED_SECURITY_BLOCK",
-                        "interrupted intake was reconciled without resuming admission",
-                    )
-                    terminal = IntakeDisposition(
-                        lineage_id=reservation.lineage_id,
-                        attempt_id=reservation.attempt_id,
-                        status="SECURITY_BLOCKED",
-                        recorded_at=self.clock.now(),
-                        findings=(finding,),
-                    )
-                else:
-                    terminal = self.ledger._disposition_from_dict(pending)
-                    if terminal.status != "SECURITY_BLOCKED":
-                        terminal = replace(terminal, status="SECURITY_BLOCKED")
-                self.ledger.write_disposition(terminal)
+                if disposition is None:
+                    pending = reservation.pending_disposition
+                    if pending is None:
+                        finding = _finding(
+                            "INTAKE_RECONCILED_SECURITY_BLOCK",
+                            "interrupted intake was reconciled without resuming admission",
+                        )
+                        terminal = IntakeDisposition(
+                            lineage_id=reservation.lineage_id,
+                            attempt_id=reservation.attempt_id,
+                            status="SECURITY_BLOCKED",
+                            recorded_at=self.clock.now(),
+                            findings=(finding,),
+                        )
+                    else:
+                        terminal = self.ledger._disposition_from_dict(pending)
+                        if terminal.status != "SECURITY_BLOCKED":
+                            terminal = replace(
+                                terminal,
+                                status="SECURITY_BLOCKED",
+                            )
+                    self.ledger.write_disposition(terminal)
+                durable_receipt = self.ledger.receipt(reservation.attempt_id)
+                durable_deletion = self.ledger.deletion_attestation(reservation.attempt_id)
+                durable_disposition = self.ledger.disposition(reservation.attempt_id)
+                if (
+                    (reservation.payload_fingerprint is not None and durable_receipt is None)
+                    or durable_deletion is None
+                    or not durable_deletion.deleted
+                    or durable_disposition is None
+                    or not durable_disposition.terminal
+                ):
+                    raise RuntimeError("reconciliation invariants remain incomplete")
                 self.ledger.clear_reconciliation(reservation.attempt_id)
                 resolved.append(reservation.attempt_id)
             except Exception:
@@ -1175,6 +1588,7 @@ __all__ = [
     "FileIntakeLedger",
     "FileQuarantineStore",
     "IntakeCoordinator",
+    "IntakeConflictError",
     "IntakeDisposition",
     "IntakeFinding",
     "IntakeOutcome",
@@ -1182,6 +1596,7 @@ __all__ = [
     "IntakeReconciler",
     "IntakeRequest",
     "IntakeReservation",
+    "KeyedFingerprint",
     "KeyedFingerprintProvider",
     "MalwareScanResult",
     "MalwareScanner",

--- a/src/pmpe/contracts/intake.py
+++ b/src/pmpe/contracts/intake.py
@@ -1,0 +1,1191 @@
+"""Fail-closed PMOS contract intake with durable, reconcilable local state.
+
+The file-backed implementations in this module are deterministic reference
+implementations. Cryptography, keyed fingerprints, malware scanning, clocks,
+and opaque ID generation remain provider boundaries so a deployment can bind
+them to its approved services without changing the intake state machine.
+"""
+
+from __future__ import annotations
+
+import base64
+import fcntl
+import hashlib
+import json
+import os
+import re
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from pmpe.contracts.canonical import CanonicalInputError, strict_loads
+
+_SAFE_HANDLE = re.compile(r"^[A-Z][A-Z0-9-]{0,127}$")
+_SECRET_PATTERNS = (
+    re.compile(rb"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(rb"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(
+        rb"(?i)\b(?:api[_-]?key|access[_-]?token|client[_-]?secret|password)"
+        rb"\s*[:=]\s*[\"']?[A-Za-z0-9_./+=-]{12,}"
+    ),
+)
+_PRIVACY_PATTERNS = (re.compile(rb"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b"),)
+
+
+class Clock(Protocol):
+    def now(self) -> str: ...
+
+
+class IdProvider(Protocol):
+    def new_id(self, kind: str) -> str: ...
+
+
+@runtime_checkable
+class KeyedFingerprintProvider(Protocol):
+    """Provider boundary for a non-exportable, versioned keyed digest."""
+
+    key_version: str
+
+    def fingerprint(self, domain: str, payload: bytes) -> str: ...
+
+
+@dataclass(frozen=True)
+class MalwareScanResult:
+    clean: bool
+    engine: str
+    signature_version: str
+    finding_code: str | None = None
+
+
+@runtime_checkable
+class MalwareScanner(Protocol):
+    def scan(self, payload: bytes) -> MalwareScanResult: ...
+
+
+@runtime_checkable
+class QuarantineCipher(Protocol):
+    """Encryption provider boundary; key custody is intentionally external."""
+
+    key_version: str
+
+    def encrypt(self, payload: bytes) -> bytes: ...
+
+    def decrypt(self, payload: bytes) -> bytes: ...
+
+
+@runtime_checkable
+class QuarantineStore(Protocol):
+    def put(self, handle: str, payload: bytes, metadata: dict[str, Any]) -> None: ...
+
+    def read(self, handle: str) -> bytes: ...
+
+    def delete(self, handle: str) -> bool: ...
+
+    def exists(self, handle: str) -> bool: ...
+
+
+@dataclass(frozen=True)
+class CorrectionReference:
+    lineage_id: str
+    attempt_id: str
+
+    def as_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class IntakeRequest:
+    retry_key: str
+    payload: bytes
+    content_type: str
+    publisher: str
+    channel: str
+    correction_reference: CorrectionReference | None = None
+
+
+@dataclass(frozen=True)
+class IntakeReservation:
+    lineage_id: str
+    attempt_id: str
+    quarantine_handle: str
+    reserved_at: str
+    publisher: str
+    channel: str
+    retry_fingerprint: str
+    correction_reference: CorrectionReference | None = None
+    correction_state: str = "NONE"
+    possible_duplicate: bool = False
+    reconciliation_required: bool = False
+    reconciliation_reason: str | None = None
+    payload_fingerprint: str | None = None
+    fingerprint_key_version: str | None = None
+    pending_receipt: dict[str, Any] | None = None
+    pending_disposition: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["correction_reference"] = (
+            self.correction_reference.as_dict() if self.correction_reference else None
+        )
+        return value
+
+
+@dataclass(frozen=True)
+class IntakeReceipt:
+    lineage_id: str
+    attempt_id: str
+    received_at: str
+    publisher: str
+    channel: str
+    quarantine_handle: str
+    key_version: str
+    fingerprint: str
+    correction_reference: CorrectionReference | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["correction_reference"] = (
+            self.correction_reference.as_dict() if self.correction_reference else None
+        )
+        return value
+
+
+@dataclass(frozen=True)
+class IntakeFinding:
+    code: str
+    message: str
+    blocking: bool = True
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DeletionAttestation:
+    lineage_id: str
+    attempt_id: str
+    quarantine_handle: str
+    deleted: bool
+    deleted_at: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class IntakeDisposition:
+    lineage_id: str
+    attempt_id: str
+    status: str
+    recorded_at: str
+    findings: tuple[IntakeFinding, ...] = ()
+    terminal: bool = True
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["findings"] = [finding.as_dict() for finding in self.findings]
+        return value
+
+
+@dataclass(frozen=True)
+class IntakeOutcome:
+    status: str
+    reservation: IntakeReservation
+    receipt: IntakeReceipt | None
+    disposition: IntakeDisposition
+    deletion_attestation: DeletionAttestation | None
+    findings: tuple[IntakeFinding, ...]
+    admitted_payload: bytes | None
+    quarantine_retained: bool
+    replayed: bool = False
+
+
+@dataclass(frozen=True)
+class ReconciliationReport:
+    resolved_attempt_ids: tuple[str, ...]
+    blocked_attempt_ids: tuple[str, ...]
+
+
+def _safe_id(value: str, label: str) -> str:
+    if not _SAFE_HANDLE.fullmatch(value):
+        raise ValueError(f"{label} must be an opaque uppercase identifier")
+    return value
+
+
+def _decode_correction(value: Any) -> CorrectionReference | None:
+    if value is None:
+        return None
+    return CorrectionReference(
+        lineage_id=str(value["lineage_id"]),
+        attempt_id=str(value["attempt_id"]),
+    )
+
+
+def _atomic_write(path: Path, data: bytes, *, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, mode)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    _atomic_write(
+        path,
+        (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode(),
+    )
+
+
+class FileQuarantineStore:
+    """Access-isolated, bounded encrypted quarantine reference implementation."""
+
+    def __init__(self, root: Path, *, cipher: QuarantineCipher, max_bytes: int) -> None:
+        if max_bytes <= 0:
+            raise ValueError("max_bytes must be positive")
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(self.root, 0o700)
+        self.cipher = cipher
+        self.max_bytes = max_bytes
+
+    def _path(self, handle: str) -> Path:
+        return self.root / f"{_safe_id(handle, 'quarantine handle')}.sealed"
+
+    def put(self, handle: str, payload: bytes, metadata: dict[str, Any]) -> None:
+        if len(payload) > self.max_bytes:
+            raise ValueError("quarantine payload exceeds configured bound")
+        path = self._path(handle)
+        if path.exists():
+            raise FileExistsError(f"quarantine object already exists for {handle}")
+        ordinary_digest = str(
+            metadata.get("ordinary_digest") or hashlib.sha256(payload).hexdigest()
+        )
+        envelope = {
+            "cipher_key_version": self.cipher.key_version,
+            "metadata": {**metadata, "ordinary_digest": ordinary_digest},
+            "payload": base64.b64encode(payload).decode("ascii"),
+        }
+        cleartext = json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode()
+        _atomic_write(path, self.cipher.encrypt(cleartext))
+
+    def read(self, handle: str) -> bytes:
+        cleartext = self.cipher.decrypt(self._path(handle).read_bytes())
+        envelope = json.loads(cleartext)
+        encoded = envelope.get("payload")
+        if not isinstance(encoded, str):
+            raise ValueError("quarantine envelope is malformed")
+        return base64.b64decode(encoded, validate=True)
+
+    def delete(self, handle: str) -> bool:
+        path = self._path(handle)
+        if not path.exists():
+            return True
+        path.unlink()
+        directory_descriptor = os.open(self.root, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+        return not path.exists()
+
+    def exists(self, handle: str) -> bool:
+        return self._path(handle).exists()
+
+
+class FileIntakeLedger:
+    """Safe-metadata reservation, receipt, disposition, and deletion ledger."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        clock: Clock,
+        id_provider: IdProvider,
+        fingerprint_provider: KeyedFingerprintProvider,
+    ) -> None:
+        self.root = Path(root)
+        self.clock = clock
+        self.id_provider = id_provider
+        self.fingerprint_provider = fingerprint_provider
+        for name in (
+            "reservations",
+            "receipts",
+            "dispositions",
+            "deletions",
+            "retry-index",
+        ):
+            directory = self.root / name
+            directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+            os.chmod(directory, 0o700)
+        self._lock_path = self.root / ".ledger.lock"
+        self._lock_path.touch(mode=0o600, exist_ok=True)
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        with self._lock_path.open("rb") as stream:
+            fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+    def _path(self, collection: str, identifier: str) -> Path:
+        return self.root / collection / f"{_safe_id(identifier, collection)}.json"
+
+    def _retry_id(self, retry_key: str) -> str:
+        fingerprint = self.fingerprint_provider.fingerprint(
+            "retry-key",
+            retry_key.encode("utf-8"),
+        )
+        if not re.fullmatch(r"[0-9a-fA-F]{32,}", fingerprint):
+            raise ValueError("retry-key fingerprint provider returned an unsafe identifier")
+        return f"RETRY-{fingerprint.upper()}"
+
+    @staticmethod
+    def _reservation_from_dict(value: dict[str, Any]) -> IntakeReservation:
+        return IntakeReservation(
+            lineage_id=value["lineage_id"],
+            attempt_id=value["attempt_id"],
+            quarantine_handle=value["quarantine_handle"],
+            reserved_at=value["reserved_at"],
+            publisher=value["publisher"],
+            channel=value["channel"],
+            retry_fingerprint=value["retry_fingerprint"],
+            correction_reference=_decode_correction(value.get("correction_reference")),
+            correction_state=value.get("correction_state", "NONE"),
+            possible_duplicate=bool(value.get("possible_duplicate", False)),
+            reconciliation_required=bool(value.get("reconciliation_required", False)),
+            reconciliation_reason=value.get("reconciliation_reason"),
+            payload_fingerprint=value.get("payload_fingerprint"),
+            fingerprint_key_version=value.get("fingerprint_key_version"),
+            pending_receipt=value.get("pending_receipt"),
+            pending_disposition=value.get("pending_disposition"),
+        )
+
+    @staticmethod
+    def _receipt_from_dict(value: dict[str, Any]) -> IntakeReceipt:
+        return IntakeReceipt(
+            lineage_id=value["lineage_id"],
+            attempt_id=value["attempt_id"],
+            received_at=value["received_at"],
+            publisher=value["publisher"],
+            channel=value["channel"],
+            quarantine_handle=value["quarantine_handle"],
+            key_version=value["key_version"],
+            fingerprint=value["fingerprint"],
+            correction_reference=_decode_correction(value.get("correction_reference")),
+        )
+
+    @staticmethod
+    def _findings(value: dict[str, Any]) -> tuple[IntakeFinding, ...]:
+        return tuple(
+            IntakeFinding(
+                code=item["code"],
+                message=item["message"],
+                blocking=bool(item.get("blocking", True)),
+            )
+            for item in value.get("findings", [])
+        )
+
+    @classmethod
+    def _disposition_from_dict(cls, value: dict[str, Any]) -> IntakeDisposition:
+        return IntakeDisposition(
+            lineage_id=value["lineage_id"],
+            attempt_id=value["attempt_id"],
+            status=value["status"],
+            recorded_at=value["recorded_at"],
+            findings=cls._findings(value),
+            terminal=bool(value.get("terminal", True)),
+        )
+
+    @staticmethod
+    def _deletion_from_dict(value: dict[str, Any]) -> DeletionAttestation:
+        return DeletionAttestation(
+            lineage_id=value["lineage_id"],
+            attempt_id=value["attempt_id"],
+            quarantine_handle=value["quarantine_handle"],
+            deleted=bool(value["deleted"]),
+            deleted_at=value["deleted_at"],
+        )
+
+    def reserve(
+        self,
+        *,
+        retry_key: str,
+        publisher: str,
+        channel: str,
+        correction_reference: CorrectionReference | None,
+    ) -> IntakeReservation:
+        if not retry_key or not publisher or not channel:
+            raise ValueError("retry key, publisher, and channel are required")
+        retry_fingerprint = self._retry_id(retry_key)
+        retry_path = self._path("retry-index", retry_fingerprint)
+        with self._locked():
+            if retry_path.exists():
+                index = json.loads(retry_path.read_text())
+                existing = self.reservation_by_attempt(index["attempt_id"])
+                if existing is None:
+                    raise RuntimeError("retry index references a missing reservation")
+                return existing
+            recovered = [
+                reservation
+                for reservation in self.reservations()
+                if reservation.retry_fingerprint == retry_fingerprint
+            ]
+            if len(recovered) > 1:
+                raise RuntimeError("retry fingerprint resolves to multiple reservations")
+            if recovered:
+                _atomic_json(retry_path, {"attempt_id": recovered[0].attempt_id})
+                return recovered[0]
+
+            lineage_id: str
+            correction_state = "NONE"
+            possible_duplicate = False
+            safe_correction_reference = correction_reference
+            if safe_correction_reference is not None:
+                try:
+                    _safe_id(
+                        safe_correction_reference.lineage_id,
+                        "correction lineage ID",
+                    )
+                    _safe_id(
+                        safe_correction_reference.attempt_id,
+                        "correction attempt ID",
+                    )
+                except ValueError:
+                    safe_correction_reference = None
+            if correction_reference is None:
+                lineage_id = _safe_id(
+                    self.id_provider.new_id("lineage"),
+                    "lineage ID",
+                )
+            else:
+                predecessor = (
+                    self.reservation_by_attempt(safe_correction_reference.attempt_id)
+                    if safe_correction_reference is not None
+                    else None
+                )
+                if (
+                    predecessor is None
+                    or safe_correction_reference is None
+                    or predecessor.lineage_id != safe_correction_reference.lineage_id
+                ):
+                    lineage_id = _safe_id(
+                        self.id_provider.new_id("lineage"),
+                        "lineage ID",
+                    )
+                    correction_state = "INVALID"
+                    possible_duplicate = True
+                else:
+                    lineage_id = predecessor.lineage_id
+                    predecessor_disposition = self.disposition(predecessor.attempt_id)
+                    predecessor_deletion = self.deletion_attestation(predecessor.attempt_id)
+                    if (
+                        predecessor_disposition is not None
+                        and predecessor_disposition.terminal
+                        and predecessor_deletion is not None
+                        and predecessor_deletion.deleted
+                    ):
+                        correction_state = "VALID"
+                    else:
+                        correction_state = "BLOCKED"
+
+            reservation = IntakeReservation(
+                lineage_id=lineage_id,
+                attempt_id=_safe_id(
+                    self.id_provider.new_id("attempt"),
+                    "attempt ID",
+                ),
+                quarantine_handle=_safe_id(
+                    self.id_provider.new_id("quarantine"),
+                    "quarantine handle",
+                ),
+                reserved_at=self.clock.now(),
+                publisher=publisher,
+                channel=channel,
+                retry_fingerprint=retry_fingerprint,
+                correction_reference=safe_correction_reference,
+                correction_state=correction_state,
+                possible_duplicate=possible_duplicate,
+            )
+            reservation_path = self._path("reservations", reservation.attempt_id)
+            if reservation_path.exists() or self.reservation_by_handle(
+                reservation.quarantine_handle
+            ):
+                raise RuntimeError("opaque ID provider returned a duplicate identifier")
+            _atomic_json(
+                reservation_path,
+                reservation.as_dict(),
+            )
+            _atomic_json(retry_path, {"attempt_id": reservation.attempt_id})
+            return reservation
+
+    def reservation_for_retry_key(self, retry_key: str) -> IntakeReservation | None:
+        retry_path = self._path("retry-index", self._retry_id(retry_key))
+        if not retry_path.exists():
+            return None
+        value = json.loads(retry_path.read_text())
+        return self.reservation_by_attempt(value["attempt_id"])
+
+    def reservation_by_attempt(self, attempt_id: str) -> IntakeReservation | None:
+        path = self._path("reservations", attempt_id)
+        if not path.exists():
+            return None
+        return self._reservation_from_dict(json.loads(path.read_text()))
+
+    def reservation_by_handle(self, handle: str) -> IntakeReservation | None:
+        for reservation in self.reservations():
+            if reservation.quarantine_handle == handle:
+                return reservation
+        return None
+
+    def reservations(self) -> tuple[IntakeReservation, ...]:
+        values = [
+            self._reservation_from_dict(json.loads(path.read_text()))
+            for path in sorted((self.root / "reservations").glob("*.json"))
+        ]
+        return tuple(values)
+
+    def _update_reservation(self, reservation: IntakeReservation) -> None:
+        _atomic_json(
+            self._path("reservations", reservation.attempt_id),
+            reservation.as_dict(),
+        )
+
+    def bind_payload(
+        self,
+        attempt_id: str,
+        *,
+        fingerprint: str,
+        key_version: str,
+    ) -> IntakeReservation:
+        reservation = self.reservation_by_attempt(attempt_id)
+        if reservation is None:
+            raise KeyError(attempt_id)
+        if reservation.payload_fingerprint is not None:
+            if (
+                reservation.payload_fingerprint != fingerprint
+                or reservation.fingerprint_key_version != key_version
+            ):
+                raise RuntimeError("retry key is already bound to a different payload")
+            return reservation
+        updated = replace(
+            reservation,
+            payload_fingerprint=fingerprint,
+            fingerprint_key_version=key_version,
+        )
+        self._update_reservation(updated)
+        return updated
+
+    def prepare_receipt(self, receipt: IntakeReceipt) -> None:
+        reservation = self.reservation_by_attempt(receipt.attempt_id)
+        if reservation is None:
+            raise KeyError(receipt.attempt_id)
+        self._update_reservation(replace(reservation, pending_receipt=receipt.as_dict()))
+
+    def finalize_receipt(self, receipt: IntakeReceipt) -> None:
+        path = self._path("receipts", receipt.attempt_id)
+        if path.exists():
+            existing = self._receipt_from_dict(json.loads(path.read_text()))
+            if existing != receipt:
+                raise RuntimeError("attempt already has a different intake receipt")
+            return
+        _atomic_json(path, receipt.as_dict())
+        reservation = self.reservation_by_attempt(receipt.attempt_id)
+        if reservation is not None:
+            self._update_reservation(replace(reservation, pending_receipt=None))
+
+    def receipt(self, attempt_id: str) -> IntakeReceipt | None:
+        path = self._path("receipts", attempt_id)
+        if not path.exists():
+            return None
+        return self._receipt_from_dict(json.loads(path.read_text()))
+
+    def prepare_disposition(self, disposition: IntakeDisposition) -> None:
+        reservation = self.reservation_by_attempt(disposition.attempt_id)
+        if reservation is None:
+            raise KeyError(disposition.attempt_id)
+        self._update_reservation(replace(reservation, pending_disposition=disposition.as_dict()))
+
+    def write_disposition(self, disposition: IntakeDisposition) -> None:
+        path = self._path("dispositions", disposition.attempt_id)
+        if path.exists():
+            existing = self._disposition_from_dict(json.loads(path.read_text()))
+            if existing != disposition:
+                raise RuntimeError("attempt already has a different terminal disposition")
+            return
+        _atomic_json(path, disposition.as_dict())
+        reservation = self.reservation_by_attempt(disposition.attempt_id)
+        if reservation is not None:
+            self._update_reservation(replace(reservation, pending_disposition=None))
+
+    def disposition(self, attempt_id: str) -> IntakeDisposition | None:
+        path = self._path("dispositions", attempt_id)
+        if not path.exists():
+            return None
+        return self._disposition_from_dict(json.loads(path.read_text()))
+
+    def write_deletion_attestation(self, attestation: DeletionAttestation) -> None:
+        path = self._path("deletions", attestation.attempt_id)
+        if path.exists():
+            existing = self._deletion_from_dict(json.loads(path.read_text()))
+            if existing != attestation:
+                raise RuntimeError("attempt already has a different deletion attestation")
+            return
+        _atomic_json(path, attestation.as_dict())
+
+    def deletion_attestation(self, attempt_id: str) -> DeletionAttestation | None:
+        path = self._path("deletions", attempt_id)
+        if not path.exists():
+            return None
+        return self._deletion_from_dict(json.loads(path.read_text()))
+
+    def mark_reconciliation(self, attempt_id: str, reason: str) -> IntakeReservation:
+        reservation = self.reservation_by_attempt(attempt_id)
+        if reservation is None:
+            raise KeyError(attempt_id)
+        updated = replace(
+            reservation,
+            reconciliation_required=True,
+            reconciliation_reason=reason,
+        )
+        self._update_reservation(updated)
+        return updated
+
+    def clear_reconciliation(self, attempt_id: str) -> IntakeReservation:
+        reservation = self.reservation_by_attempt(attempt_id)
+        if reservation is None:
+            raise KeyError(attempt_id)
+        updated = replace(
+            reservation,
+            reconciliation_required=False,
+            reconciliation_reason=None,
+            pending_receipt=None,
+            pending_disposition=None,
+        )
+        self._update_reservation(updated)
+        return updated
+
+
+def _finding(code: str, message: str) -> IntakeFinding:
+    return IntakeFinding(code=code, message=message)
+
+
+class IntakeCoordinator:
+    def __init__(
+        self,
+        *,
+        ledger: FileIntakeLedger,
+        quarantine: QuarantineStore,
+        fingerprint_provider: KeyedFingerprintProvider,
+        malware_scanner: MalwareScanner,
+        clock: Clock,
+        max_bytes: int,
+        allowed_content_types: set[str],
+    ) -> None:
+        if max_bytes <= 0:
+            raise ValueError("max_bytes must be positive")
+        self.ledger = ledger
+        self.quarantine = quarantine
+        self.fingerprint_provider = fingerprint_provider
+        self.malware_scanner = malware_scanner
+        self.clock = clock
+        self.max_bytes = max_bytes
+        self.allowed_content_types = frozenset(allowed_content_types)
+
+    def receive(self, request: IntakeRequest) -> IntakeOutcome:
+        reservation = self.ledger.reserve(
+            retry_key=request.retry_key,
+            publisher=request.publisher,
+            channel=request.channel,
+            correction_reference=request.correction_reference,
+        )
+        payload_fingerprint = self.fingerprint_provider.fingerprint(
+            "payload",
+            request.payload,
+        )
+        if reservation.payload_fingerprint is not None and (
+            reservation.payload_fingerprint != payload_fingerprint
+            or reservation.fingerprint_key_version != self.fingerprint_provider.key_version
+        ):
+            finding = _finding(
+                "RETRY_KEY_PAYLOAD_MISMATCH",
+                "retry key is already bound to different contract bytes",
+            )
+            return IntakeOutcome(
+                status="SECURITY_BLOCKED",
+                reservation=reservation,
+                receipt=self.ledger.receipt(reservation.attempt_id),
+                disposition=self._disposition(
+                    reservation,
+                    "SECURITY_BLOCKED",
+                    (finding,),
+                ),
+                deletion_attestation=self.ledger.deletion_attestation(reservation.attempt_id),
+                findings=(finding,),
+                admitted_payload=None,
+                quarantine_retained=self.quarantine.exists(reservation.quarantine_handle),
+                replayed=True,
+            )
+        try:
+            reservation = self.ledger.bind_payload(
+                reservation.attempt_id,
+                fingerprint=payload_fingerprint,
+                key_version=self.fingerprint_provider.key_version,
+            )
+        except Exception:
+            return self._block_before_receipt(
+                reservation,
+                _finding(
+                    "PAYLOAD_BINDING_FAILED",
+                    "durable retry-key payload binding failed and requires reconciliation",
+                ),
+            )
+        existing_disposition = self.ledger.disposition(reservation.attempt_id)
+        if existing_disposition is not None and existing_disposition.terminal:
+            return IntakeOutcome(
+                status=existing_disposition.status,
+                reservation=reservation,
+                receipt=self.ledger.receipt(reservation.attempt_id),
+                disposition=existing_disposition,
+                deletion_attestation=self.ledger.deletion_attestation(reservation.attempt_id),
+                findings=existing_disposition.findings,
+                admitted_payload=None,
+                quarantine_retained=self.quarantine.exists(reservation.quarantine_handle),
+                replayed=True,
+            )
+
+        possible_duplicate: list[IntakeFinding] = []
+        if reservation.possible_duplicate:
+            possible_duplicate.append(
+                _finding(
+                    "POSSIBLE_DUPLICATE",
+                    "correction reference is missing or invalid; a new lineage was reserved",
+                )
+            )
+        if reservation.correction_state == "BLOCKED":
+            correction_findings = (
+                *possible_duplicate,
+                _finding(
+                    "CORRECTION_PREDECESSOR_UNRESOLVED",
+                    "correction predecessor lacks proven deletion and terminal disposition",
+                ),
+            )
+            receipt = self._receipt(
+                request,
+                reservation,
+                payload_fingerprint,
+            )
+            return self._complete_without_payload(
+                reservation,
+                receipt,
+                "SECURITY_BLOCKED",
+                correction_findings,
+            )
+
+        stored = False
+        if len(request.payload) <= self.max_bytes:
+            try:
+                self.quarantine.put(
+                    reservation.quarantine_handle,
+                    request.payload,
+                    {"ordinary_digest": hashlib.sha256(request.payload).hexdigest()},
+                )
+                stored = True
+            except FileExistsError:
+                stored = self.quarantine.exists(reservation.quarantine_handle)
+            except Exception:
+                return self._block_before_receipt(
+                    reservation,
+                    _finding(
+                        "QUARANTINE_WRITE_FAILED",
+                        "quarantine persistence failed and requires reconciliation",
+                    ),
+                )
+
+        receipt = self._receipt(
+            request,
+            reservation,
+            payload_fingerprint,
+        )
+        try:
+            self.ledger.prepare_receipt(receipt)
+            self.ledger.finalize_receipt(receipt)
+        except Exception:
+            blocked = _finding(
+                "RECEIPT_FINALIZATION_FAILED",
+                "durable intake receipt finalization failed and requires reconciliation",
+            )
+            reservation = self.ledger.mark_reconciliation(
+                reservation.attempt_id,
+                blocked.code,
+            )
+            disposition = self._disposition(
+                reservation,
+                "SECURITY_BLOCKED",
+                (blocked,),
+            )
+            return IntakeOutcome(
+                status="SECURITY_BLOCKED",
+                reservation=reservation,
+                receipt=receipt,
+                disposition=disposition,
+                deletion_attestation=None,
+                findings=(blocked,),
+                admitted_payload=None,
+                quarantine_retained=stored,
+            )
+
+        findings = possible_duplicate
+        if len(request.payload) > self.max_bytes:
+            findings.append(
+                _finding("PAYLOAD_TOO_LARGE", "payload exceeds the configured intake bound")
+            )
+        elif request.content_type not in self.allowed_content_types:
+            findings.append(
+                _finding(
+                    "CONTENT_TYPE_REJECTED",
+                    "content type is not in the admitted contract format set",
+                )
+            )
+        else:
+            try:
+                scan = self.malware_scanner.scan(request.payload)
+            except Exception:
+                findings.append(
+                    _finding(
+                        "MALWARE_SCAN_FAILED",
+                        "malware scanning failed closed",
+                    )
+                )
+            else:
+                if not scan.clean:
+                    findings.append(
+                        _finding(
+                            "MALWARE_DETECTED",
+                            "malware scanner returned a blocking finding",
+                        )
+                    )
+            if not findings:
+                if any(pattern.search(request.payload) for pattern in _SECRET_PATTERNS):
+                    findings.append(
+                        _finding(
+                            "SECRET_DETECTED",
+                            "input matched a prohibited secret pattern",
+                        )
+                    )
+                elif any(pattern.search(request.payload) for pattern in _PRIVACY_PATTERNS):
+                    findings.append(
+                        _finding(
+                            "PRIVACY_PATTERN_DETECTED",
+                            "input matched a privacy-sensitive pattern",
+                        )
+                    )
+            if not findings:
+                try:
+                    strict_loads(request.payload, request.content_type)
+                except CanonicalInputError:
+                    findings.append(
+                        _finding(
+                            "MALFORMED_INPUT",
+                            "input failed strict structural admission",
+                        )
+                    )
+
+        status = "REJECTED" if findings else "ADMITTED"
+        return self._finalize(
+            reservation,
+            receipt,
+            status,
+            tuple(findings),
+            admitted_payload=request.payload if status == "ADMITTED" else None,
+        )
+
+    def _receipt(
+        self,
+        request: IntakeRequest,
+        reservation: IntakeReservation,
+        payload_fingerprint: str,
+    ) -> IntakeReceipt:
+        return IntakeReceipt(
+            lineage_id=reservation.lineage_id,
+            attempt_id=reservation.attempt_id,
+            received_at=self.clock.now(),
+            publisher=request.publisher,
+            channel=request.channel,
+            correction_reference=reservation.correction_reference,
+            quarantine_handle=reservation.quarantine_handle,
+            key_version=self.fingerprint_provider.key_version,
+            fingerprint=payload_fingerprint,
+        )
+
+    def _disposition(
+        self,
+        reservation: IntakeReservation,
+        status: str,
+        findings: tuple[IntakeFinding, ...],
+    ) -> IntakeDisposition:
+        return IntakeDisposition(
+            lineage_id=reservation.lineage_id,
+            attempt_id=reservation.attempt_id,
+            status=status,
+            recorded_at=self.clock.now(),
+            findings=findings,
+        )
+
+    def _complete_without_payload(
+        self,
+        reservation: IntakeReservation,
+        receipt: IntakeReceipt,
+        status: str,
+        findings: tuple[IntakeFinding, ...],
+    ) -> IntakeOutcome:
+        try:
+            self.ledger.prepare_receipt(receipt)
+            self.ledger.finalize_receipt(receipt)
+        except Exception:
+            blocked = _finding(
+                "RECEIPT_FINALIZATION_FAILED",
+                "durable intake receipt finalization failed and requires reconciliation",
+            )
+            findings = (*findings, blocked)
+            reservation = self.ledger.mark_reconciliation(
+                reservation.attempt_id,
+                blocked.code,
+            )
+        return self._finalize(
+            reservation,
+            receipt,
+            status,
+            findings,
+            admitted_payload=None,
+        )
+
+    def _block_before_receipt(
+        self,
+        reservation: IntakeReservation,
+        finding: IntakeFinding,
+    ) -> IntakeOutcome:
+        reservation = self.ledger.mark_reconciliation(
+            reservation.attempt_id,
+            finding.code,
+        )
+        disposition = self._disposition(
+            reservation,
+            "SECURITY_BLOCKED",
+            (finding,),
+        )
+        return IntakeOutcome(
+            status="SECURITY_BLOCKED",
+            reservation=reservation,
+            receipt=None,
+            disposition=disposition,
+            deletion_attestation=None,
+            findings=(finding,),
+            admitted_payload=None,
+            quarantine_retained=self.quarantine.exists(reservation.quarantine_handle),
+        )
+
+    def _finalize(
+        self,
+        reservation: IntakeReservation,
+        receipt: IntakeReceipt,
+        desired_status: str,
+        findings: tuple[IntakeFinding, ...],
+        *,
+        admitted_payload: bytes | None,
+    ) -> IntakeOutcome:
+        try:
+            deleted = self.quarantine.delete(reservation.quarantine_handle)
+            if not deleted:
+                raise OSError("quarantine store did not attest deletion")
+            attestation = DeletionAttestation(
+                lineage_id=reservation.lineage_id,
+                attempt_id=reservation.attempt_id,
+                quarantine_handle=reservation.quarantine_handle,
+                deleted=True,
+                deleted_at=self.clock.now(),
+            )
+            self.ledger.write_deletion_attestation(attestation)
+        except Exception:
+            blocked_finding = _finding(
+                "QUARANTINE_DELETION_FAILED",
+                "quarantine deletion is unresolved and requires reconciliation",
+            )
+            blocked_findings = (*findings, blocked_finding)
+            disposition = self._disposition(
+                reservation,
+                "SECURITY_BLOCKED",
+                blocked_findings,
+            )
+            try:
+                self.ledger.prepare_disposition(disposition)
+            finally:
+                reservation = self.ledger.mark_reconciliation(
+                    reservation.attempt_id,
+                    blocked_finding.code,
+                )
+            return IntakeOutcome(
+                status="SECURITY_BLOCKED",
+                reservation=reservation,
+                receipt=receipt,
+                disposition=disposition,
+                deletion_attestation=None,
+                findings=blocked_findings,
+                admitted_payload=None,
+                quarantine_retained=self.quarantine.exists(reservation.quarantine_handle),
+            )
+
+        disposition = self._disposition(reservation, desired_status, findings)
+        try:
+            self.ledger.prepare_disposition(disposition)
+            self.ledger.write_disposition(disposition)
+        except Exception:
+            blocked_finding = _finding(
+                "DISPOSITION_WRITE_FAILED",
+                "terminal disposition persistence failed and requires reconciliation",
+            )
+            blocked_findings = (*findings, blocked_finding)
+            blocked_disposition = self._disposition(
+                reservation,
+                "SECURITY_BLOCKED",
+                blocked_findings,
+            )
+            self.ledger.prepare_disposition(blocked_disposition)
+            reservation = self.ledger.mark_reconciliation(
+                reservation.attempt_id,
+                blocked_finding.code,
+            )
+            return IntakeOutcome(
+                status="SECURITY_BLOCKED",
+                reservation=reservation,
+                receipt=receipt,
+                disposition=blocked_disposition,
+                deletion_attestation=attestation,
+                findings=blocked_findings,
+                admitted_payload=None,
+                quarantine_retained=False,
+            )
+
+        reservation = self.ledger.reservation_by_attempt(reservation.attempt_id) or reservation
+        return IntakeOutcome(
+            status=desired_status,
+            reservation=reservation,
+            receipt=receipt,
+            disposition=disposition,
+            deletion_attestation=attestation,
+            findings=findings,
+            admitted_payload=admitted_payload,
+            quarantine_retained=False,
+        )
+
+
+class IntakeReconciler:
+    """Completes interrupted receipt, deletion, and terminal-disposition writes."""
+
+    def __init__(
+        self,
+        *,
+        ledger: FileIntakeLedger,
+        quarantine: QuarantineStore,
+        clock: Clock,
+    ) -> None:
+        self.ledger = ledger
+        self.quarantine = quarantine
+        self.clock = clock
+
+    def reconcile(self) -> ReconciliationReport:
+        resolved: list[str] = []
+        blocked: list[str] = []
+        for reservation in self.ledger.reservations():
+            disposition = self.ledger.disposition(reservation.attempt_id)
+            if disposition is not None and disposition.terminal:
+                if reservation.reconciliation_required:
+                    self.ledger.clear_reconciliation(reservation.attempt_id)
+                continue
+            try:
+                if reservation.pending_receipt is not None:
+                    self.ledger.finalize_receipt(
+                        self.ledger._receipt_from_dict(reservation.pending_receipt)
+                    )
+                deleted = self.quarantine.delete(reservation.quarantine_handle)
+                if not deleted:
+                    raise OSError("quarantine deletion remains unresolved")
+                attestation = self.ledger.deletion_attestation(reservation.attempt_id)
+                if attestation is None:
+                    self.ledger.write_deletion_attestation(
+                        DeletionAttestation(
+                            lineage_id=reservation.lineage_id,
+                            attempt_id=reservation.attempt_id,
+                            quarantine_handle=reservation.quarantine_handle,
+                            deleted=True,
+                            deleted_at=self.clock.now(),
+                        )
+                    )
+                pending = reservation.pending_disposition
+                if pending is None:
+                    finding = _finding(
+                        "INTAKE_RECONCILED_SECURITY_BLOCK",
+                        "interrupted intake was reconciled without resuming admission",
+                    )
+                    terminal = IntakeDisposition(
+                        lineage_id=reservation.lineage_id,
+                        attempt_id=reservation.attempt_id,
+                        status="SECURITY_BLOCKED",
+                        recorded_at=self.clock.now(),
+                        findings=(finding,),
+                    )
+                else:
+                    terminal = self.ledger._disposition_from_dict(pending)
+                    if terminal.status != "SECURITY_BLOCKED":
+                        terminal = replace(terminal, status="SECURITY_BLOCKED")
+                self.ledger.write_disposition(terminal)
+                self.ledger.clear_reconciliation(reservation.attempt_id)
+                resolved.append(reservation.attempt_id)
+            except Exception:
+                self.ledger.mark_reconciliation(
+                    reservation.attempt_id,
+                    "RECONCILIATION_FAILED",
+                )
+                blocked.append(reservation.attempt_id)
+        return ReconciliationReport(tuple(resolved), tuple(blocked))
+
+
+__all__ = [
+    "CorrectionReference",
+    "DeletionAttestation",
+    "FileIntakeLedger",
+    "FileQuarantineStore",
+    "IntakeCoordinator",
+    "IntakeDisposition",
+    "IntakeFinding",
+    "IntakeOutcome",
+    "IntakeReceipt",
+    "IntakeReconciler",
+    "IntakeRequest",
+    "IntakeReservation",
+    "KeyedFingerprintProvider",
+    "MalwareScanResult",
+    "MalwareScanner",
+    "QuarantineCipher",
+    "QuarantineStore",
+    "ReconciliationReport",
+]

--- a/src/pmpe/contracts/intake.py
+++ b/src/pmpe/contracts/intake.py
@@ -27,6 +27,9 @@ from pmpe.contracts.canonical import CanonicalInputError, strict_loads
 
 _SAFE_HANDLE = re.compile(r"^[A-Z][A-Z0-9-]{0,127}$")
 _SAFE_METADATA = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$")
+_SAFE_CONTENT_TYPE = re.compile(
+    r"^[a-z0-9][a-z0-9!#$&^_.+-]{0,63}/[a-z0-9][a-z0-9!#$&^_.+-]{0,63}$"
+)
 _SECRET_PATTERNS = (
     re.compile(rb"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
     re.compile(rb"\bAKIA[0-9A-Z]{16}\b"),
@@ -132,6 +135,7 @@ class IntakeReservation:
     retry_fingerprint: str
     retry_key_version: str
     expires_at: str
+    content_type: str | None = None
     correction_reference: CorrectionReference | None = None
     correction_state: str = "NONE"
     possible_duplicate: bool = False
@@ -157,6 +161,7 @@ class IntakeReceipt:
     received_at: str
     publisher: str
     channel: str
+    content_type: str
     quarantine_handle: str
     key_version: str
     fingerprint: str
@@ -244,6 +249,12 @@ def _safe_metadata(value: str, label: str) -> str:
         or any(pattern.search(encoded) for pattern in _PRIVACY_PATTERNS)
     ):
         raise ValueError(f"{label} must be a bounded safe metadata identifier")
+    return value
+
+
+def _safe_content_type(value: str) -> str:
+    if not _SAFE_CONTENT_TYPE.fullmatch(value):
+        raise ValueError("content type must be bounded canonical media-type metadata")
     return value
 
 
@@ -450,6 +461,7 @@ class FileIntakeLedger:
             retry_fingerprint=value["retry_fingerprint"],
             retry_key_version=value["retry_key_version"],
             expires_at=value["expires_at"],
+            content_type=value.get("content_type"),
             correction_reference=_decode_correction(value.get("correction_reference")),
             correction_state=value.get("correction_state", "NONE"),
             possible_duplicate=bool(value.get("possible_duplicate", False)),
@@ -469,6 +481,7 @@ class FileIntakeLedger:
             received_at=value["received_at"],
             publisher=value["publisher"],
             channel=value["channel"],
+            content_type=value["content_type"],
             quarantine_handle=value["quarantine_handle"],
             key_version=value["key_version"],
             fingerprint=value["fingerprint"],
@@ -696,11 +709,13 @@ class FileIntakeLedger:
         *,
         fingerprint: str,
         key_version: str,
+        content_type: str,
     ) -> IntakeReservation:
         if not re.fullmatch(r"[0-9a-fA-F]{32,}", fingerprint) or not _SAFE_METADATA.fullmatch(
             key_version
         ):
             raise ValueError("payload fingerprint metadata is unsafe")
+        content_type = _safe_content_type(content_type)
         with self._locked():
             reservation = self.reservation_by_attempt(attempt_id)
             if reservation is None:
@@ -712,13 +727,17 @@ class FileIntakeLedger:
                         fingerprint,
                     )
                     or reservation.fingerprint_key_version != key_version
+                    or reservation.content_type != content_type
                 ):
-                    raise IntakeConflictError("retry key is already bound to a different payload")
+                    raise IntakeConflictError(
+                        "retry key is already bound to a different payload or media type"
+                    )
                 return reservation
             updated = replace(
                 reservation,
                 payload_fingerprint=fingerprint,
                 fingerprint_key_version=key_version,
+                content_type=content_type,
             )
             self._update_reservation(updated)
             return updated
@@ -972,6 +991,7 @@ class IntakeCoordinator:
                 reservation.attempt_id,
                 fingerprint=payload_fingerprint,
                 key_version=payload_key_version,
+                content_type=request.content_type,
             )
         except IntakeConflictError:
             finding = _finding(
@@ -1271,12 +1291,15 @@ class IntakeCoordinator:
         payload_fingerprint: str,
         payload_key_version: str,
     ) -> IntakeReceipt:
+        if reservation.content_type is None:
+            raise RuntimeError("payload media type is not durably bound")
         return IntakeReceipt(
             lineage_id=reservation.lineage_id,
             attempt_id=reservation.attempt_id,
             received_at=self.clock.now(),
             publisher=reservation.publisher,
             channel=reservation.channel,
+            content_type=reservation.content_type,
             correction_reference=reservation.correction_reference,
             quarantine_handle=reservation.quarantine_handle,
             key_version=payload_key_version,
@@ -1512,12 +1535,15 @@ class IntakeReconciler:
                     and reservation.payload_fingerprint is not None
                     and reservation.fingerprint_key_version is not None
                 ):
+                    if reservation.content_type is None:
+                        raise RuntimeError("payload media type binding is missing")
                     recovered_receipt = IntakeReceipt(
                         lineage_id=reservation.lineage_id,
                         attempt_id=reservation.attempt_id,
                         received_at=reservation.reserved_at,
                         publisher=reservation.publisher,
                         channel=reservation.channel,
+                        content_type=reservation.content_type,
                         quarantine_handle=reservation.quarantine_handle,
                         key_version=reservation.fingerprint_key_version,
                         fingerprint=reservation.payload_fingerprint,

--- a/src/pmpe/contracts/migrations.py
+++ b/src/pmpe/contracts/migrations.py
@@ -1,0 +1,86 @@
+"""Pure, ordered, versioned canonical-contract migrations."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+class MigrationError(ValueError):
+    """The requested migration path is unsafe, missing, or ambiguous."""
+
+
+def _version_tuple(version: str) -> tuple[int, int, int]:
+    try:
+        parts = tuple(int(part) for part in version.split("."))
+    except ValueError as exc:
+        raise MigrationError(f"invalid semantic version: {version}") from exc
+    if len(parts) != 3 or any(part < 0 for part in parts):
+        raise MigrationError(f"invalid semantic version: {version}")
+    return parts
+
+
+@dataclass(frozen=True)
+class MigrationStep:
+    source_version: str
+    target_version: str
+    rule_version: str
+    transform: Callable[[dict[str, Any]], dict[str, Any]]
+
+    def __post_init__(self) -> None:
+        if _version_tuple(self.target_version) <= _version_tuple(self.source_version):
+            raise MigrationError("migration steps must move forward; downgrade is forbidden")
+
+
+class MigrationRegistry:
+    """A linear registry: one outgoing step per version, registered in order."""
+
+    def __init__(self) -> None:
+        self._steps: list[MigrationStep] = []
+
+    def register(self, step: MigrationStep) -> None:
+        if any(existing.source_version == step.source_version for existing in self._steps):
+            raise MigrationError(f"ambiguous migration path from {step.source_version}")
+        if self._steps and step.source_version != self._steps[-1].target_version:
+            raise MigrationError(
+                "migration registration order must form one contiguous forward path"
+            )
+        self._steps.append(step)
+
+    def migrate(
+        self,
+        value: dict[str, Any],
+        source_version: str,
+        target_version: str,
+    ) -> tuple[dict[str, Any], tuple[str, ...]]:
+        if _version_tuple(target_version) < _version_tuple(source_version):
+            raise MigrationError("downgrade migrations are forbidden")
+        if source_version == target_version:
+            return copy.deepcopy(value), ()
+        current = source_version
+        output = copy.deepcopy(value)
+        rules: list[str] = []
+        by_source = {step.source_version: step for step in self._steps}
+        visited: set[str] = set()
+        while current != target_version:
+            if current in visited:
+                raise MigrationError("migration cycle detected")
+            visited.add(current)
+            step = by_source.get(current)
+            if step is None:
+                raise MigrationError(f"no migration path from {source_version} to {target_version}")
+            if _version_tuple(step.target_version) > _version_tuple(target_version):
+                raise MigrationError(
+                    f"migration path from {source_version} overshoots {target_version}"
+                )
+            try:
+                output = step.transform(copy.deepcopy(output))
+            except Exception as exc:
+                raise MigrationError(f"migration rule {step.rule_version} failed") from exc
+            if not isinstance(output, dict):
+                raise MigrationError(f"migration rule {step.rule_version} returned non-object")
+            rules.append(step.rule_version)
+            current = step.target_version
+        return output, tuple(rules)

--- a/src/pmpe/contracts/pipeline.py
+++ b/src/pmpe/contracts/pipeline.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import fcntl
-import json
 import os
 import tempfile
 from collections.abc import Iterator
@@ -12,7 +11,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from pmpe.contracts.canonical import canonical_digest, canonical_json_bytes
+from pmpe.contracts.canonical import (
+    CanonicalInputError,
+    canonical_digest,
+    canonical_json_bytes,
+    strict_loads,
+)
 from pmpe.contracts.compiler import (
     CanonicalCompiler,
     CompilationBlocked,
@@ -133,35 +137,134 @@ class FileCompilationEvidenceStore:
                 canonical_json_bytes(evidence) + b"\n",
             )
 
-    def load_compilation(self, attempt_id: str) -> CompilationResult | None:
+    @staticmethod
+    def _load_canonical_object(path: Path) -> dict[str, Any]:
+        try:
+            payload = path.read_bytes()
+            value = strict_loads(payload, "application/json")
+            if payload != canonical_json_bytes(value) + b"\n":
+                raise CompilationEvidenceError("stored compiler evidence is not byte-canonical")
+            return value
+        except CompilationEvidenceError:
+            raise
+        except (CanonicalInputError, OSError, ValueError) as exc:
+            raise CompilationEvidenceError("stored compiler evidence is malformed") from exc
+
+    @staticmethod
+    def _validate_intake_binding(
+        evidence: dict[str, Any],
+        expected_intake_binding: dict[str, str],
+    ) -> None:
+        if evidence.get("intake") != expected_intake_binding:
+            raise CompilationEvidenceError(
+                "stored compiler evidence does not match the exact intake receipt"
+            )
+
+    def load_compilation(
+        self,
+        attempt_id: str,
+        expected_intake_binding: dict[str, str],
+    ) -> CompilationResult | None:
         target = self.root / attempt_id
         paths = (
             target / "bundle.json",
             target / "manifest.json",
             target / "compiler-evidence.json",
         )
-        if not all(path.exists() for path in paths):
+        present = tuple(path.exists() for path in paths)
+        if not any(present):
             return None
-        bundle: dict[str, Any] = json.loads(paths[0].read_text())
-        manifest: dict[str, Any] = json.loads(paths[1].read_text())
-        evidence: dict[str, Any] = json.loads(paths[2].read_text())
-        bundle_digest = canonical_digest(bundle)
-        manifest_projection = dict(manifest)
-        manifest_digest = manifest_projection.pop("manifest_digest", None)
-        recomputed_manifest_digest = canonical_digest(manifest_projection)
-        if (
-            evidence.get("bundle_digest") != bundle_digest
-            or manifest.get("bundle", {}).get("content_digest") != bundle_digest
-            or evidence.get("manifest_digest") != manifest_digest
-            or manifest_digest != recomputed_manifest_digest
-        ):
-            raise CompilationEvidenceError(
-                "stored compiler artifacts fail their canonical digest bindings"
+        if present in {(True, False, False), (True, True, False)}:
+            return None
+        if not all(present) or (target / "compiler-diagnostics.json").exists():
+            raise CompilationEvidenceError("stored compiler evidence set is inconsistent")
+        try:
+            bundle = self._load_canonical_object(paths[0])
+            manifest = self._load_canonical_object(paths[1])
+            evidence = self._load_canonical_object(paths[2])
+            self._validate_intake_binding(evidence, expected_intake_binding)
+            bundle_digest = canonical_digest(bundle)
+            manifest_projection = dict(manifest)
+            manifest_digest = manifest_projection.pop("manifest_digest", None)
+            recomputed_manifest_digest = canonical_digest(manifest_projection)
+            bundle_provenance = bundle.get("provenance")
+            manifest_provenance = manifest.get("provenance")
+            compiler_provenance = (
+                bundle_provenance.get("compiler_provenance")
+                if isinstance(bundle_provenance, dict)
+                else None
             )
-        return CompilationResult.from_artifacts(bundle, manifest, evidence)
+            manifest_bundle = manifest.get("bundle")
+            if (
+                evidence.get("bundle_digest") != bundle_digest
+                or not isinstance(manifest_bundle, dict)
+                or manifest_bundle.get("content_digest") != bundle_digest
+                or manifest_bundle.get("bundle_id") != bundle.get("bundle_id")
+                or manifest_bundle.get("bundle_version") != bundle.get("bundle_version")
+                or evidence.get("manifest_digest") != manifest_digest
+                or manifest_digest != recomputed_manifest_digest
+                or not isinstance(bundle_provenance, dict)
+                or manifest_provenance != bundle_provenance
+                or evidence.get("source_digest") != bundle_provenance.get("source_digest")
+                or evidence.get("source_version_value") != bundle_provenance.get("source_version")
+                or not isinstance(compiler_provenance, dict)
+                or evidence.get("compiler_id") != compiler_provenance.get("compiler_id")
+                or evidence.get("compiler_version") != compiler_provenance.get("compiler_version")
+                or not isinstance(evidence.get("diagnostics"), list)
+            ):
+                raise CompilationEvidenceError(
+                    "stored compiler artifacts fail their provenance bindings"
+                )
+            return CompilationResult.from_artifacts(bundle, manifest, evidence)
+        except CompilationEvidenceError:
+            raise
+        except (KeyError, TypeError, ValueError) as exc:
+            raise CompilationEvidenceError(
+                "stored compiler evidence is structurally invalid"
+            ) from exc
 
-    def blocked_exists(self, attempt_id: str) -> bool:
-        return (self.root / attempt_id / "compiler-diagnostics.json").exists()
+    def load_blocked(
+        self,
+        attempt_id: str,
+        expected_intake_binding: dict[str, str],
+    ) -> bool:
+        target = self.root / attempt_id
+        path = target / "compiler-diagnostics.json"
+        if not path.exists():
+            return False
+        if any(
+            (target / name).exists()
+            for name in ("bundle.json", "manifest.json", "compiler-evidence.json")
+        ):
+            raise CompilationEvidenceError("blocked and compiled evidence cannot coexist")
+        evidence = self._load_canonical_object(path)
+        self._validate_intake_binding(evidence, expected_intake_binding)
+        diagnostics = evidence.get("diagnostics")
+        expected_fields = {
+            "blocking",
+            "code",
+            "message",
+            "source_path",
+            "target_path",
+        }
+        if (
+            set(evidence) != {"diagnostics", "intake", "status"}
+            or evidence.get("status") != "COMPILATION_BLOCKED"
+            or not isinstance(diagnostics, list)
+            or not diagnostics
+            or any(
+                not isinstance(item, dict)
+                or set(item) != expected_fields
+                or item.get("blocking") is not True
+                or any(
+                    not isinstance(item.get(field), str)
+                    for field in ("code", "message", "source_path", "target_path")
+                )
+                for item in diagnostics
+            )
+        ):
+            raise CompilationEvidenceError("stored compiler diagnostics are structurally invalid")
+        return True
 
 
 class PmosCompilationService:
@@ -193,9 +296,23 @@ class PmosCompilationService:
                 compilation=None,
                 replayed=intake_outcome.replayed,
             )
+        binding = {
+            "attempt_id": receipt.attempt_id,
+            "fingerprint": receipt.fingerprint,
+            "key_version": receipt.key_version,
+            "lineage_id": receipt.lineage_id,
+            "received_at": receipt.received_at,
+        }
         if intake_outcome.status == "ADMITTED":
             try:
-                compiled = self.evidence_store.load_compilation(receipt.attempt_id)
+                compiled = self.evidence_store.load_compilation(
+                    receipt.attempt_id,
+                    binding,
+                )
+                blocked_evidence = self.evidence_store.load_blocked(
+                    receipt.attempt_id,
+                    binding,
+                )
             except CompilationEvidenceError:
                 return PmosCompilationOutcome(
                     status="EVIDENCE_SECURITY_BLOCKED",
@@ -210,11 +327,7 @@ class PmosCompilationService:
                     compilation=compiled,
                     replayed=True,
                 )
-            status = (
-                "COMPILATION_BLOCKED"
-                if self.evidence_store.blocked_exists(receipt.attempt_id)
-                else "EVIDENCE_SECURITY_BLOCKED"
-            )
+            status = "COMPILATION_BLOCKED" if blocked_evidence else "EVIDENCE_SECURITY_BLOCKED"
             return PmosCompilationOutcome(
                 status=status,
                 intake=intake_outcome,
@@ -228,15 +341,15 @@ class PmosCompilationService:
                 compilation=None,
             )
 
-        binding = {
-            "attempt_id": receipt.attempt_id,
-            "fingerprint": receipt.fingerprint,
-            "key_version": receipt.key_version,
-            "lineage_id": receipt.lineage_id,
-            "received_at": receipt.received_at,
-        }
         try:
-            existing = self.evidence_store.load_compilation(receipt.attempt_id)
+            existing = self.evidence_store.load_compilation(
+                receipt.attempt_id,
+                binding,
+            )
+            blocked_evidence = self.evidence_store.load_blocked(
+                receipt.attempt_id,
+                binding,
+            )
         except CompilationEvidenceError:
             return PmosCompilationOutcome(
                 status="EVIDENCE_SECURITY_BLOCKED",
@@ -244,7 +357,7 @@ class PmosCompilationService:
                 compilation=None,
                 replayed=True,
             )
-        if existing is not None or self.evidence_store.blocked_exists(receipt.attempt_id):
+        if existing is not None or blocked_evidence:
             finalized = self._finalize_intake(intake_outcome)
             if finalized.status != "ADMITTED":
                 return PmosCompilationOutcome(

--- a/src/pmpe/contracts/pipeline.py
+++ b/src/pmpe/contracts/pipeline.py
@@ -1,0 +1,245 @@
+"""Durable intake-to-canonical-compilation orchestration for PMOS contracts."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pmpe.contracts.canonical import canonical_digest, canonical_json_bytes
+from pmpe.contracts.compiler import (
+    CanonicalCompiler,
+    CompilationBlocked,
+    CompilationResult,
+)
+from pmpe.contracts.intake import IntakeCoordinator, IntakeOutcome, IntakeRequest
+
+
+def _atomic_write(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+@dataclass(frozen=True)
+class PmosCompilationOutcome:
+    status: str
+    intake: IntakeOutcome
+    compilation: CompilationResult | None
+    replayed: bool = False
+
+
+class CompilationEvidenceError(ValueError):
+    """Stored compiler evidence does not match its exact canonical artifacts."""
+
+
+class FileCompilationEvidenceStore:
+    """Content-addressed compiler evidence bound to one admitted intake attempt."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(self.root, 0o700)
+
+    def _attempt_dir(self, attempt_id: str) -> Path:
+        if not attempt_id or "/" in attempt_id or "\\" in attempt_id or attempt_id in {".", ".."}:
+            raise ValueError("attempt ID is unsafe for evidence materialization")
+        path = self.root / attempt_id
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(path, 0o700)
+        return path
+
+    def write_compilation(
+        self,
+        attempt_id: str,
+        result: CompilationResult,
+        intake_binding: dict[str, str],
+    ) -> None:
+        target = self._attempt_dir(attempt_id)
+        evidence = {**result.evidence, "intake": dict(intake_binding)}
+        _atomic_write(target / "bundle.json", result.bundle_bytes + b"\n")
+        _atomic_write(target / "manifest.json", result.manifest_bytes + b"\n")
+        _atomic_write(
+            target / "compiler-evidence.json",
+            canonical_json_bytes(evidence) + b"\n",
+        )
+
+    def write_blocked(
+        self,
+        attempt_id: str,
+        blocked: CompilationBlocked,
+        intake_binding: dict[str, str],
+    ) -> None:
+        target = self._attempt_dir(attempt_id)
+        evidence = {
+            "diagnostics": [diagnostic.as_dict() for diagnostic in blocked.diagnostics],
+            "intake": dict(intake_binding),
+            "status": "COMPILATION_BLOCKED",
+        }
+        _atomic_write(
+            target / "compiler-diagnostics.json",
+            canonical_json_bytes(evidence) + b"\n",
+        )
+
+    def load_compilation(self, attempt_id: str) -> CompilationResult | None:
+        target = self.root / attempt_id
+        paths = (
+            target / "bundle.json",
+            target / "manifest.json",
+            target / "compiler-evidence.json",
+        )
+        if not all(path.exists() for path in paths):
+            return None
+        bundle: dict[str, Any] = json.loads(paths[0].read_text())
+        manifest: dict[str, Any] = json.loads(paths[1].read_text())
+        evidence: dict[str, Any] = json.loads(paths[2].read_text())
+        bundle_digest = canonical_digest(bundle)
+        manifest_projection = dict(manifest)
+        manifest_digest = manifest_projection.pop("manifest_digest", None)
+        recomputed_manifest_digest = canonical_digest(manifest_projection)
+        if (
+            evidence.get("bundle_digest") != bundle_digest
+            or manifest.get("bundle", {}).get("content_digest") != bundle_digest
+            or evidence.get("manifest_digest") != manifest_digest
+            or manifest_digest != recomputed_manifest_digest
+        ):
+            raise CompilationEvidenceError(
+                "stored compiler artifacts fail their canonical digest bindings"
+            )
+        return CompilationResult.from_artifacts(bundle, manifest, evidence)
+
+    def blocked_exists(self, attempt_id: str) -> bool:
+        return (self.root / attempt_id / "compiler-diagnostics.json").exists()
+
+
+class PmosCompilationService:
+    def __init__(
+        self,
+        *,
+        intake: IntakeCoordinator,
+        compiler: CanonicalCompiler,
+        evidence_store: FileCompilationEvidenceStore,
+    ) -> None:
+        self.intake = intake
+        self.compiler = compiler
+        self.evidence_store = evidence_store
+
+    def process(self, request: IntakeRequest) -> PmosCompilationOutcome:
+        intake_outcome = self.intake.receive(request)
+        receipt = intake_outcome.receipt
+        if receipt is None:
+            return PmosCompilationOutcome(
+                status="INTAKE_SECURITY_BLOCKED",
+                intake=intake_outcome,
+                compilation=None,
+                replayed=intake_outcome.replayed,
+            )
+        if intake_outcome.replayed:
+            try:
+                compiled = self.evidence_store.load_compilation(receipt.attempt_id)
+            except CompilationEvidenceError:
+                return PmosCompilationOutcome(
+                    status="EVIDENCE_SECURITY_BLOCKED",
+                    intake=intake_outcome,
+                    compilation=None,
+                    replayed=True,
+                )
+            if compiled is not None:
+                return PmosCompilationOutcome(
+                    status="COMPILED_BLOCKED" if compiled.blocked else "COMPILED",
+                    intake=intake_outcome,
+                    compilation=compiled,
+                    replayed=True,
+                )
+            status = (
+                "COMPILATION_BLOCKED"
+                if self.evidence_store.blocked_exists(receipt.attempt_id)
+                else (
+                    "INTAKE_REJECTED"
+                    if intake_outcome.status == "REJECTED"
+                    else "INTAKE_SECURITY_BLOCKED"
+                )
+            )
+            return PmosCompilationOutcome(
+                status=status,
+                intake=intake_outcome,
+                compilation=None,
+                replayed=True,
+            )
+        if intake_outcome.status == "REJECTED":
+            return PmosCompilationOutcome(
+                status="INTAKE_REJECTED",
+                intake=intake_outcome,
+                compilation=None,
+            )
+        if intake_outcome.status != "ADMITTED" or intake_outcome.admitted_payload is None:
+            return PmosCompilationOutcome(
+                status="INTAKE_SECURITY_BLOCKED",
+                intake=intake_outcome,
+                compilation=None,
+            )
+
+        binding = {
+            "attempt_id": receipt.attempt_id,
+            "fingerprint": receipt.fingerprint,
+            "key_version": receipt.key_version,
+            "lineage_id": receipt.lineage_id,
+            "received_at": receipt.received_at,
+        }
+        try:
+            compilation = self.compiler.compile(
+                intake_outcome.admitted_payload,
+                content_type=request.content_type,
+                received_at=receipt.received_at,
+                source_name=receipt.attempt_id,
+            )
+        except CompilationBlocked as blocked:
+            self.evidence_store.write_blocked(
+                receipt.attempt_id,
+                blocked,
+                binding,
+            )
+            return PmosCompilationOutcome(
+                status="COMPILATION_BLOCKED",
+                intake=intake_outcome,
+                compilation=None,
+            )
+
+        self.evidence_store.write_compilation(
+            receipt.attempt_id,
+            compilation,
+            binding,
+        )
+        return PmosCompilationOutcome(
+            status="COMPILED_BLOCKED" if compilation.blocked else "COMPILED",
+            intake=intake_outcome,
+            compilation=compilation,
+        )
+
+
+__all__ = [
+    "CompilationEvidenceError",
+    "FileCompilationEvidenceStore",
+    "PmosCompilationOutcome",
+    "PmosCompilationService",
+]

--- a/src/pmpe/contracts/pipeline.py
+++ b/src/pmpe/contracts/pipeline.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import fcntl
+import hashlib
+import hmac
 import os
+import re
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -22,7 +25,12 @@ from pmpe.contracts.compiler import (
     CompilationBlocked,
     CompilationResult,
 )
-from pmpe.contracts.intake import IntakeCoordinator, IntakeOutcome, IntakeRequest
+from pmpe.contracts.intake import (
+    IntakeCoordinator,
+    IntakeOutcome,
+    IntakeRequest,
+    KeyedFingerprintProvider,
+)
 
 
 def _atomic_write(path: Path, payload: bytes) -> None:
@@ -63,12 +71,18 @@ class CompilationEvidenceError(ValueError):
 class FileCompilationEvidenceStore:
     """Content-addressed compiler evidence bound to one admitted intake attempt."""
 
-    def __init__(self, root: Path) -> None:
+    def __init__(
+        self,
+        root: Path,
+        *,
+        fingerprint_provider: KeyedFingerprintProvider,
+    ) -> None:
         self.root = Path(root)
         self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
         os.chmod(self.root, 0o700)
         self._lock_path = self.root / ".evidence.lock"
         self._lock_path.touch(mode=0o600, exist_ok=True)
+        self.fingerprint_provider = fingerprint_provider
 
     @contextmanager
     def _locked(self) -> Iterator[None]:
@@ -101,41 +115,158 @@ class FileCompilationEvidenceStore:
         self,
         attempt_id: str,
         result: CompilationResult,
-        intake_binding: dict[str, str],
+        intake_binding: dict[str, Any],
     ) -> None:
         with self._locked():
             target = self._attempt_dir(attempt_id)
+            if (target / "compiler-diagnostics.json").exists():
+                raise CompilationEvidenceError("blocked and compiled evidence cannot coexist")
             evidence = {**result.evidence, "intake": dict(intake_binding)}
+            artifact_payloads = {
+                "bundle.json": result.bundle_bytes + b"\n",
+                "manifest.json": result.manifest_bytes + b"\n",
+                "compiler-evidence.json": canonical_json_bytes(evidence) + b"\n",
+            }
             self._write_once(
                 target / "bundle.json",
-                result.bundle_bytes + b"\n",
+                artifact_payloads["bundle.json"],
             )
             self._write_once(
                 target / "manifest.json",
-                result.manifest_bytes + b"\n",
+                artifact_payloads["manifest.json"],
             )
             self._write_once(
                 target / "compiler-evidence.json",
-                canonical_json_bytes(evidence) + b"\n",
+                artifact_payloads["compiler-evidence.json"],
+            )
+            self._write_attestation(
+                target,
+                "COMPILATION",
+                artifact_payloads,
+                intake_binding,
             )
 
     def write_blocked(
         self,
         attempt_id: str,
         blocked: CompilationBlocked,
-        intake_binding: dict[str, str],
+        intake_binding: dict[str, Any],
     ) -> None:
         with self._locked():
             target = self._attempt_dir(attempt_id)
+            if any(
+                (target / name).exists()
+                for name in ("bundle.json", "manifest.json", "compiler-evidence.json")
+            ):
+                raise CompilationEvidenceError("blocked and compiled evidence cannot coexist")
             evidence = {
                 "diagnostics": [diagnostic.as_dict() for diagnostic in blocked.diagnostics],
                 "intake": dict(intake_binding),
                 "status": "COMPILATION_BLOCKED",
             }
+            artifact_payloads = {
+                "compiler-diagnostics.json": canonical_json_bytes(evidence) + b"\n"
+            }
             self._write_once(
                 target / "compiler-diagnostics.json",
-                canonical_json_bytes(evidence) + b"\n",
+                artifact_payloads["compiler-diagnostics.json"],
             )
+            self._write_attestation(
+                target,
+                "COMPILATION_BLOCKED",
+                artifact_payloads,
+                intake_binding,
+            )
+
+    @staticmethod
+    def _attestation_payload(
+        kind: str,
+        artifact_payloads: dict[str, bytes],
+        intake_binding: dict[str, Any],
+    ) -> bytes:
+        return canonical_json_bytes(
+            {
+                "artifact_digests": {
+                    name: "sha256:" + hashlib.sha256(payload).hexdigest()
+                    for name, payload in sorted(artifact_payloads.items())
+                },
+                "intake": intake_binding,
+                "kind": kind,
+                "profile": "PMPE-COMPILER-EVIDENCE-1",
+            }
+        )
+
+    def _write_attestation(
+        self,
+        target: Path,
+        kind: str,
+        artifact_payloads: dict[str, bytes],
+        intake_binding: dict[str, Any],
+    ) -> None:
+        payload = self._attestation_payload(
+            kind,
+            artifact_payloads,
+            intake_binding,
+        )
+        fingerprint = self.fingerprint_provider.fingerprint(
+            "compiler-evidence",
+            payload,
+        )
+        key_version = self.fingerprint_provider.key_version
+        if not re.fullmatch(r"[0-9a-fA-F]{32,}", fingerprint):
+            raise CompilationEvidenceError(
+                "fingerprint provider returned an unsafe evidence attestation"
+            )
+        self._write_once(
+            target / "evidence-attestation.json",
+            canonical_json_bytes(
+                {
+                    "domain": "compiler-evidence",
+                    "fingerprint": fingerprint,
+                    "key_version": key_version,
+                    "profile": "PMPE-COMPILER-EVIDENCE-1",
+                }
+            )
+            + b"\n",
+        )
+
+    def _verify_attestation(
+        self,
+        target: Path,
+        kind: str,
+        artifact_payloads: dict[str, bytes],
+        intake_binding: dict[str, Any],
+    ) -> None:
+        attestation = self._load_canonical_object(target / "evidence-attestation.json")
+        if (
+            set(attestation) != {"domain", "fingerprint", "key_version", "profile"}
+            or attestation.get("domain") != "compiler-evidence"
+            or attestation.get("profile") != "PMPE-COMPILER-EVIDENCE-1"
+            or not isinstance(attestation.get("key_version"), str)
+            or not isinstance(attestation.get("fingerprint"), str)
+        ):
+            raise CompilationEvidenceError("stored compiler evidence attestation is malformed")
+        payload = self._attestation_payload(
+            kind,
+            artifact_payloads,
+            intake_binding,
+        )
+        candidate = next(
+            (
+                item
+                for item in self.fingerprint_provider.candidate_fingerprints(
+                    "compiler-evidence",
+                    payload,
+                )
+                if item.key_version == attestation["key_version"]
+            ),
+            None,
+        )
+        if candidate is None or not hmac.compare_digest(
+            candidate.value,
+            attestation["fingerprint"],
+        ):
+            raise CompilationEvidenceError("stored compiler evidence fails its keyed attestation")
 
     @staticmethod
     def _load_canonical_object(path: Path) -> dict[str, Any]:
@@ -153,7 +284,7 @@ class FileCompilationEvidenceStore:
     @staticmethod
     def _validate_intake_binding(
         evidence: dict[str, Any],
-        expected_intake_binding: dict[str, str],
+        expected_intake_binding: dict[str, Any],
     ) -> None:
         if evidence.get("intake") != expected_intake_binding:
             raise CompilationEvidenceError(
@@ -163,18 +294,23 @@ class FileCompilationEvidenceStore:
     def load_compilation(
         self,
         attempt_id: str,
-        expected_intake_binding: dict[str, str],
+        expected_intake_binding: dict[str, Any],
     ) -> CompilationResult | None:
         target = self.root / attempt_id
         paths = (
             target / "bundle.json",
             target / "manifest.json",
             target / "compiler-evidence.json",
+            target / "evidence-attestation.json",
         )
         present = tuple(path.exists() for path in paths)
-        if not any(present):
+        if not any(present[:3]):
             return None
-        if present in {(True, False, False), (True, True, False)}:
+        if present in {
+            (True, False, False, False),
+            (True, True, False, False),
+            (True, True, True, False),
+        }:
             return None
         if not all(present) or (target / "compiler-diagnostics.json").exists():
             raise CompilationEvidenceError("stored compiler evidence set is inconsistent")
@@ -183,6 +319,16 @@ class FileCompilationEvidenceStore:
             manifest = self._load_canonical_object(paths[1])
             evidence = self._load_canonical_object(paths[2])
             self._validate_intake_binding(evidence, expected_intake_binding)
+            self._verify_attestation(
+                target,
+                "COMPILATION",
+                {
+                    "bundle.json": paths[0].read_bytes(),
+                    "manifest.json": paths[1].read_bytes(),
+                    "compiler-evidence.json": paths[2].read_bytes(),
+                },
+                expected_intake_binding,
+            )
             bundle_digest = canonical_digest(bundle)
             manifest_projection = dict(manifest)
             manifest_digest = manifest_projection.pop("manifest_digest", None)
@@ -226,12 +372,24 @@ class FileCompilationEvidenceStore:
     def load_blocked(
         self,
         attempt_id: str,
-        expected_intake_binding: dict[str, str],
+        expected_intake_binding: dict[str, Any],
     ) -> bool:
         target = self.root / attempt_id
         path = target / "compiler-diagnostics.json"
-        if not path.exists():
+        attestation_path = target / "evidence-attestation.json"
+        if not path.exists() and not attestation_path.exists():
             return False
+        if path.exists() and not attestation_path.exists():
+            return False
+        if not path.exists():
+            if any(
+                (target / name).exists()
+                for name in ("bundle.json", "manifest.json", "compiler-evidence.json")
+            ):
+                return False
+            raise CompilationEvidenceError(
+                "compiler evidence attestation has no diagnostic artifact"
+            )
         if any(
             (target / name).exists()
             for name in ("bundle.json", "manifest.json", "compiler-evidence.json")
@@ -239,6 +397,12 @@ class FileCompilationEvidenceStore:
             raise CompilationEvidenceError("blocked and compiled evidence cannot coexist")
         evidence = self._load_canonical_object(path)
         self._validate_intake_binding(evidence, expected_intake_binding)
+        self._verify_attestation(
+            target,
+            "COMPILATION_BLOCKED",
+            {"compiler-diagnostics.json": path.read_bytes()},
+            expected_intake_binding,
+        )
         diagnostics = evidence.get("diagnostics")
         expected_fields = {
             "blocking",
@@ -265,6 +429,44 @@ class FileCompilationEvidenceStore:
         ):
             raise CompilationEvidenceError("stored compiler diagnostics are structurally invalid")
         return True
+
+    def verify_compilation(
+        self,
+        attempt_id: str,
+        expected: CompilationResult,
+        intake_binding: dict[str, Any],
+    ) -> CompilationResult:
+        stored = self.load_compilation(attempt_id, intake_binding)
+        expected_evidence = {**expected.evidence, "intake": intake_binding}
+        if (
+            stored is None
+            or stored.bundle_bytes != expected.bundle_bytes
+            or stored.manifest_bytes != expected.manifest_bytes
+            or stored.evidence != expected_evidence
+        ):
+            raise CompilationEvidenceError(
+                "stored compiler evidence differs from deterministic recompilation"
+            )
+        return stored
+
+    def verify_blocked(
+        self,
+        attempt_id: str,
+        expected: CompilationBlocked,
+        intake_binding: dict[str, Any],
+    ) -> None:
+        if not self.load_blocked(attempt_id, intake_binding):
+            raise CompilationEvidenceError("stored blocking evidence is incomplete")
+        actual = self._load_canonical_object(self.root / attempt_id / "compiler-diagnostics.json")
+        expected_evidence = {
+            "diagnostics": [diagnostic.as_dict() for diagnostic in expected.diagnostics],
+            "intake": intake_binding,
+            "status": "COMPILATION_BLOCKED",
+        }
+        if actual != expected_evidence:
+            raise CompilationEvidenceError(
+                "stored diagnostics differ from deterministic recompilation"
+            )
 
 
 class PmosCompilationService:
@@ -296,13 +498,7 @@ class PmosCompilationService:
                 compilation=None,
                 replayed=intake_outcome.replayed,
             )
-        binding = {
-            "attempt_id": receipt.attempt_id,
-            "fingerprint": receipt.fingerprint,
-            "key_version": receipt.key_version,
-            "lineage_id": receipt.lineage_id,
-            "received_at": receipt.received_at,
-        }
+        binding = receipt.as_dict()
         if intake_outcome.status == "ADMITTED":
             try:
                 compiled = self.evidence_store.load_compilation(
@@ -358,6 +554,49 @@ class PmosCompilationService:
                 replayed=True,
             )
         if existing is not None or blocked_evidence:
+            try:
+                source_payload = self.intake.load_validated_payload(intake_outcome)
+                try:
+                    expected_compilation = self.compiler.compile(
+                        source_payload,
+                        content_type=receipt.content_type,
+                        received_at=receipt.received_at,
+                        source_name=receipt.attempt_id,
+                    )
+                except CompilationBlocked as expected_blocked:
+                    if existing is not None or not blocked_evidence:
+                        raise CompilationEvidenceError(
+                            "stored compiler evidence type differs from recompilation"
+                        ) from expected_blocked
+                    self.evidence_store.verify_blocked(
+                        receipt.attempt_id,
+                        expected_blocked,
+                        binding,
+                    )
+                else:
+                    if existing is None or blocked_evidence:
+                        raise CompilationEvidenceError(
+                            "stored compiler evidence type differs from recompilation"
+                        )
+                    existing = self.evidence_store.verify_compilation(
+                        receipt.attempt_id,
+                        expected_compilation,
+                        binding,
+                    )
+            except CompilationEvidenceError:
+                return PmosCompilationOutcome(
+                    status="EVIDENCE_SECURITY_BLOCKED",
+                    intake=intake_outcome,
+                    compilation=None,
+                    replayed=True,
+                )
+            except Exception:
+                return PmosCompilationOutcome(
+                    status="COMPILATION_SECURITY_BLOCKED",
+                    intake=intake_outcome,
+                    compilation=None,
+                    replayed=True,
+                )
             finalized = self._finalize_intake(intake_outcome)
             if finalized.status != "ADMITTED":
                 return PmosCompilationOutcome(
@@ -381,7 +620,7 @@ class PmosCompilationService:
             source_payload = self.intake.load_validated_payload(intake_outcome)
             compilation = self.compiler.compile(
                 source_payload,
-                content_type=request.content_type,
+                content_type=receipt.content_type,
                 received_at=receipt.received_at,
                 source_name=receipt.attempt_id,
             )
@@ -392,7 +631,12 @@ class PmosCompilationService:
                     blocked,
                     binding,
                 )
-            except (OSError, CompilationEvidenceError):
+                self.evidence_store.verify_blocked(
+                    receipt.attempt_id,
+                    blocked,
+                    binding,
+                )
+            except Exception:
                 return PmosCompilationOutcome(
                     status="COMPILATION_SECURITY_BLOCKED",
                     intake=intake_outcome,
@@ -421,7 +665,12 @@ class PmosCompilationService:
                 compilation,
                 binding,
             )
-        except (OSError, CompilationEvidenceError):
+            compilation = self.evidence_store.verify_compilation(
+                receipt.attempt_id,
+                compilation,
+                binding,
+            )
+        except Exception:
             return PmosCompilationOutcome(
                 status="COMPILATION_SECURITY_BLOCKED",
                 intake=intake_outcome,

--- a/src/pmpe/contracts/pipeline.py
+++ b/src/pmpe/contracts/pipeline.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -60,6 +63,27 @@ class FileCompilationEvidenceStore:
         self.root = Path(root)
         self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
         os.chmod(self.root, 0o700)
+        self._lock_path = self.root / ".evidence.lock"
+        self._lock_path.touch(mode=0o600, exist_ok=True)
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        with self._lock_path.open("rb") as stream:
+            fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+    @staticmethod
+    def _write_once(path: Path, payload: bytes) -> None:
+        if path.exists():
+            if path.read_bytes() != payload:
+                raise CompilationEvidenceError(
+                    "attempt already contains different compiler evidence"
+                )
+            return
+        _atomic_write(path, payload)
 
     def _attempt_dir(self, attempt_id: str) -> Path:
         if not attempt_id or "/" in attempt_id or "\\" in attempt_id or attempt_id in {".", ".."}:
@@ -75,14 +99,21 @@ class FileCompilationEvidenceStore:
         result: CompilationResult,
         intake_binding: dict[str, str],
     ) -> None:
-        target = self._attempt_dir(attempt_id)
-        evidence = {**result.evidence, "intake": dict(intake_binding)}
-        _atomic_write(target / "bundle.json", result.bundle_bytes + b"\n")
-        _atomic_write(target / "manifest.json", result.manifest_bytes + b"\n")
-        _atomic_write(
-            target / "compiler-evidence.json",
-            canonical_json_bytes(evidence) + b"\n",
-        )
+        with self._locked():
+            target = self._attempt_dir(attempt_id)
+            evidence = {**result.evidence, "intake": dict(intake_binding)}
+            self._write_once(
+                target / "bundle.json",
+                result.bundle_bytes + b"\n",
+            )
+            self._write_once(
+                target / "manifest.json",
+                result.manifest_bytes + b"\n",
+            )
+            self._write_once(
+                target / "compiler-evidence.json",
+                canonical_json_bytes(evidence) + b"\n",
+            )
 
     def write_blocked(
         self,
@@ -90,16 +121,17 @@ class FileCompilationEvidenceStore:
         blocked: CompilationBlocked,
         intake_binding: dict[str, str],
     ) -> None:
-        target = self._attempt_dir(attempt_id)
-        evidence = {
-            "diagnostics": [diagnostic.as_dict() for diagnostic in blocked.diagnostics],
-            "intake": dict(intake_binding),
-            "status": "COMPILATION_BLOCKED",
-        }
-        _atomic_write(
-            target / "compiler-diagnostics.json",
-            canonical_json_bytes(evidence) + b"\n",
-        )
+        with self._locked():
+            target = self._attempt_dir(attempt_id)
+            evidence = {
+                "diagnostics": [diagnostic.as_dict() for diagnostic in blocked.diagnostics],
+                "intake": dict(intake_binding),
+                "status": "COMPILATION_BLOCKED",
+            }
+            self._write_once(
+                target / "compiler-diagnostics.json",
+                canonical_json_bytes(evidence) + b"\n",
+            )
 
     def load_compilation(self, attempt_id: str) -> CompilationResult | None:
         target = self.root / attempt_id
@@ -154,7 +186,14 @@ class PmosCompilationService:
                 compilation=None,
                 replayed=intake_outcome.replayed,
             )
-        if intake_outcome.replayed:
+        if intake_outcome.status == "REJECTED":
+            return PmosCompilationOutcome(
+                status="INTAKE_REJECTED",
+                intake=intake_outcome,
+                compilation=None,
+                replayed=intake_outcome.replayed,
+            )
+        if intake_outcome.status == "ADMITTED":
             try:
                 compiled = self.evidence_store.load_compilation(receipt.attempt_id)
             except CompilationEvidenceError:
@@ -174,11 +213,7 @@ class PmosCompilationService:
             status = (
                 "COMPILATION_BLOCKED"
                 if self.evidence_store.blocked_exists(receipt.attempt_id)
-                else (
-                    "INTAKE_REJECTED"
-                    if intake_outcome.status == "REJECTED"
-                    else "INTAKE_SECURITY_BLOCKED"
-                )
+                else "EVIDENCE_SECURITY_BLOCKED"
             )
             return PmosCompilationOutcome(
                 status=status,
@@ -186,13 +221,7 @@ class PmosCompilationService:
                 compilation=None,
                 replayed=True,
             )
-        if intake_outcome.status == "REJECTED":
-            return PmosCompilationOutcome(
-                status="INTAKE_REJECTED",
-                intake=intake_outcome,
-                compilation=None,
-            )
-        if intake_outcome.status != "ADMITTED" or intake_outcome.admitted_payload is None:
+        if intake_outcome.status != "VALIDATED_PENDING_COMPILATION":
             return PmosCompilationOutcome(
                 status="INTAKE_SECURITY_BLOCKED",
                 intake=intake_outcome,
@@ -207,34 +236,100 @@ class PmosCompilationService:
             "received_at": receipt.received_at,
         }
         try:
+            existing = self.evidence_store.load_compilation(receipt.attempt_id)
+        except CompilationEvidenceError:
+            return PmosCompilationOutcome(
+                status="EVIDENCE_SECURITY_BLOCKED",
+                intake=intake_outcome,
+                compilation=None,
+                replayed=True,
+            )
+        if existing is not None or self.evidence_store.blocked_exists(receipt.attempt_id):
+            finalized = self._finalize_intake(intake_outcome)
+            if finalized.status != "ADMITTED":
+                return PmosCompilationOutcome(
+                    status="INTAKE_SECURITY_BLOCKED",
+                    intake=finalized,
+                    compilation=existing,
+                    replayed=True,
+                )
+            return PmosCompilationOutcome(
+                status=(
+                    "COMPILED_BLOCKED"
+                    if existing is not None and existing.blocked
+                    else ("COMPILED" if existing is not None else "COMPILATION_BLOCKED")
+                ),
+                intake=finalized,
+                compilation=existing,
+                replayed=True,
+            )
+
+        try:
+            source_payload = self.intake.load_validated_payload(intake_outcome)
             compilation = self.compiler.compile(
-                intake_outcome.admitted_payload,
+                source_payload,
                 content_type=request.content_type,
                 received_at=receipt.received_at,
                 source_name=receipt.attempt_id,
             )
         except CompilationBlocked as blocked:
-            self.evidence_store.write_blocked(
-                receipt.attempt_id,
-                blocked,
-                binding,
-            )
+            try:
+                self.evidence_store.write_blocked(
+                    receipt.attempt_id,
+                    blocked,
+                    binding,
+                )
+            except (OSError, CompilationEvidenceError):
+                return PmosCompilationOutcome(
+                    status="COMPILATION_SECURITY_BLOCKED",
+                    intake=intake_outcome,
+                    compilation=None,
+                )
+            finalized = self._finalize_intake(intake_outcome)
             return PmosCompilationOutcome(
-                status="COMPILATION_BLOCKED",
+                status=(
+                    "COMPILATION_BLOCKED"
+                    if finalized.status == "ADMITTED"
+                    else "INTAKE_SECURITY_BLOCKED"
+                ),
+                intake=finalized,
+                compilation=None,
+            )
+        except Exception:
+            return PmosCompilationOutcome(
+                status="COMPILATION_SECURITY_BLOCKED",
                 intake=intake_outcome,
                 compilation=None,
             )
 
-        self.evidence_store.write_compilation(
-            receipt.attempt_id,
-            compilation,
-            binding,
-        )
+        try:
+            self.evidence_store.write_compilation(
+                receipt.attempt_id,
+                compilation,
+                binding,
+            )
+        except (OSError, CompilationEvidenceError):
+            return PmosCompilationOutcome(
+                status="COMPILATION_SECURITY_BLOCKED",
+                intake=intake_outcome,
+                compilation=None,
+            )
+        finalized = self._finalize_intake(intake_outcome)
         return PmosCompilationOutcome(
-            status="COMPILED_BLOCKED" if compilation.blocked else "COMPILED",
-            intake=intake_outcome,
+            status=(
+                "COMPILED_BLOCKED"
+                if compilation.blocked and finalized.status == "ADMITTED"
+                else ("COMPILED" if finalized.status == "ADMITTED" else "INTAKE_SECURITY_BLOCKED")
+            ),
+            intake=finalized,
             compilation=compilation,
         )
+
+    def _finalize_intake(self, intake_outcome: IntakeOutcome) -> IntakeOutcome:
+        try:
+            return self.intake.finalize_admission(intake_outcome)
+        except Exception:
+            return intake_outcome
 
 
 __all__ = [

--- a/tests/integration/test_pmos_compilation_pipeline.py
+++ b/tests/integration/test_pmos_compilation_pipeline.py
@@ -1,0 +1,186 @@
+"""Issue #76 integrated intake -> compile -> durable evidence lifecycle."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from tests.unit.test_pmos_intake import (
+    CleanMalwareScanner,
+    FixedClock,
+    SequenceIds,
+    TestCipher,
+    TestFingerprintProvider,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "tests" / "fixtures"
+BUNDLE_SCHEMA = json.loads((ROOT / "schemas" / "pmos_contract_bundle.schema.json").read_text())
+MANIFEST_SCHEMA = json.loads((ROOT / "schemas" / "pmos_contract_manifest.schema.json").read_text())
+
+
+def _module(name: str) -> ModuleType:
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError:
+        pytest.fail(f"issue #76 module {name!r} is not implemented", pytrace=False)
+
+
+def _service(tmp_path: Path) -> Any:
+    intake = _module("pmpe.contracts.intake")
+    pipeline = _module("pmpe.contracts.pipeline")
+    compiler = _module("pmpe.contracts.compiler")
+    clock = FixedClock()
+    ids = SequenceIds()
+    fingerprints = TestFingerprintProvider()
+    ledger = intake.FileIntakeLedger(
+        tmp_path / "ledger",
+        clock=clock,
+        id_provider=ids,
+        fingerprint_provider=fingerprints,
+    )
+    quarantine = intake.FileQuarantineStore(
+        tmp_path / "quarantine",
+        cipher=TestCipher(),
+        max_bytes=2_000_000,
+    )
+    coordinator = intake.IntakeCoordinator(
+        ledger=ledger,
+        quarantine=quarantine,
+        fingerprint_provider=fingerprints,
+        malware_scanner=CleanMalwareScanner(),
+        clock=clock,
+        max_bytes=2_000_000,
+        allowed_content_types={"application/json", "application/yaml"},
+    )
+    return pipeline.PmosCompilationService(
+        intake=coordinator,
+        compiler=compiler.CanonicalCompiler(),
+        evidence_store=pipeline.FileCompilationEvidenceStore(tmp_path / "evidence"),
+    )
+
+
+def _request(path: Path, retry_key: str) -> Any:
+    intake = _module("pmpe.contracts.intake")
+    return intake.IntakeRequest(
+        retry_key=retry_key,
+        payload=path.read_bytes(),
+        content_type="application/json",
+        publisher="pm-agent-os",
+        channel="contract-api",
+        correction_reference=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("fixture", "retry_key"),
+    [
+        (FIXTURES / "minimal_valid_spec.json", "v1"),
+        (FIXTURES / "v2" / "contract_approved.json", "v2"),
+        (FIXTURES / "v3" / "fullstack_contract_approved.json", "v3"),
+    ],
+)
+def test_supported_input_produces_durable_schema_valid_evidence(
+    tmp_path: Path,
+    fixture: Path,
+    retry_key: str,
+) -> None:
+    result = _service(tmp_path).process(_request(fixture, retry_key))
+    assert result.status == "COMPILED_BLOCKED"
+    assert result.compilation.blocked
+    assert list(Draft202012Validator(BUNDLE_SCHEMA).iter_errors(result.compilation.bundle)) == []
+    assert (
+        list(Draft202012Validator(MANIFEST_SCHEMA).iter_errors(result.compilation.manifest)) == []
+    )
+    attempt_dir = tmp_path / "evidence" / result.intake.receipt.attempt_id
+    assert (attempt_dir / "bundle.json").read_bytes() == result.compilation.bundle_bytes + b"\n"
+    assert (attempt_dir / "manifest.json").read_bytes() == result.compilation.manifest_bytes + b"\n"
+    evidence = json.loads((attempt_dir / "compiler-evidence.json").read_text())
+    assert evidence["bundle_digest"] == result.compilation.bundle_digest
+    assert evidence["manifest_digest"] == result.compilation.manifest_digest
+    assert evidence["intake"]["lineage_id"] == result.intake.receipt.lineage_id
+    assert evidence["intake"]["attempt_id"] == result.intake.receipt.attempt_id
+    assert "payload" not in evidence["intake"]
+    assert not result.intake.quarantine_retained
+
+
+def test_acknowledgement_retry_returns_same_compilation_without_new_object(
+    tmp_path: Path,
+) -> None:
+    service = _service(tmp_path)
+    request = _request(FIXTURES / "minimal_valid_spec.json", "ack-retry")
+    first = service.process(request)
+    second = service.process(request)
+    assert second.replayed
+    assert second.intake.reservation == first.intake.reservation
+    assert second.compilation.bundle_digest == first.compilation.bundle_digest
+    assert second.compilation.manifest_digest == first.compilation.manifest_digest
+    assert len(list((tmp_path / "evidence").iterdir())) == 1
+
+
+def test_unsupported_source_is_deleted_and_emits_no_bundle_or_manifest(
+    tmp_path: Path,
+) -> None:
+    intake = _module("pmpe.contracts.intake")
+    request = intake.IntakeRequest(
+        retry_key="unsupported",
+        payload=b'{"spec_version":"9.9","product_name":"Unsupported"}',
+        content_type="application/json",
+        publisher="pm-agent-os",
+        channel="contract-api",
+        correction_reference=None,
+    )
+    result = _service(tmp_path).process(request)
+    assert result.status == "COMPILATION_BLOCKED"
+    assert result.compilation is None
+    assert result.intake.deletion_attestation.deleted
+    attempt_dir = tmp_path / "evidence" / result.intake.receipt.attempt_id
+    assert not (attempt_dir / "bundle.json").exists()
+    assert not (attempt_dir / "manifest.json").exists()
+    diagnostic = json.loads((attempt_dir / "compiler-diagnostics.json").read_text())
+    assert diagnostic["diagnostics"][0]["code"] == "UNSUPPORTED_SOURCE_VERSION"
+
+
+def test_rejected_secret_never_reaches_compiler_or_immutable_evidence(tmp_path: Path) -> None:
+    intake = _module("pmpe.contracts.intake")
+    payload = b'{"spec_version":"1.0","token":"ghp_abcdefghijklmnopqrstuvwxyz123456"}'
+    result = _service(tmp_path).process(
+        intake.IntakeRequest(
+            retry_key="secret",
+            payload=payload,
+            content_type="application/json",
+            publisher="pm-agent-os",
+            channel="contract-api",
+            correction_reference=None,
+        )
+    )
+    assert result.status == "INTAKE_REJECTED"
+    assert result.compilation is None
+    evidence_bytes = b"\n".join(
+        path.read_bytes() for path in (tmp_path / "evidence").rglob("*") if path.is_file()
+    )
+    assert payload not in evidence_bytes
+    assert b"ghp_" not in evidence_bytes
+
+
+def test_compiler_evidence_is_bound_to_exact_intake_receipt(tmp_path: Path) -> None:
+    result = _service(tmp_path).process(
+        _request(FIXTURES / "v2" / "contract_approved.json", "receipt-binding")
+    )
+    evidence_path = (
+        tmp_path / "evidence" / result.intake.receipt.attempt_id / "compiler-evidence.json"
+    )
+    evidence = json.loads(evidence_path.read_text())
+    assert evidence["intake"] == {
+        "attempt_id": result.intake.receipt.attempt_id,
+        "fingerprint": result.intake.receipt.fingerprint,
+        "key_version": result.intake.receipt.key_version,
+        "lineage_id": result.intake.receipt.lineage_id,
+        "received_at": result.intake.receipt.received_at,
+    }

--- a/tests/integration/test_pmos_compilation_pipeline.py
+++ b/tests/integration/test_pmos_compilation_pipeline.py
@@ -124,6 +124,20 @@ def test_acknowledgement_retry_returns_same_compilation_without_new_object(
     assert len(list((tmp_path / "evidence").iterdir())) == 1
 
 
+def test_tampered_compilation_evidence_fails_closed_on_retry(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    request = _request(FIXTURES / "minimal_valid_spec.json", "tamper")
+    first = service.process(request)
+    bundle_path = tmp_path / "evidence" / first.intake.receipt.attempt_id / "bundle.json"
+    bundle = json.loads(bundle_path.read_text())
+    bundle["bundle_version"] = "9.9.9"
+    bundle_path.write_text(json.dumps(bundle))
+    replay = service.process(request)
+    assert replay.status == "EVIDENCE_SECURITY_BLOCKED"
+    assert replay.compilation is None
+    assert replay.replayed
+
+
 def test_unsupported_source_is_deleted_and_emits_no_bundle_or_manifest(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_pmos_compilation_pipeline.py
+++ b/tests/integration/test_pmos_compilation_pipeline.py
@@ -121,7 +121,29 @@ def test_acknowledgement_retry_returns_same_compilation_without_new_object(
     assert second.intake.reservation == first.intake.reservation
     assert second.compilation.bundle_digest == first.compilation.bundle_digest
     assert second.compilation.manifest_digest == first.compilation.manifest_digest
-    assert len(list((tmp_path / "evidence").iterdir())) == 1
+    assert len([path for path in (tmp_path / "evidence").iterdir() if path.is_dir()]) == 1
+
+
+def test_compiler_failure_keeps_validated_source_for_safe_retry(
+    tmp_path: Path,
+) -> None:
+    service = _service(tmp_path)
+    request = _request(FIXTURES / "minimal_valid_spec.json", "compiler-crash")
+    real_compile = service.compiler.compile
+
+    def fail_once(*args: Any, **kwargs: Any) -> Any:
+        service.compiler.compile = real_compile
+        raise RuntimeError("simulated compiler crash")
+
+    service.compiler.compile = fail_once
+    failed = service.process(request)
+    assert failed.status == "COMPILATION_SECURITY_BLOCKED"
+    assert failed.intake.quarantine_retained
+    assert failed.intake.disposition.terminal is False
+    retried = service.process(request)
+    assert retried.status == "COMPILED_BLOCKED"
+    assert retried.intake.deletion_attestation.deleted
+    assert not retried.intake.quarantine_retained
 
 
 def test_tampered_compilation_evidence_fails_closed_on_retry(tmp_path: Path) -> None:

--- a/tests/integration/test_pmos_compilation_pipeline.py
+++ b/tests/integration/test_pmos_compilation_pipeline.py
@@ -62,7 +62,10 @@ def _service(tmp_path: Path) -> Any:
     return pipeline.PmosCompilationService(
         intake=coordinator,
         compiler=compiler.CanonicalCompiler(),
-        evidence_store=pipeline.FileCompilationEvidenceStore(tmp_path / "evidence"),
+        evidence_store=pipeline.FileCompilationEvidenceStore(
+            tmp_path / "evidence",
+            fingerprint_provider=fingerprints,
+        ),
     )
 
 
@@ -106,7 +109,9 @@ def test_supported_input_produces_durable_schema_valid_evidence(
     assert evidence["manifest_digest"] == result.compilation.manifest_digest
     assert evidence["intake"]["lineage_id"] == result.intake.receipt.lineage_id
     assert evidence["intake"]["attempt_id"] == result.intake.receipt.attempt_id
+    assert evidence["intake"] == result.intake.receipt.as_dict()
     assert "payload" not in evidence["intake"]
+    assert (attempt_dir / "evidence-attestation.json").exists()
     assert not result.intake.quarantine_retained
 
 
@@ -184,6 +189,26 @@ def test_forged_compilation_intake_binding_cannot_finalize_retained_source(
     assert replay.compilation is None
     assert replay.intake.quarantine_retained
     assert replay.intake.deletion_attestation is None
+
+
+def test_self_consistent_compiler_provenance_forgery_fails_keyed_attestation(
+    tmp_path: Path,
+) -> None:
+    service = _service(tmp_path)
+    request = _request(FIXTURES / "minimal_valid_spec.json", "forged-provenance")
+    first = service.process(request)
+    evidence_path = (
+        tmp_path / "evidence" / first.intake.receipt.attempt_id / "compiler-evidence.json"
+    )
+    evidence = json.loads(evidence_path.read_text())
+    evidence["source_format"] = "PMOS_V3"
+    evidence["source_version"] = "1"
+    evidence_path.write_bytes(
+        _module("pmpe.contracts.canonical").canonical_json_bytes(evidence) + b"\n"
+    )
+    replay = service.process(request)
+    assert replay.status == "EVIDENCE_SECURITY_BLOCKED"
+    assert replay.compilation is None
 
 
 def test_forged_blocked_intake_binding_cannot_finalize_retained_source(
@@ -273,10 +298,8 @@ def test_compiler_evidence_is_bound_to_exact_intake_receipt(tmp_path: Path) -> N
         tmp_path / "evidence" / result.intake.receipt.attempt_id / "compiler-evidence.json"
     )
     evidence = json.loads(evidence_path.read_text())
-    assert evidence["intake"] == {
-        "attempt_id": result.intake.receipt.attempt_id,
-        "fingerprint": result.intake.receipt.fingerprint,
-        "key_version": result.intake.receipt.key_version,
-        "lineage_id": result.intake.receipt.lineage_id,
-        "received_at": result.intake.receipt.received_at,
-    }
+    assert evidence["intake"] == result.intake.receipt.as_dict()
+    assert evidence["intake"]["content_type"] == "application/json"
+    assert evidence["intake"]["publisher"] == "pm-agent-os"
+    assert evidence["intake"]["channel"] == "contract-api"
+    assert evidence["intake"]["quarantine_handle"] == result.intake.receipt.quarantine_handle

--- a/tests/integration/test_pmos_compilation_pipeline.py
+++ b/tests/integration/test_pmos_compilation_pipeline.py
@@ -160,6 +160,66 @@ def test_tampered_compilation_evidence_fails_closed_on_retry(tmp_path: Path) -> 
     assert replay.replayed
 
 
+def test_forged_compilation_intake_binding_cannot_finalize_retained_source(
+    tmp_path: Path,
+) -> None:
+    service = _service(tmp_path)
+    request = _request(FIXTURES / "minimal_valid_spec.json", "forged-compilation-binding")
+    real_finalize = service._finalize_intake
+    service._finalize_intake = lambda outcome: outcome
+    first = service.process(request)
+    assert first.status == "INTAKE_SECURITY_BLOCKED"
+    assert first.intake.quarantine_retained
+    evidence_path = (
+        tmp_path / "evidence" / first.intake.receipt.attempt_id / "compiler-evidence.json"
+    )
+    evidence = json.loads(evidence_path.read_text())
+    evidence["intake"]["attempt_id"] = "ATTEMPT-999999"
+    evidence_path.write_bytes(
+        _module("pmpe.contracts.canonical").canonical_json_bytes(evidence) + b"\n"
+    )
+    service._finalize_intake = real_finalize
+    replay = service.process(request)
+    assert replay.status == "EVIDENCE_SECURITY_BLOCKED"
+    assert replay.compilation is None
+    assert replay.intake.quarantine_retained
+    assert replay.intake.deletion_attestation is None
+
+
+def test_forged_blocked_intake_binding_cannot_finalize_retained_source(
+    tmp_path: Path,
+) -> None:
+    service = _service(tmp_path)
+    intake = _module("pmpe.contracts.intake")
+    request = intake.IntakeRequest(
+        retry_key="forged-blocked-binding",
+        payload=b'{"spec_version":"9.9","product_name":"Unsupported"}',
+        content_type="application/json",
+        publisher="pm-agent-os",
+        channel="contract-api",
+        correction_reference=None,
+    )
+    real_finalize = service._finalize_intake
+    service._finalize_intake = lambda outcome: outcome
+    first = service.process(request)
+    assert first.status == "INTAKE_SECURITY_BLOCKED"
+    assert first.intake.quarantine_retained
+    evidence_path = (
+        tmp_path / "evidence" / first.intake.receipt.attempt_id / "compiler-diagnostics.json"
+    )
+    evidence = json.loads(evidence_path.read_text())
+    evidence["intake"]["attempt_id"] = "ATTEMPT-999999"
+    evidence_path.write_bytes(
+        _module("pmpe.contracts.canonical").canonical_json_bytes(evidence) + b"\n"
+    )
+    service._finalize_intake = real_finalize
+    replay = service.process(request)
+    assert replay.status == "EVIDENCE_SECURITY_BLOCKED"
+    assert replay.compilation is None
+    assert replay.intake.quarantine_retained
+    assert replay.intake.deletion_attestation is None
+
+
 def test_unsupported_source_is_deleted_and_emits_no_bundle_or_manifest(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_pmos_compiler.py
+++ b/tests/unit/test_pmos_compiler.py
@@ -1,0 +1,464 @@
+"""Issue #76: loss-aware PMOS V1/V2/V3 compilation and migration evidence."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "tests" / "fixtures"
+BUNDLE_SCHEMA = json.loads((ROOT / "schemas" / "pmos_contract_bundle.schema.json").read_text())
+MANIFEST_SCHEMA = json.loads((ROOT / "schemas" / "pmos_contract_manifest.schema.json").read_text())
+FIXED_TIME = "2026-07-31T08:00:00Z"
+
+LEGACY_CASES = (
+    ("PMOS_V1", "1.0", FIXTURES / "minimal_valid_spec.json"),
+    ("PMOS_V2", "1", FIXTURES / "v2" / "contract_approved.json"),
+    ("PMOS_V3", "1", FIXTURES / "v3" / "fullstack_contract_approved.json"),
+)
+
+
+def _module(name: str) -> ModuleType:
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError:
+        pytest.fail(f"issue #76 module {name!r} is not implemented", pytrace=False)
+
+
+def _compiler() -> Any:
+    module = _module("pmpe.contracts.compiler")
+    compiler_type = getattr(module, "CanonicalCompiler", None)
+    assert compiler_type is not None, "CanonicalCompiler is not implemented"
+    return compiler_type()
+
+
+def _compile(path: Path) -> Any:
+    return _compiler().compile(
+        path.read_bytes(),
+        content_type="application/json",
+        received_at=FIXED_TIME,
+        source_name=path.name,
+    )
+
+
+def _schema_errors(instance: Any, schema: dict[str, Any]) -> list[str]:
+    return [
+        f"{error.json_path}: {error.message}"
+        for error in Draft202012Validator(schema).iter_errors(instance)
+    ]
+
+
+def _manifest_projection(manifest: dict[str, Any]) -> dict[str, Any]:
+    projected = copy.deepcopy(manifest)
+    del projected["manifest_digest"]
+    return projected
+
+
+def test_issue76_public_compiler_components_exist() -> None:
+    compiler = _module("pmpe.contracts.compiler")
+    migrations = _module("pmpe.contracts.migrations")
+    canonical = _module("pmpe.contracts.canonical")
+    for name in (
+        "CanonicalCompiler",
+        "CompilationBlocked",
+        "CompilationDiagnostic",
+        "CompilationResult",
+        "SourceFormat",
+    ):
+        assert hasattr(compiler, name), f"missing compiler component: {name}"
+    for name in ("MigrationError", "MigrationRegistry", "MigrationStep"):
+        assert hasattr(migrations, name), f"missing migration component: {name}"
+    for name in ("canonical_digest", "canonical_json_bytes", "strict_loads"):
+        assert hasattr(canonical, name), f"missing canonicalization component: {name}"
+
+
+@pytest.mark.parametrize(("expected_format", "expected_version", "fixture"), LEGACY_CASES)
+def test_supported_legacy_contract_compiles_to_schema_valid_draft(
+    expected_format: str,
+    expected_version: str,
+    fixture: Path,
+) -> None:
+    result = _compile(fixture)
+    assert result.source_format.value == expected_format
+    assert result.source_version == expected_version
+    assert result.bundle["contract_status"] == "DRAFT"
+    assert result.blocked is True
+    assert result.bundle["unresolved_product_truth"]
+    assert _schema_errors(result.bundle, BUNDLE_SCHEMA) == []
+    assert _schema_errors(result.manifest, MANIFEST_SCHEMA) == []
+
+
+@pytest.mark.parametrize(("_format", "_version", "fixture"), LEGACY_CASES)
+def test_same_source_and_toolchain_are_byte_deterministic(
+    _format: str,
+    _version: str,
+    fixture: Path,
+) -> None:
+    first = _compile(fixture)
+    second = _compile(fixture)
+    assert first.bundle_bytes == second.bundle_bytes
+    assert first.manifest_bytes == second.manifest_bytes
+    assert first.bundle_digest == second.bundle_digest
+    assert first.manifest_digest == second.manifest_digest
+    assert first.evidence == second.evidence
+
+
+@pytest.mark.parametrize(("_format", "_version", "fixture"), LEGACY_CASES)
+def test_source_formatting_and_key_order_do_not_change_compilation(
+    _format: str,
+    _version: str,
+    fixture: Path,
+) -> None:
+    data = json.loads(fixture.read_text())
+    reordered = dict(reversed(list(data.items())))
+    rendered = json.dumps(reordered, indent=4).encode()
+    original = _compile(fixture)
+    changed_format = _compiler().compile(
+        rendered,
+        content_type="application/json",
+        received_at=FIXED_TIME,
+        source_name=fixture.name,
+    )
+    assert changed_format.bundle_bytes == original.bundle_bytes
+    assert changed_format.manifest_bytes == original.manifest_bytes
+    assert changed_format.evidence["source_digest"] == original.evidence["source_digest"]
+
+
+def test_v1_exact_scope_is_mapped_without_defaults() -> None:
+    result = _compile(FIXTURES / "minimal_valid_spec.json")
+    source = json.loads((FIXTURES / "minimal_valid_spec.json").read_text())
+    assert result.bundle["scope"] == {
+        "in_scope": source["scope"],
+        "non_goals": source["non_goals"],
+    }
+    rendered = json.dumps(result.bundle, sort_keys=True)
+    assert "TBD" not in rendered
+    assert "TODO" not in rendered
+    assert "unknown" not in rendered.lower()
+
+
+def test_v2_required_approvals_and_source_approver_are_preserved() -> None:
+    result = _compile(FIXTURES / "v2" / "contract_approved.json")
+    source = json.loads((FIXTURES / "v2" / "contract_approved.json").read_text())
+    assert result.bundle["provenance"]["source_approved_by"] == source["approved_by"]
+    assert result.bundle["required_approvals"] == {
+        "APPROVAL-REQ-001": {
+            "purpose": source["required_approvals"][0]["for"],
+            "role": source["required_approvals"][0]["role"],
+        }
+    }
+
+
+def test_v3_api_and_backend_capability_values_are_preserved() -> None:
+    result = _compile(FIXTURES / "v3" / "fullstack_contract_approved.json")
+    source = json.loads((FIXTURES / "v3" / "fullstack_contract_approved.json").read_text())
+    assert result.bundle["api_contracts"]["API-1"] == {
+        "method": source["api_contracts"][0]["method"],
+        "path": source["api_contracts"][0]["path"],
+        "purpose": source["api_contracts"][0]["purpose"],
+    }
+    assert result.bundle["backend_capabilities"]["CAPABILITY-BC-1"] == {
+        "description": source["backend_capabilities"][0]["description"]
+    }
+    mapping = result.bundle["source_identity_mappings"]["SOURCE-MAP-CAPABILITY-BC-1"]
+    assert mapping["source_id"] == "BC-1"
+    assert mapping["source_pointer"] == "/backend_capabilities/0"
+    assert mapping["canonical_pointer"] == "/backend_capabilities/CAPABILITY-BC-1"
+
+
+@pytest.mark.parametrize(("_format", "_version", "fixture"), LEGACY_CASES)
+def test_every_source_field_is_mapped_or_preserved_in_a_blocking_diagnostic(
+    _format: str,
+    _version: str,
+    fixture: Path,
+) -> None:
+    result = _compile(fixture)
+    source = json.loads(fixture.read_text())
+    covered = set(result.evidence["mapped_source_paths"])
+    covered.update(diagnostic.source_path for diagnostic in result.diagnostics)
+    assert {f"/{key}" for key in source} <= covered
+    for diagnostic in result.diagnostics:
+        assert diagnostic.blocking
+        assert diagnostic.source_path.startswith("/") or diagnostic.source_path == ""
+        assert diagnostic.message
+        assert "secret" not in diagnostic.message.lower()
+
+
+def test_missing_canonical_truth_is_explicit_and_never_gets_a_source_value() -> None:
+    result = _compile(FIXTURES / "minimal_valid_spec.json")
+    absent = [
+        item
+        for item in result.bundle["unresolved_product_truth"].values()
+        if item["reason_code"] == "REQUIRED_PRODUCT_TRUTH_ABSENT"
+    ]
+    assert absent
+    assert all("source_pointer" not in item for item in absent)
+    assert all("source_value" not in item for item in absent)
+    assert all(item["target_pointer"].startswith("/") for item in absent)
+
+
+def test_supplied_unmapped_truth_is_preserved_exactly() -> None:
+    fixture = FIXTURES / "minimal_valid_spec.json"
+    source = json.loads(fixture.read_text())
+    result = _compile(fixture)
+    diagnostic = next(
+        item
+        for item in result.bundle["unresolved_product_truth"].values()
+        if item.get("source_pointer") == "/product_name"
+    )
+    assert diagnostic["source_value"] == source["product_name"]
+    assert diagnostic["reason_code"] in {"AMBIGUOUS_MAPPING", "SOURCE_FIELD_UNMAPPED"}
+
+
+def test_unknown_source_field_fails_closed_with_pointer_and_no_artifact() -> None:
+    compiler = _module("pmpe.contracts.compiler")
+    blocked_type = compiler.CompilationBlocked
+    source = json.loads((FIXTURES / "minimal_valid_spec.json").read_text())
+    source["surprise_product_truth"] = "must not disappear"
+    with pytest.raises(blocked_type) as raised:
+        _compiler().compile(
+            json.dumps(source).encode(),
+            content_type="application/json",
+            received_at=FIXED_TIME,
+            source_name="unknown.json",
+        )
+    assert raised.value.bundle is None
+    assert any(
+        diagnostic.code == "SOURCE_FIELD_UNKNOWN"
+        and diagnostic.source_path == "/surprise_product_truth"
+        for diagnostic in raised.value.diagnostics
+    )
+
+
+@pytest.mark.parametrize(
+    ("fixture", "version_field", "unsupported"),
+    [
+        (FIXTURES / "minimal_valid_spec.json", "spec_version", "2.0"),
+        (FIXTURES / "v2" / "contract_approved.json", "contract_version", 2),
+        (FIXTURES / "v3" / "fullstack_contract_approved.json", "contract_version", 9),
+    ],
+)
+def test_unsupported_source_version_fails_closed(
+    fixture: Path,
+    version_field: str,
+    unsupported: Any,
+) -> None:
+    compiler = _module("pmpe.contracts.compiler")
+    blocked_type = compiler.CompilationBlocked
+    source = json.loads(fixture.read_text())
+    source[version_field] = unsupported
+    with pytest.raises(blocked_type) as raised:
+        _compiler().compile(
+            json.dumps(source).encode(),
+            content_type="application/json",
+            received_at=FIXED_TIME,
+            source_name=fixture.name,
+        )
+    assert any(
+        diagnostic.code == "UNSUPPORTED_SOURCE_VERSION" for diagnostic in raised.value.diagnostics
+    )
+
+
+def test_ambiguous_source_shape_fails_closed() -> None:
+    compiler = _module("pmpe.contracts.compiler")
+    blocked_type = compiler.CompilationBlocked
+    ambiguous = {
+        "spec_version": "1.0",
+        "contract_version": 1,
+        "contract_id": "PDC-AMBIGUOUS",
+    }
+    with pytest.raises(blocked_type) as raised:
+        _compiler().compile(
+            json.dumps(ambiguous).encode(),
+            content_type="application/json",
+            received_at=FIXED_TIME,
+            source_name="ambiguous.json",
+        )
+    assert any(
+        diagnostic.code == "AMBIGUOUS_SOURCE_FORMAT" for diagnostic in raised.value.diagnostics
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "code"),
+    [
+        (b'{"spec_version":"1.0","spec_version":"1.0"}', "DUPLICATE_OBJECT_KEY"),
+        (b'{"spec_version": NaN}', "NON_JSON_NUMBER"),
+        (b'{"spec_version":"\\ud800"}', "INVALID_UNICODE"),
+        (b'{"spec_version":"1.0"', "MALFORMED_SOURCE"),
+    ],
+)
+def test_malformed_or_non_interoperable_json_fails_before_detection(
+    payload: bytes,
+    code: str,
+) -> None:
+    compiler = _module("pmpe.contracts.compiler")
+    blocked_type = compiler.CompilationBlocked
+    with pytest.raises(blocked_type) as raised:
+        _compiler().compile(
+            payload,
+            content_type="application/json",
+            received_at=FIXED_TIME,
+            source_name="invalid.json",
+        )
+    assert raised.value.diagnostics[0].code == code
+    assert raised.value.bundle is None
+
+
+def test_yaml_v1_is_supported_with_duplicate_aware_parsing() -> None:
+    source = json.loads((FIXTURES / "minimal_valid_spec.json").read_text())
+    yaml = _module("yaml")
+    payload = yaml.safe_dump(source, sort_keys=False).encode()
+    result = _compiler().compile(
+        payload,
+        content_type="application/yaml",
+        received_at=FIXED_TIME,
+        source_name="v1.yaml",
+    )
+    assert result.source_format.value == "PMOS_V1"
+    assert _schema_errors(result.bundle, BUNDLE_SCHEMA) == []
+
+
+def test_duplicate_yaml_key_fails_closed() -> None:
+    compiler = _module("pmpe.contracts.compiler")
+    blocked_type = compiler.CompilationBlocked
+    with pytest.raises(blocked_type) as raised:
+        _compiler().compile(
+            b"spec_version: '1.0'\nspec_version: '1.0'\n",
+            content_type="application/yaml",
+            received_at=FIXED_TIME,
+            source_name="duplicate.yaml",
+        )
+    assert raised.value.diagnostics[0].code == "DUPLICATE_OBJECT_KEY"
+
+
+def test_rfc8785_vectors_cover_numbers_escapes_and_utf16_key_order() -> None:
+    canonical = _module("pmpe.contracts.canonical")
+    value = {
+        "\u20ac": "Euro Sign",
+        "\r": "Carriage Return",
+        "\ufb33": "Hebrew Letter Dalet With Dagesh",
+        "1": 1.0,
+        "\U0001f600": "Emoji",
+        "\u0080": "Control",
+        "\u00f6": "Latin Small Letter O With Diaeresis",
+    }
+    rendered = canonical.canonical_json_bytes(value)
+    assert rendered == (
+        b'{"\\r":"Carriage Return","1":1,"\xc2\x80":"Control",'
+        b'"\xc3\xb6":"Latin Small Letter O With Diaeresis",'
+        b'"\xe2\x82\xac":"Euro Sign","\xf0\x9f\x98\x80":"Emoji",'
+        b'"\xef\xac\xb3":"Hebrew Letter Dalet With Dagesh"}'
+    )
+
+
+def test_manifest_digest_bindings_recompute_from_exact_projections() -> None:
+    canonical = _module("pmpe.contracts.canonical")
+    result = _compile(FIXTURES / "v2" / "contract_approved.json")
+    assert result.manifest["bundle"]["content_digest"] == canonical.canonical_digest(result.bundle)
+    assert result.manifest["approval_digest"] == canonical.canonical_digest(
+        result.bundle.get("approvals", {})
+    )
+    assert result.manifest["manifest_digest"] == canonical.canonical_digest(
+        _manifest_projection(result.manifest)
+    )
+
+
+@pytest.mark.parametrize(("_format", "_version", "fixture"), LEGACY_CASES)
+def test_complete_compiler_evidence_binds_versions_rules_digests_and_diagnostics(
+    _format: str,
+    _version: str,
+    fixture: Path,
+) -> None:
+    result = _compile(fixture)
+    evidence = result.evidence
+    assert evidence["source_format"] == result.source_format.value
+    assert evidence["source_version"] == result.source_version
+    assert evidence["source_digest"].startswith("sha256:")
+    assert evidence["compiler_id"] == "pmpe-pmos-compiler"
+    assert evidence["compiler_version"]
+    assert evidence["rule_version"]
+    assert evidence["migration_path"]
+    assert evidence["bundle_digest"] == result.bundle_digest
+    assert evidence["manifest_digest"] == result.manifest_digest
+    assert evidence["diagnostics"] == [diagnostic.as_dict() for diagnostic in result.diagnostics]
+
+
+def test_migration_registry_is_ordered_pure_and_refuses_downgrade() -> None:
+    migrations = _module("pmpe.contracts.migrations")
+    registry = migrations.MigrationRegistry()
+
+    def add_middle(value: dict[str, Any]) -> dict[str, Any]:
+        return {**value, "middle": True}
+
+    def add_final(value: dict[str, Any]) -> dict[str, Any]:
+        return {**value, "final": True}
+
+    registry.register(migrations.MigrationStep("1.0.0", "1.1.0", "RULE-A", add_middle))
+    registry.register(migrations.MigrationStep("1.1.0", "2.0.0", "RULE-B", add_final))
+    source = {"source": True}
+    migrated, path = registry.migrate(source, "1.0.0", "2.0.0")
+    assert source == {"source": True}
+    assert migrated == {"source": True, "middle": True, "final": True}
+    assert path == ("RULE-A", "RULE-B")
+    with pytest.raises(migrations.MigrationError, match="downgrade"):
+        registry.migrate(source, "2.0.0", "1.0.0")
+
+
+def test_migration_registry_rejects_ambiguous_and_reordered_paths() -> None:
+    migrations = _module("pmpe.contracts.migrations")
+    registry = migrations.MigrationRegistry()
+
+    def identity(value: dict[str, Any]) -> dict[str, Any]:
+        return dict(value)
+
+    registry.register(migrations.MigrationStep("1.0.0", "1.1.0", "RULE-A", identity))
+    registry.register(migrations.MigrationStep("1.1.0", "2.0.0", "RULE-B", identity))
+    with pytest.raises(migrations.MigrationError, match="order"):
+        registry.register(migrations.MigrationStep("0.9.0", "1.0.0", "RULE-OLD", identity))
+    with pytest.raises(migrations.MigrationError, match="ambiguous"):
+        registry.register(migrations.MigrationStep("1.0.0", "1.5.0", "RULE-X", identity))
+
+
+def test_source_change_changes_source_bundle_and_manifest_digests() -> None:
+    fixture = FIXTURES / "minimal_valid_spec.json"
+    source = json.loads(fixture.read_text())
+    original = _compile(fixture)
+    source["scope"].append("Second exact scope item")
+    changed = _compiler().compile(
+        json.dumps(source).encode(),
+        content_type="application/json",
+        received_at=FIXED_TIME,
+        source_name=fixture.name,
+    )
+    assert original.evidence["source_digest"] != changed.evidence["source_digest"]
+    assert original.bundle_digest != changed.bundle_digest
+    assert original.manifest_digest != changed.manifest_digest
+
+
+def test_no_ordinary_rejected_payload_digest_appears_in_diagnostics() -> None:
+    compiler = _module("pmpe.contracts.compiler")
+    blocked_type = compiler.CompilationBlocked
+    payload = b'{"spec_version":"9.9","secret_value":"do-not-retain"}'
+    ordinary_digest = hashlib.sha256(payload).hexdigest()
+    with pytest.raises(blocked_type) as raised:
+        _compiler().compile(
+            payload,
+            content_type="application/json",
+            received_at=FIXED_TIME,
+            source_name="rejected.json",
+        )
+    rendered = json.dumps(
+        [diagnostic.as_dict() for diagnostic in raised.value.diagnostics],
+        sort_keys=True,
+    )
+    assert ordinary_digest not in rendered
+    assert "do-not-retain" not in rendered

--- a/tests/unit/test_pmos_compiler.py
+++ b/tests/unit/test_pmos_compiler.py
@@ -174,6 +174,32 @@ def test_v3_api_and_backend_capability_values_are_preserved() -> None:
     assert mapping["canonical_pointer"] == "/backend_capabilities/CAPABILITY-BC-1"
 
 
+def test_v3_identifier_normalization_collision_fails_without_artifact() -> None:
+    compiler = _module("pmpe.contracts.compiler")
+    source = json.loads((FIXTURES / "v3" / "fullstack_contract_approved.json").read_text())
+    duplicate = copy.deepcopy(source["backend_capabilities"][0])
+    duplicate["capability_id"] = "BC_1"
+    source["backend_capabilities"].append(duplicate)
+    with pytest.raises(compiler.CompilationBlocked) as raised:
+        _compiler().compile(
+            json.dumps(source).encode(),
+            content_type="application/json",
+            received_at=FIXED_TIME,
+            source_name="collision.json",
+        )
+    assert raised.value.bundle is None
+    assert raised.value.diagnostics[0].code == "SOURCE_ID_COLLISION"
+    assert raised.value.diagnostics[0].source_path.endswith("/capability_id")
+
+
+def test_integer_legacy_source_version_is_preserved_in_provenance() -> None:
+    result = _compile(FIXTURES / "v2" / "contract_approved.json")
+    assert result.source_version == "1"
+    assert result.bundle["provenance"]["source_version"] == 1
+    assert result.manifest["provenance"]["source_version"] == 1
+    assert result.evidence["source_version_value"] == 1
+
+
 @pytest.mark.parametrize(("_format", "_version", "fixture"), LEGACY_CASES)
 def test_every_source_field_is_mapped_or_preserved_in_a_blocking_diagnostic(
     _format: str,
@@ -426,6 +452,19 @@ def test_migration_registry_rejects_ambiguous_and_reordered_paths() -> None:
         registry.register(migrations.MigrationStep("0.9.0", "1.0.0", "RULE-OLD", identity))
     with pytest.raises(migrations.MigrationError, match="ambiguous"):
         registry.register(migrations.MigrationStep("1.0.0", "1.5.0", "RULE-X", identity))
+
+
+def test_migration_transform_failure_is_sanitized_as_migration_error() -> None:
+    migrations = _module("pmpe.contracts.migrations")
+    registry = migrations.MigrationRegistry()
+
+    def broken(_value: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("source value must not escape")
+
+    registry.register(migrations.MigrationStep("1.0.0", "2.0.0", "RULE-BROKEN", broken))
+    with pytest.raises(migrations.MigrationError, match="RULE-BROKEN") as raised:
+        registry.migrate({"sensitive": "value"}, "1.0.0", "2.0.0")
+    assert "source value" not in str(raised.value)
 
 
 def test_source_change_changes_source_bundle_and_manifest_digests() -> None:

--- a/tests/unit/test_pmos_intake.py
+++ b/tests/unit/test_pmos_intake.py
@@ -165,6 +165,38 @@ def test_retry_key_resolves_exactly_one_durable_reservation(tmp_path: Path) -> N
     assert reloaded == first.reservation
 
 
+def test_retry_key_cannot_be_rebound_to_different_payload(tmp_path: Path) -> None:
+    coordinator = _coordinator(tmp_path)
+    first = coordinator.receive(_request())
+    mismatch = coordinator.receive(_request(b'{"spec_version":"1.0","product_name":"Different"}'))
+    assert mismatch.status == "SECURITY_BLOCKED"
+    assert mismatch.reservation == first.reservation
+    assert any(finding.code == "RETRY_KEY_PAYLOAD_MISMATCH" for finding in mismatch.findings)
+    assert len(list((tmp_path / "quarantine").glob("*.sealed"))) == 0
+
+
+def test_missing_retry_index_is_recovered_from_safe_reservation_metadata(
+    tmp_path: Path,
+) -> None:
+    coordinator = _coordinator(tmp_path)
+    reservation = coordinator.ledger.reserve(
+        retry_key="recoverable",
+        publisher="pm-agent-os",
+        channel="contract-api",
+        correction_reference=None,
+    )
+    retry_index = next((tmp_path / "ledger" / "retry-index").glob("*.json"))
+    retry_index.unlink()
+    recovered = coordinator.ledger.reserve(
+        retry_key="recoverable",
+        publisher="pm-agent-os",
+        channel="contract-api",
+        correction_reference=None,
+    )
+    assert recovered == reservation
+    assert len(list((tmp_path / "ledger" / "reservations").glob("*.json"))) == 1
+
+
 def test_reservation_exists_before_quarantine_write(tmp_path: Path) -> None:
     module = _module()
     observed: list[bool] = []
@@ -305,6 +337,18 @@ def test_invalid_correction_reference_creates_new_lineage_and_duplicate_finding(
     outcome = _coordinator(tmp_path).receive(_request(correction_reference=reference))
     assert outcome.reservation.lineage_id != reference.lineage_id
     assert any(finding.code == "POSSIBLE_DUPLICATE" for finding in outcome.findings)
+
+
+def test_syntactically_invalid_correction_reference_is_not_persisted(
+    tmp_path: Path,
+) -> None:
+    module = _module()
+    reference = module.CorrectionReference("../secret", "not/a/handle")
+    outcome = _coordinator(tmp_path).receive(_request(correction_reference=reference))
+    assert outcome.reservation.correction_reference is None
+    assert any(finding.code == "POSSIBLE_DUPLICATE" for finding in outcome.findings)
+    ledger_text = "\n".join(path.read_text() for path in (tmp_path / "ledger").rglob("*.json"))
+    assert "../secret" not in ledger_text
 
 
 def test_valid_correction_reuses_lineage_only_after_terminal_cleanup(tmp_path: Path) -> None:

--- a/tests/unit/test_pmos_intake.py
+++ b/tests/unit/test_pmos_intake.py
@@ -1,0 +1,477 @@
+"""Issue #76: durable fail-closed intake, quarantine, deletion, and reconciliation."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import importlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+VALID_PAYLOAD = b'{"spec_version":"1.0","product_name":"Safe Product"}'
+FIXED_TIME = "2026-07-31T08:00:00Z"
+
+
+def _module() -> ModuleType:
+    try:
+        return importlib.import_module("pmpe.contracts.intake")
+    except ModuleNotFoundError:
+        pytest.fail("issue #76 intake module is not implemented", pytrace=False)
+
+
+@dataclass
+class FixedClock:
+    value: str = FIXED_TIME
+
+    def now(self) -> str:
+        return self.value
+
+
+class SequenceIds:
+    def __init__(self) -> None:
+        self.counts: dict[str, int] = {}
+
+    def new_id(self, kind: str) -> str:
+        next_value = self.counts.get(kind, 0) + 1
+        self.counts[kind] = next_value
+        return f"{kind.upper()}-{next_value:06d}"
+
+
+class TestFingerprintProvider:
+    key_version = "TEST-KEY-V1"
+    _key = b"test-only-key-material"
+
+    def fingerprint(self, domain: str, payload: bytes) -> str:
+        assert domain in {"payload", "retry-key"}
+        return hmac.new(
+            self._key,
+            b"pmpe-intake:" + domain.encode() + b"\x00" + payload,
+            hashlib.sha256,
+        ).hexdigest()
+
+
+class TestCipher:
+    """Deterministic test cipher; production cryptography is a provider boundary."""
+
+    key_version = "TEST-CIPHER-V1"
+
+    def encrypt(self, payload: bytes) -> bytes:
+        return b"sealed:" + base64.b64encode(payload[::-1])
+
+    def decrypt(self, payload: bytes) -> bytes:
+        assert payload.startswith(b"sealed:")
+        return base64.b64decode(payload.removeprefix(b"sealed:"))[::-1]
+
+
+class CleanMalwareScanner:
+    def scan(self, payload: bytes) -> Any:
+        module = _module()
+        return module.MalwareScanResult(clean=True, engine="test", signature_version="1")
+
+
+class MalwareScanner:
+    def scan(self, payload: bytes) -> Any:
+        module = _module()
+        return module.MalwareScanResult(
+            clean=False,
+            engine="test",
+            signature_version="1",
+            finding_code="TEST-MALWARE",
+        )
+
+
+def _coordinator(tmp_path: Path, **overrides: Any) -> Any:
+    module = _module()
+    clock = overrides.pop("clock", FixedClock())
+    ids = overrides.pop("ids", SequenceIds())
+    fingerprints = overrides.pop("fingerprints", TestFingerprintProvider())
+    ledger = overrides.pop(
+        "ledger",
+        module.FileIntakeLedger(
+            tmp_path / "ledger",
+            clock=clock,
+            id_provider=ids,
+            fingerprint_provider=fingerprints,
+        ),
+    )
+    quarantine = overrides.pop(
+        "quarantine",
+        module.FileQuarantineStore(
+            tmp_path / "quarantine",
+            cipher=TestCipher(),
+            max_bytes=2048,
+        ),
+    )
+    return module.IntakeCoordinator(
+        ledger=ledger,
+        quarantine=quarantine,
+        fingerprint_provider=fingerprints,
+        malware_scanner=overrides.pop("malware_scanner", CleanMalwareScanner()),
+        clock=clock,
+        max_bytes=2048,
+        allowed_content_types={"application/json", "application/yaml"},
+        **overrides,
+    )
+
+
+def _request(payload: bytes = VALID_PAYLOAD, **overrides: Any) -> Any:
+    module = _module()
+    values = {
+        "retry_key": "publisher-retry-001",
+        "payload": payload,
+        "content_type": "application/json",
+        "publisher": "pm-agent-os",
+        "channel": "contract-api",
+        "correction_reference": None,
+    }
+    values.update(overrides)
+    return module.IntakeRequest(**values)
+
+
+def test_issue76_public_intake_components_exist() -> None:
+    module = _module()
+    for name in (
+        "FileIntakeLedger",
+        "FileQuarantineStore",
+        "IntakeCoordinator",
+        "IntakeReceipt",
+        "IntakeRequest",
+        "IntakeReservation",
+        "IntakeReconciler",
+        "KeyedFingerprintProvider",
+        "MalwareScanner",
+        "QuarantineCipher",
+        "QuarantineStore",
+    ):
+        assert hasattr(module, name), f"missing intake component: {name}"
+
+
+def test_retry_key_resolves_exactly_one_durable_reservation(tmp_path: Path) -> None:
+    coordinator = _coordinator(tmp_path)
+    first = coordinator.receive(_request())
+    second = coordinator.receive(_request())
+    assert first.reservation == second.reservation
+    assert first.receipt == second.receipt
+    assert second.replayed is True
+    quarantine_files = list((tmp_path / "quarantine").glob("*.sealed"))
+    assert len(quarantine_files) <= 1
+    reloaded = _coordinator(tmp_path).ledger.reservation_for_retry_key("publisher-retry-001")
+    assert reloaded == first.reservation
+
+
+def test_reservation_exists_before_quarantine_write(tmp_path: Path) -> None:
+    module = _module()
+    observed: list[bool] = []
+    coordinator = _coordinator(tmp_path)
+    real_store = coordinator.quarantine
+
+    class AssertingStore:
+        def put(self, handle: str, payload: bytes, metadata: dict[str, Any]) -> None:
+            observed.append(coordinator.ledger.reservation_by_handle(handle) is not None)
+            real_store.put(handle, payload, metadata)
+
+        def read(self, handle: str) -> bytes:
+            return real_store.read(handle)
+
+        def delete(self, handle: str) -> Any:
+            return real_store.delete(handle)
+
+        def exists(self, handle: str) -> bool:
+            return real_store.exists(handle)
+
+    coordinator.quarantine = AssertingStore()
+    outcome = coordinator.receive(_request())
+    assert observed == [True]
+    assert outcome.reservation.quarantine_handle
+    assert isinstance(outcome.reservation, module.IntakeReservation)
+
+
+def test_receipt_is_durable_before_parsing_or_scanning(tmp_path: Path) -> None:
+    observed: list[bool] = []
+    coordinator = _coordinator(tmp_path)
+
+    class AssertingScanner:
+        def scan(self, payload: bytes) -> Any:
+            reservation = coordinator.ledger.reservation_for_retry_key("publisher-retry-001")
+            observed.append(coordinator.ledger.receipt(reservation.attempt_id) is not None)
+            return CleanMalwareScanner().scan(payload)
+
+    coordinator.malware_scanner = AssertingScanner()
+    outcome = coordinator.receive(_request())
+    assert observed == [True]
+    assert outcome.receipt.received_at == FIXED_TIME
+    assert outcome.receipt.lineage_id == outcome.reservation.lineage_id
+    assert outcome.receipt.attempt_id == outcome.reservation.attempt_id
+
+
+def test_receipt_contains_only_safe_metadata_and_keyed_fingerprint(tmp_path: Path) -> None:
+    outcome = _coordinator(tmp_path).receive(_request())
+    receipt = outcome.receipt.as_dict()
+    assert receipt["publisher"] == "pm-agent-os"
+    assert receipt["channel"] == "contract-api"
+    assert receipt["key_version"] == "TEST-KEY-V1"
+    assert receipt["fingerprint"]
+    rendered = json.dumps(receipt, sort_keys=True)
+    assert hashlib.sha256(VALID_PAYLOAD).hexdigest() not in rendered
+    assert "Safe Product" not in rendered
+    assert "publisher-retry-001" not in rendered
+    assert not hasattr(outcome.receipt, "verify_fingerprint")
+
+
+def test_quarantine_payload_and_ordinary_digest_are_encrypted_and_deleted(
+    tmp_path: Path,
+) -> None:
+    coordinator = _coordinator(tmp_path)
+    outcome = coordinator.receive(_request())
+    files = list((tmp_path / "quarantine").glob("*"))
+    assert outcome.deletion_attestation is not None
+    assert outcome.deletion_attestation.deleted
+    assert not coordinator.quarantine.exists(outcome.reservation.quarantine_handle)
+    rendered = b"\n".join(path.read_bytes() for path in files if path.is_file())
+    assert VALID_PAYLOAD not in rendered
+    assert hashlib.sha256(VALID_PAYLOAD).hexdigest().encode() not in rendered
+
+
+@pytest.mark.parametrize(
+    ("payload", "content_type", "code"),
+    [
+        (b"x" * 2049, "application/json", "PAYLOAD_TOO_LARGE"),
+        (VALID_PAYLOAD, "text/plain", "CONTENT_TYPE_REJECTED"),
+        (b"{not-json", "application/json", "MALFORMED_INPUT"),
+        (
+            b'{"token":"ghp_abcdefghijklmnopqrstuvwxyz123456"}',
+            "application/json",
+            "SECRET_DETECTED",
+        ),
+        (
+            b'{"customer_email":"person@example.com"}',
+            "application/json",
+            "PRIVACY_PATTERN_DETECTED",
+        ),
+    ],
+)
+def test_admission_rejections_delete_bytes_and_retain_sanitized_terminal_evidence(
+    tmp_path: Path,
+    payload: bytes,
+    content_type: str,
+    code: str,
+) -> None:
+    outcome = _coordinator(tmp_path).receive(_request(payload, content_type=content_type))
+    assert outcome.status == "REJECTED"
+    assert outcome.admitted_payload is None
+    assert outcome.deletion_attestation.deleted
+    assert any(finding.code == code for finding in outcome.findings)
+    assert not outcome.quarantine_retained
+    rendered = json.dumps(outcome.disposition.as_dict(), sort_keys=True)
+    assert payload.decode(errors="ignore") not in rendered
+    assert hashlib.sha256(payload).hexdigest() not in rendered
+
+
+def test_malware_result_blocks_and_deletes_without_retaining_scanner_payload(
+    tmp_path: Path,
+) -> None:
+    outcome = _coordinator(
+        tmp_path,
+        malware_scanner=MalwareScanner(),
+    ).receive(_request())
+    assert outcome.status == "REJECTED"
+    assert any(finding.code == "MALWARE_DETECTED" for finding in outcome.findings)
+    assert outcome.deletion_attestation.deleted
+    assert outcome.disposition.status == "REJECTED"
+
+
+def test_valid_payload_is_admitted_only_after_all_checks_and_quarantine_cleanup(
+    tmp_path: Path,
+) -> None:
+    outcome = _coordinator(tmp_path).receive(_request())
+    assert outcome.status == "ADMITTED"
+    assert outcome.admitted_payload == VALID_PAYLOAD
+    assert outcome.deletion_attestation.deleted
+    assert not outcome.quarantine_retained
+    assert outcome.disposition.status == "ADMITTED"
+
+
+def test_invalid_correction_reference_creates_new_lineage_and_duplicate_finding(
+    tmp_path: Path,
+) -> None:
+    module = _module()
+    reference = module.CorrectionReference("LINEAGE-999999", "ATTEMPT-999999")
+    outcome = _coordinator(tmp_path).receive(_request(correction_reference=reference))
+    assert outcome.reservation.lineage_id != reference.lineage_id
+    assert any(finding.code == "POSSIBLE_DUPLICATE" for finding in outcome.findings)
+
+
+def test_valid_correction_reuses_lineage_only_after_terminal_cleanup(tmp_path: Path) -> None:
+    module = _module()
+    coordinator = _coordinator(tmp_path)
+    original = coordinator.receive(_request())
+    reference = module.CorrectionReference(
+        original.reservation.lineage_id,
+        original.reservation.attempt_id,
+    )
+    correction = coordinator.receive(
+        _request(
+            retry_key="publisher-retry-002",
+            payload=b'{"spec_version":"1.0","product_name":"Corrected"}',
+            correction_reference=reference,
+        )
+    )
+    assert correction.reservation.lineage_id == original.reservation.lineage_id
+    assert correction.reservation.attempt_id != original.reservation.attempt_id
+    assert correction.receipt.correction_reference == reference
+
+
+def test_correction_cannot_resume_while_original_cleanup_is_unresolved(
+    tmp_path: Path,
+) -> None:
+    module = _module()
+    coordinator = _coordinator(tmp_path)
+    original = coordinator.ledger.reserve(
+        retry_key="original",
+        publisher="pm-agent-os",
+        channel="contract-api",
+        correction_reference=None,
+    )
+    reference = module.CorrectionReference(original.lineage_id, original.attempt_id)
+    blocked = coordinator.receive(_request(retry_key="correction", correction_reference=reference))
+    assert blocked.status == "SECURITY_BLOCKED"
+    assert blocked.admitted_payload is None
+    assert any(finding.code == "CORRECTION_PREDECESSOR_UNRESOLVED" for finding in blocked.findings)
+    assert not coordinator.quarantine.exists(blocked.reservation.quarantine_handle)
+
+
+def test_receipt_failure_remains_reconcilable_under_original_handle(tmp_path: Path) -> None:
+    coordinator = _coordinator(tmp_path)
+    ledger = coordinator.ledger
+    real_finalize = ledger.finalize_receipt
+
+    def fail_once(receipt: Any) -> None:
+        ledger.finalize_receipt = real_finalize
+        raise OSError("simulated durable receipt failure")
+
+    ledger.finalize_receipt = fail_once
+    outcome = coordinator.receive(_request())
+    assert outcome.status == "SECURITY_BLOCKED"
+    reservation = ledger.reservation_for_retry_key("publisher-retry-001")
+    assert reservation.quarantine_handle == outcome.reservation.quarantine_handle
+    assert reservation.reconciliation_required
+    assert any(finding.code == "RECEIPT_FINALIZATION_FAILED" for finding in outcome.findings)
+
+
+def test_deletion_failure_is_security_blocked_and_never_ordinary_rejection(
+    tmp_path: Path,
+) -> None:
+    coordinator = _coordinator(tmp_path)
+    real_delete = coordinator.quarantine.delete
+
+    def fail_delete(handle: str) -> Any:
+        raise OSError("simulated deletion failure")
+
+    coordinator.quarantine.delete = fail_delete
+    outcome = coordinator.receive(_request(b"{not-json"))
+    assert outcome.status == "SECURITY_BLOCKED"
+    assert outcome.disposition.status == "SECURITY_BLOCKED"
+    assert outcome.quarantine_retained
+    assert outcome.reservation.reconciliation_required
+    coordinator.quarantine.delete = real_delete
+
+
+def test_disposition_failure_after_deletion_remains_reconcilable(
+    tmp_path: Path,
+) -> None:
+    coordinator = _coordinator(tmp_path)
+    ledger = coordinator.ledger
+    real_write = ledger.write_disposition
+
+    def fail_once(disposition: Any) -> None:
+        ledger.write_disposition = real_write
+        raise OSError("simulated disposition failure")
+
+    ledger.write_disposition = fail_once
+    outcome = coordinator.receive(_request(b"{not-json"))
+    assert outcome.status == "SECURITY_BLOCKED"
+    assert outcome.deletion_attestation.deleted
+    assert outcome.reservation.reconciliation_required
+    assert any(finding.code == "DISPOSITION_WRITE_FAILED" for finding in outcome.findings)
+
+
+def test_reconciler_completes_cleanup_or_keeps_security_blocked(tmp_path: Path) -> None:
+    module = _module()
+    coordinator = _coordinator(tmp_path)
+    original_delete = coordinator.quarantine.delete
+
+    def fail_delete(handle: str) -> Any:
+        raise OSError("simulated temporary deletion failure")
+
+    coordinator.quarantine.delete = fail_delete
+    blocked = coordinator.receive(_request(b"{not-json"))
+    assert blocked.status == "SECURITY_BLOCKED"
+    coordinator.quarantine.delete = original_delete
+    report = module.IntakeReconciler(
+        ledger=coordinator.ledger,
+        quarantine=coordinator.quarantine,
+        clock=FixedClock(),
+    ).reconcile()
+    assert report.resolved_attempt_ids == (blocked.reservation.attempt_id,)
+    reservation = coordinator.ledger.reservation_by_attempt(blocked.reservation.attempt_id)
+    assert not reservation.reconciliation_required
+    assert coordinator.ledger.disposition(blocked.reservation.attempt_id).terminal
+
+
+def test_orphan_watchdog_blocks_reserved_handle_and_reconciles_it(tmp_path: Path) -> None:
+    module = _module()
+    coordinator = _coordinator(tmp_path)
+    reservation = coordinator.ledger.reserve(
+        retry_key="orphan",
+        publisher="pm-agent-os",
+        channel="contract-api",
+        correction_reference=None,
+    )
+    coordinator.quarantine.put(
+        reservation.quarantine_handle,
+        VALID_PAYLOAD,
+        {"ordinary_digest": hashlib.sha256(VALID_PAYLOAD).hexdigest()},
+    )
+    report = module.IntakeReconciler(
+        ledger=coordinator.ledger,
+        quarantine=coordinator.quarantine,
+        clock=FixedClock(),
+    ).reconcile()
+    assert reservation.attempt_id in report.resolved_attempt_ids
+    assert not coordinator.quarantine.exists(reservation.quarantine_handle)
+    disposition = coordinator.ledger.disposition(reservation.attempt_id)
+    assert disposition.status == "SECURITY_BLOCKED"
+    assert disposition.terminal
+
+
+def test_terminal_retry_never_allocates_second_quarantine_object(tmp_path: Path) -> None:
+    ids = SequenceIds()
+    coordinator = _coordinator(tmp_path, ids=ids)
+    first = coordinator.receive(_request())
+    second = coordinator.receive(_request())
+    assert first.reservation.quarantine_handle == second.reservation.quarantine_handle
+    assert ids.counts["quarantine"] == 1
+    assert ids.counts["attempt"] == 1
+    assert ids.counts["lineage"] == 1
+
+
+def test_no_public_fingerprint_validation_or_payload_logging_api(tmp_path: Path) -> None:
+    module = _module()
+    coordinator = _coordinator(tmp_path)
+    coordinator.receive(_request())
+    public_names = {name for name in dir(module) if not name.startswith("_")}
+    assert "validate_fingerprint" not in public_names
+    assert "verify_fingerprint" not in public_names
+    ledger_text = "\n".join(
+        path.read_text(errors="ignore")
+        for path in (tmp_path / "ledger").rglob("*")
+        if path.is_file()
+    )
+    assert "Safe Product" not in ledger_text
+    assert hashlib.sha256(VALID_PAYLOAD).hexdigest() not in ledger_text

--- a/tests/unit/test_pmos_intake.py
+++ b/tests/unit/test_pmos_intake.py
@@ -63,7 +63,7 @@ class TestFingerprintProvider:
 
     @staticmethod
     def _fingerprint_for_key(key: bytes, domain: str, payload: bytes) -> str:
-        assert domain in {"payload", "retry-key"}
+        assert domain in {"compiler-evidence", "payload", "retry-key"}
         return hmac.new(
             key,
             b"pmpe-intake:" + domain.encode() + b"\x00" + payload,
@@ -198,6 +198,19 @@ def test_retry_key_cannot_be_rebound_to_different_payload(tmp_path: Path) -> Non
     assert mismatch.reservation == first.reservation
     assert any(finding.code == "RETRY_KEY_PAYLOAD_MISMATCH" for finding in mismatch.findings)
     assert len(list((tmp_path / "quarantine").glob("*.sealed"))) == 0
+
+
+def test_retry_key_cannot_change_immutable_payload_media_type(
+    tmp_path: Path,
+) -> None:
+    coordinator = _coordinator(tmp_path)
+    first = coordinator.finalize_admission(coordinator.receive(_request()))
+    changed = coordinator.receive(_request(content_type="application/yaml"))
+    assert changed.status == "SECURITY_BLOCKED"
+    assert changed.reservation == first.reservation
+    assert changed.receipt == first.receipt
+    assert changed.receipt.content_type == "application/json"
+    assert changed.admitted_payload is None
 
 
 def test_retry_key_resolves_across_governed_key_rotation(tmp_path: Path) -> None:

--- a/tests/unit/test_pmos_intake.py
+++ b/tests/unit/test_pmos_intake.py
@@ -7,6 +7,7 @@ import hashlib
 import hmac
 import importlib
 import json
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
@@ -45,15 +46,39 @@ class SequenceIds:
 
 class TestFingerprintProvider:
     key_version = "TEST-KEY-V1"
-    _key = b"test-only-key-material"
+    _keys = {"TEST-KEY-V1": b"test-only-key-material"}
 
     def fingerprint(self, domain: str, payload: bytes) -> str:
+        return self._fingerprint_for_key(self._keys[self.key_version], domain, payload)
+
+    def candidate_fingerprints(self, domain: str, payload: bytes) -> tuple[Any, ...]:
+        module = _module()
+        return tuple(
+            module.KeyedFingerprint(
+                key_version=version,
+                value=self._fingerprint_for_key(key, domain, payload),
+            )
+            for version, key in self._keys.items()
+        )
+
+    @staticmethod
+    def _fingerprint_for_key(key: bytes, domain: str, payload: bytes) -> str:
         assert domain in {"payload", "retry-key"}
         return hmac.new(
-            self._key,
+            key,
             b"pmpe-intake:" + domain.encode() + b"\x00" + payload,
             hashlib.sha256,
         ).hexdigest()
+
+
+class RotatingFingerprintProvider(TestFingerprintProvider):
+    def __init__(
+        self,
+        current: str,
+        keys: dict[str, bytes],
+    ) -> None:
+        self.key_version = current
+        self._keys = keys
 
 
 class TestCipher:
@@ -154,7 +179,7 @@ def test_issue76_public_intake_components_exist() -> None:
 
 def test_retry_key_resolves_exactly_one_durable_reservation(tmp_path: Path) -> None:
     coordinator = _coordinator(tmp_path)
-    first = coordinator.receive(_request())
+    first = coordinator.finalize_admission(coordinator.receive(_request()))
     second = coordinator.receive(_request())
     assert first.reservation == second.reservation
     assert first.receipt == second.receipt
@@ -167,12 +192,52 @@ def test_retry_key_resolves_exactly_one_durable_reservation(tmp_path: Path) -> N
 
 def test_retry_key_cannot_be_rebound_to_different_payload(tmp_path: Path) -> None:
     coordinator = _coordinator(tmp_path)
-    first = coordinator.receive(_request())
+    first = coordinator.finalize_admission(coordinator.receive(_request()))
     mismatch = coordinator.receive(_request(b'{"spec_version":"1.0","product_name":"Different"}'))
     assert mismatch.status == "SECURITY_BLOCKED"
     assert mismatch.reservation == first.reservation
     assert any(finding.code == "RETRY_KEY_PAYLOAD_MISMATCH" for finding in mismatch.findings)
     assert len(list((tmp_path / "quarantine").glob("*.sealed"))) == 0
+
+
+def test_retry_key_resolves_across_governed_key_rotation(tmp_path: Path) -> None:
+    old = RotatingFingerprintProvider(
+        "KEY-V1",
+        {"KEY-V1": b"old-test-key"},
+    )
+    first_coordinator = _coordinator(tmp_path, fingerprints=old)
+    first = first_coordinator.finalize_admission(first_coordinator.receive(_request()))
+    rotated = RotatingFingerprintProvider(
+        "KEY-V2",
+        {
+            "KEY-V2": b"new-test-key",
+            "KEY-V1": b"old-test-key",
+        },
+    )
+    retried = _coordinator(tmp_path, fingerprints=rotated).receive(_request())
+    assert retried.replayed
+    assert retried.reservation.attempt_id == first.reservation.attempt_id
+    assert retried.receipt == first.receipt
+    assert len(list((tmp_path / "ledger" / "reservations").glob("*.json"))) == 1
+
+
+def test_concurrent_retry_payload_binding_is_atomic(tmp_path: Path) -> None:
+    coordinator = _coordinator(tmp_path)
+    requests = (
+        _request(b'{"spec_version":"1.0","product_name":"First"}'),
+        _request(b'{"spec_version":"1.0","product_name":"Second"}'),
+    )
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = tuple(pool.map(coordinator.receive, requests))
+    assert {outcome.status for outcome in outcomes} == {
+        "SECURITY_BLOCKED",
+        "VALIDATED_PENDING_COMPILATION",
+    }
+    reservations = {outcome.reservation.attempt_id for outcome in outcomes}
+    assert len(reservations) == 1
+    persisted = coordinator.ledger.reservation_for_retry_key("publisher-retry-001")
+    assert persisted is not None
+    assert not persisted.reconciliation_required
 
 
 def test_missing_retry_index_is_recovered_from_safe_reservation_metadata(
@@ -260,7 +325,10 @@ def test_quarantine_payload_and_ordinary_digest_are_encrypted_and_deleted(
     tmp_path: Path,
 ) -> None:
     coordinator = _coordinator(tmp_path)
-    outcome = coordinator.receive(_request())
+    pending = coordinator.receive(_request())
+    assert pending.status == "VALIDATED_PENDING_COMPILATION"
+    assert pending.quarantine_retained
+    outcome = coordinator.finalize_admission(pending)
     files = list((tmp_path / "quarantine").glob("*"))
     assert outcome.deletion_attestation is not None
     assert outcome.deletion_attestation.deleted
@@ -321,9 +389,15 @@ def test_malware_result_blocks_and_deletes_without_retaining_scanner_payload(
 def test_valid_payload_is_admitted_only_after_all_checks_and_quarantine_cleanup(
     tmp_path: Path,
 ) -> None:
-    outcome = _coordinator(tmp_path).receive(_request())
+    coordinator = _coordinator(tmp_path)
+    pending = coordinator.receive(_request())
+    assert pending.status == "VALIDATED_PENDING_COMPILATION"
+    assert pending.admitted_payload == VALID_PAYLOAD
+    assert pending.quarantine_retained
+    assert pending.deletion_attestation is None
+    outcome = coordinator.finalize_admission(pending)
     assert outcome.status == "ADMITTED"
-    assert outcome.admitted_payload == VALID_PAYLOAD
+    assert outcome.admitted_payload is None
     assert outcome.deletion_attestation.deleted
     assert not outcome.quarantine_retained
     assert outcome.disposition.status == "ADMITTED"
@@ -354,7 +428,7 @@ def test_syntactically_invalid_correction_reference_is_not_persisted(
 def test_valid_correction_reuses_lineage_only_after_terminal_cleanup(tmp_path: Path) -> None:
     module = _module()
     coordinator = _coordinator(tmp_path)
-    original = coordinator.receive(_request())
+    original = coordinator.finalize_admission(coordinator.receive(_request()))
     reference = module.CorrectionReference(
         original.reservation.lineage_id,
         original.reservation.attempt_id,
@@ -485,7 +559,7 @@ def test_orphan_watchdog_blocks_reserved_handle_and_reconciles_it(tmp_path: Path
     report = module.IntakeReconciler(
         ledger=coordinator.ledger,
         quarantine=coordinator.quarantine,
-        clock=FixedClock(),
+        clock=FixedClock("2026-07-31T08:10:00Z"),
     ).reconcile()
     assert reservation.attempt_id in report.resolved_attempt_ids
     assert not coordinator.quarantine.exists(reservation.quarantine_handle)
@@ -497,7 +571,7 @@ def test_orphan_watchdog_blocks_reserved_handle_and_reconciles_it(tmp_path: Path
 def test_terminal_retry_never_allocates_second_quarantine_object(tmp_path: Path) -> None:
     ids = SequenceIds()
     coordinator = _coordinator(tmp_path, ids=ids)
-    first = coordinator.receive(_request())
+    first = coordinator.finalize_admission(coordinator.receive(_request()))
     second = coordinator.receive(_request())
     assert first.reservation.quarantine_handle == second.reservation.quarantine_handle
     assert ids.counts["quarantine"] == 1
@@ -519,3 +593,96 @@ def test_no_public_fingerprint_validation_or_payload_logging_api(tmp_path: Path)
     )
     assert "Safe Product" not in ledger_text
     assert hashlib.sha256(VALID_PAYLOAD).hexdigest() not in ledger_text
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b'{"token":"ghp_abcdefghijklmnopqr\\u0073tuvwxyz123456"}',
+        b'{"customer_email":"person\\u0040example.com"}',
+    ],
+)
+def test_decoded_secret_and_privacy_values_are_rejected(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    outcome = _coordinator(tmp_path).receive(_request(payload))
+    assert outcome.status == "REJECTED"
+    assert outcome.deletion_attestation.deleted
+    assert outcome.admitted_payload is None
+
+
+def test_unbounded_or_sensitive_safe_metadata_is_rejected_before_reservation(
+    tmp_path: Path,
+) -> None:
+    coordinator = _coordinator(tmp_path)
+    for publisher in (
+        "ghp_abcdefghijklmnopqrstuvwxyz123456",
+        "x" * 129,
+        "publisher\ninjection",
+    ):
+        with pytest.raises(ValueError, match="safe metadata"):
+            coordinator.receive(_request(publisher=publisher))
+    assert list((tmp_path / "ledger" / "reservations").glob("*.json")) == []
+
+
+def test_receipt_failure_on_blocked_correction_is_finalized_by_reconciler(
+    tmp_path: Path,
+) -> None:
+    module = _module()
+    coordinator = _coordinator(tmp_path)
+    predecessor = coordinator.ledger.reserve(
+        retry_key="unresolved-original",
+        publisher="pm-agent-os",
+        channel="contract-api",
+        correction_reference=None,
+    )
+    ledger = coordinator.ledger
+    real_finalize = ledger.finalize_receipt
+
+    def fail_once(receipt: Any) -> None:
+        ledger.finalize_receipt = real_finalize
+        raise OSError("simulated durable receipt failure")
+
+    ledger.finalize_receipt = fail_once
+    blocked = coordinator.receive(
+        _request(
+            retry_key="blocked-correction",
+            correction_reference=module.CorrectionReference(
+                predecessor.lineage_id,
+                predecessor.attempt_id,
+            ),
+        )
+    )
+    assert blocked.status == "SECURITY_BLOCKED"
+    assert ledger.receipt(blocked.reservation.attempt_id) is None
+    assert ledger.disposition(blocked.reservation.attempt_id) is None
+    report = module.IntakeReconciler(
+        ledger=ledger,
+        quarantine=coordinator.quarantine,
+        clock=FixedClock(),
+    ).reconcile()
+    assert report.resolved_attempt_ids == (blocked.reservation.attempt_id,)
+    assert ledger.receipt(blocked.reservation.attempt_id) is not None
+    assert ledger.disposition(blocked.reservation.attempt_id).terminal
+
+
+def test_active_unexpired_reservation_is_not_reconciled_as_orphan(
+    tmp_path: Path,
+) -> None:
+    module = _module()
+    coordinator = _coordinator(tmp_path)
+    reservation = coordinator.ledger.reserve(
+        retry_key="active",
+        publisher="pm-agent-os",
+        channel="contract-api",
+        correction_reference=None,
+    )
+    report = module.IntakeReconciler(
+        ledger=coordinator.ledger,
+        quarantine=coordinator.quarantine,
+        clock=FixedClock(),
+    ).reconcile()
+    assert report.resolved_attempt_ids == ()
+    assert report.blocked_attempt_ids == ()
+    assert coordinator.ledger.disposition(reservation.attempt_id) is None


### PR DESCRIPTION
## Outcome

PMOS V1, V2, and V3 contract inputs now compile deterministically into the canonical bundle and manifest introduced by #62 while preserving supplied product truth and blocking unknown, ambiguous, unsupported, or lossy conversion.

Closes #76

## Problem

The repository had three supported legacy PMOS shapes and canonical schemas, but no loss-aware compiler, migration registry, secure intake lifecycle, or exact provenance bridge between them. Direct conversion risked dropping product truth, inventing defaults, or acknowledging unsafe bytes before durable evidence existed.

## Scope

- strict duplicate-aware JSON/YAML admission and RFC 8785 canonicalization;
- explicit V1/V2/V3 source detection and adapters;
- canonical bundle, manifest, diagnostics, migration, and digest provenance;
- ordered forward-only migration registry;
- durable retry-key reservation, encrypted quarantine provider boundary, safe receipt ledger, deletion attestation, terminal disposition, corrections, and reconciliation;
- evidence storage bound to the exact intake receipt and verified again on replay;
- 75 focused unit/integration cases.

## Non-goals

- production KMS, malware/privacy scanning service, or encrypted object-store claims;
- contract completeness validation owned by #63;
- frontend, workflow, deployment, or production changes;
- invention of missing PMOS product decisions.

## Decisions and trade-offs

- Incomplete legacy inputs become schema-valid DRAFT canonical bundles with blocking unresolved-product-truth records; supplied but unmappable values are preserved exactly.
- Unknown fields, identifier collisions, unsupported versions, malformed interoperability inputs, and ambiguous formats emit no bundle or manifest.
- Cryptography, fingerprints, clocks, IDs, and malware scanning are explicit provider boundaries. The file-backed ledger/quarantine is a deterministic local reference implementation, not a production-service claim.
- Retry keys are domain-separated keyed fingerprints and are durably bound to one payload before quarantine; mismatched retries fail closed without allocating another object.
- jsonschema 4.25.1 becomes a runtime dependency and stable dependency-free rfc8785 0.1.4 is pinned.

## Red-first evidence

- RED commit: c43925a50ddb165a148d3b21d8d3ea276e45a24e
- Expected result: 68 focused failures caused by the absent issue #76 modules and functionality; test syntax, formatting, and imports were valid.
- GREEN candidate: 0cabae7330c8f6ea53937bda7ae38a6cc8e8a283
- Published history was not rewritten.

## Acceptance and verification

- focused compiler/intake/pipeline: 75 passed;
- mypy strict: 106 source files, no issues;
- Ruff full source/test format and lint: passed;
- Bandit high-severity scan: passed;
- Python dependency audit: no known vulnerabilities; local pmpe package correctly skipped as non-PyPI;
- wheel build and package inventory: passed;
- git diff --check: passed;
- frontend path classifier: NOT APPLICABLE — no frontend-affecting paths changed;
- repository-wide tests with localhost binding enabled: all applicable behavior passed except the pre-existing macOS /tmp versus /private/tmp path-identity assertion in tests/unit/test_config.py; this file and configuration behavior are outside this PR.

## Security and privacy

No raw retry key or ordinary payload digest is retained outside encrypted, deletable quarantine metadata. Receipt finalization precedes scan/parse. Rejected bytes are deleted immediately, and unresolved receipt, deletion, disposition, or reconciliation work enters SECURITY_BLOCKED. Secret, privacy, content-type, size, malformed-input, and malware-provider checks fail closed. No public fingerprint validation oracle is exposed.

## Risks and rollback

The main risk is provider integration: deployments must supply approved non-exportable fingerprint keys, authenticated quarantine encryption, malware/privacy services, durable storage, and governed deletion. Rollback is a normal revert of this focused PR; no database, frontend, workflow, or production migration is introduced. Existing legacy loaders remain unchanged.

## Review boundary

Review the complete two-commit diff against main. The reviewer must remain read-only. Any blocking correction will be made in a separate fixer commit, followed by complete exact-head validation and a fresh review.