### PR TITLE
Build deterministic repository intelligence and risk inventory

### DIFF
--- a/src/pmpe/cli/__init__.py
+++ b/src/pmpe/cli/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from pmpe.cli import contracts_cmd, core, demo_cmd, eng_cmd, evals_cmd
+from pmpe.cli import contracts_cmd, core, demo_cmd, eng_cmd, evals_cmd, repository_cmd
 from pmpe.domain.errors import PmpeError, SpecError
 
 
@@ -26,6 +26,7 @@ def build_parser() -> argparse.ArgumentParser:
     demo_cmd.register(sub)
     eng_cmd.register(sub)
     evals_cmd.register(sub)
+    repository_cmd.register(sub)
     return parser
 
 

--- a/src/pmpe/cli/repository_cmd.py
+++ b/src/pmpe/cli/repository_cmd.py
@@ -14,6 +14,7 @@ from pmpe.repository import (
     RepositorySecurityError,
     ScanConfig,
     observe_governance,
+    resolve_repository_root,
     scan_repository,
 )
 
@@ -61,14 +62,15 @@ def _atomic_write(path: Path, payload: bytes) -> None:
 
 
 def _cmd_scan(args: argparse.Namespace) -> int:
-    root = Path(args.repo)
+    requested = Path(args.repo)
     try:
+        root = resolve_repository_root(requested)
         snapshot_path = _outside_repository(Path(args.snapshot_out), root)
         governance_path = (
             _outside_repository(Path(args.governance_out), root) if args.governance_out else None
         )
         snapshot = scan_repository(
-            root,
+            requested,
             commit=args.commit,
             config=ScanConfig(
                 repository=args.repository,
@@ -80,7 +82,7 @@ def _cmd_scan(args: argparse.Namespace) -> int:
             clock = _ArgumentClock(args.observed_at) if args.observed_at else None
             ids = _ArgumentIds(args.observation_id) if args.observation_id else None
             observation = observe_governance(
-                root,
+                requested,
                 repository=args.repository,
                 ref=args.default_branch or args.commit,
                 clock=clock,

--- a/src/pmpe/cli/repository_cmd.py
+++ b/src/pmpe/cli/repository_cmd.py
@@ -17,6 +17,7 @@ from pmpe.repository import (
     resolve_repository_root,
     scan_repository,
 )
+from pmpe.repository.governance import GovernanceCommandRunner
 
 
 class _ArgumentClock:
@@ -35,12 +36,55 @@ class _ArgumentIds:
         return self.value
 
 
-def _outside_repository(output: Path, repository: Path) -> Path:
+def _git_output(runner: GovernanceCommandRunner, root: Path, *args: str) -> str:
+    result = runner.run(("git", *args), root, 20)
+    if result.timed_out or result.returncode != 0:
+        raise RepositorySecurityError("repository containment metadata is unavailable")
+    try:
+        raw = result.stdout.decode("utf-8") if isinstance(result.stdout, bytes) else result.stdout
+    except UnicodeDecodeError as exc:
+        raise RepositorySecurityError("repository containment metadata is malformed") from exc
+    return raw
+
+
+def _protected_repository_paths(repository: Path) -> tuple[Path, ...]:
+    """Resolve every Git/worktree boundary that artifact writes must not touch."""
+
+    runner = GovernanceCommandRunner(max_output_bytes=1_000_000)
+    git_dir_value = _git_output(runner, repository, "rev-parse", "--absolute-git-dir").strip()
+    common_dir_value = _git_output(
+        runner,
+        repository,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir",
+    ).strip()
+    git_dir = Path(git_dir_value)
+    common_dir = Path(common_dir_value)
+    if (
+        not git_dir_value
+        or not common_dir_value
+        or not git_dir.is_absolute()
+        or not common_dir.is_absolute()
+    ):
+        raise RepositorySecurityError("absolute Git metadata containment could not be proven")
+    worktree_output = _git_output(runner, repository, "worktree", "list", "--porcelain", "-z")
+    worktrees = tuple(
+        Path(record.removeprefix("worktree ")).resolve()
+        for record in worktree_output.split("\0")
+        if record.startswith("worktree ")
+    )
+    paths = {repository.resolve(), git_dir.resolve(), common_dir.resolve(), *worktrees}
+    if not worktrees:
+        raise RepositorySecurityError("repository worktree containment could not be proven")
+    return tuple(sorted(paths, key=lambda item: str(item)))
+
+
+def _outside_repository(output: Path, protected_paths: tuple[Path, ...]) -> Path:
     resolved = output.expanduser().resolve()
-    root = repository.expanduser().resolve()
-    if resolved == root or resolved.is_relative_to(root):
+    if any(resolved == path or resolved.is_relative_to(path) for path in protected_paths):
         raise RepositorySecurityError(
-            "repository-intelligence artifacts must be written outside the scanned repository"
+            "repository-intelligence artifacts must be outside all Git and worktree boundaries"
         )
     return resolved
 
@@ -65,9 +109,12 @@ def _cmd_scan(args: argparse.Namespace) -> int:
     requested = Path(args.repo)
     try:
         root = resolve_repository_root(requested)
-        snapshot_path = _outside_repository(Path(args.snapshot_out), root)
+        protected_paths = _protected_repository_paths(root)
+        snapshot_path = _outside_repository(Path(args.snapshot_out), protected_paths)
         governance_path = (
-            _outside_repository(Path(args.governance_out), root) if args.governance_out else None
+            _outside_repository(Path(args.governance_out), protected_paths)
+            if args.governance_out
+            else None
         )
         if governance_path is not None and governance_path == snapshot_path:
             raise RepositorySecurityError(

--- a/src/pmpe/cli/repository_cmd.py
+++ b/src/pmpe/cli/repository_cmd.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import secrets
+import stat
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -95,8 +96,14 @@ class _PreparedOutput:
     path: Path
     parent_descriptor: int
     parent_identity: tuple[int, int]
+    reservation: str
 
     def close(self) -> None:
+        try:
+            os.unlink(self.reservation, dir_fd=self.parent_descriptor)
+            os.fsync(self.parent_descriptor)
+        except FileNotFoundError:
+            pass
         os.close(self.parent_descriptor)
 
 
@@ -112,34 +119,68 @@ def _prepare_output(path: Path, protected_paths: tuple[Path, ...]) -> _PreparedO
         identity = os.fstat(descriptor)
     except OSError as exc:
         raise RepositorySecurityError("artifact output directory could not be pinned") from exc
+    reservation = f".pmpe-intelligence-reservation.{secrets.token_hex(16)}"
+    reservation_descriptor: int | None = None
+    try:
+        reservation_descriptor = os.open(
+            reservation,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=descriptor,
+        )
+    except OSError as exc:
+        os.close(descriptor)
+        raise RepositorySecurityError("artifact output reservation could not be created") from exc
+    finally:
+        if reservation_descriptor is not None:
+            os.close(reservation_descriptor)
     return _PreparedOutput(
         path=validated,
         parent_descriptor=descriptor,
         parent_identity=(identity.st_dev, identity.st_ino),
+        reservation=reservation,
     )
 
 
-def _revalidate_output(output: _PreparedOutput, protected_paths: tuple[Path, ...]) -> None:
+def _revalidate_output(
+    output: _PreparedOutput,
+    protected_paths: tuple[Path, ...],
+    repository: Path,
+) -> None:
     """Reject path replacement while continuing to rely on the pinned descriptor."""
 
     try:
-        current = _outside_repository(output.path, protected_paths)
+        current_protected = tuple(
+            sorted(
+                {*protected_paths, *_protected_repository_paths(repository)},
+                key=lambda item: str(item),
+            )
+        )
+        current = _outside_repository(output.path, current_protected)
         parent = os.stat(current.parent, follow_symlinks=False)
         pinned = os.fstat(output.parent_descriptor)
+        reservation = os.stat(
+            output.reservation,
+            dir_fd=output.parent_descriptor,
+            follow_symlinks=False,
+        )
     except (OSError, RepositorySecurityError) as exc:
         raise RepositorySecurityError("artifact output containment changed during scan") from exc
     if current != output.path or (parent.st_dev, parent.st_ino) != output.parent_identity:
         raise RepositorySecurityError("artifact output containment changed during scan")
     if (pinned.st_dev, pinned.st_ino) != output.parent_identity:
         raise RepositorySecurityError("artifact output descriptor identity changed during scan")
+    if not stat.S_ISREG(reservation.st_mode) or reservation.st_nlink != 1:
+        raise RepositorySecurityError("artifact output reservation changed during scan")
 
 
 def _atomic_write(
     output: _PreparedOutput,
     payload: bytes,
     protected_paths: tuple[Path, ...],
+    repository: Path,
 ) -> None:
-    _revalidate_output(output, protected_paths)
+    _revalidate_output(output, protected_paths, repository)
     temporary = f".{output.path.name}.{secrets.token_hex(16)}"
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
     descriptor: int | None = None
@@ -151,7 +192,7 @@ def _atomic_write(
             stream.write(b"\n")
             stream.flush()
             os.fsync(stream.fileno())
-        _revalidate_output(output, protected_paths)
+        _revalidate_output(output, protected_paths, repository)
         os.replace(
             temporary,
             output.path.name,
@@ -212,9 +253,14 @@ def _cmd_scan(args: argparse.Namespace) -> int:
                 clock=clock,
                 id_provider=ids,
             )
-        _atomic_write(snapshot_output, snapshot.canonical_bytes(), protected_paths)
+        _atomic_write(snapshot_output, snapshot.canonical_bytes(), protected_paths, root)
         if governance_output is not None and observation is not None:
-            _atomic_write(governance_output, observation.canonical_bytes(), protected_paths)
+            _atomic_write(
+                governance_output,
+                observation.canonical_bytes(),
+                protected_paths,
+                root,
+            )
     except RepositoryIntelligenceError as exc:
         print(f"repository intelligence blocked: {exc}", file=sys.stderr)
         return 1

--- a/src/pmpe/cli/repository_cmd.py
+++ b/src/pmpe/cli/repository_cmd.py
@@ -69,6 +69,10 @@ def _cmd_scan(args: argparse.Namespace) -> int:
         governance_path = (
             _outside_repository(Path(args.governance_out), root) if args.governance_out else None
         )
+        if governance_path is not None and governance_path == snapshot_path:
+            raise RepositorySecurityError(
+                "snapshot and governance artifacts require distinct output paths"
+            )
         snapshot = scan_repository(
             requested,
             commit=args.commit,
@@ -102,7 +106,12 @@ def _cmd_scan(args: argparse.Namespace) -> int:
         ),
     }
     print(json.dumps(summary, sort_keys=True, separators=(",", ":")))
-    return 0 if snapshot.disposition == "COMPLETE" else 3
+    return (
+        0
+        if snapshot.disposition == "COMPLETE"
+        and (observation is None or observation.disposition == "COMPLETE")
+        else 3
+    )
 
 
 def register(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]

--- a/src/pmpe/cli/repository_cmd.py
+++ b/src/pmpe/cli/repository_cmd.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import secrets
 import sys
-import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 from pmpe.repository import (
@@ -89,24 +90,92 @@ def _outside_repository(output: Path, protected_paths: tuple[Path, ...]) -> Path
     return resolved
 
 
-def _atomic_write(path: Path, payload: bytes) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
-    temporary_path = Path(temporary)
+@dataclass(frozen=True)
+class _PreparedOutput:
+    path: Path
+    parent_descriptor: int
+    parent_identity: tuple[int, int]
+
+    def close(self) -> None:
+        os.close(self.parent_descriptor)
+
+
+def _prepare_output(path: Path, protected_paths: tuple[Path, ...]) -> _PreparedOutput:
+    """Open and pin a validated output directory before an untrusted scan runs."""
+
+    validated = _outside_repository(path, protected_paths)
+    validated.parent.mkdir(parents=True, exist_ok=True)
+    validated = _outside_repository(validated, protected_paths)
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
+        descriptor = os.open(validated.parent, flags)
+        identity = os.fstat(descriptor)
+    except OSError as exc:
+        raise RepositorySecurityError("artifact output directory could not be pinned") from exc
+    return _PreparedOutput(
+        path=validated,
+        parent_descriptor=descriptor,
+        parent_identity=(identity.st_dev, identity.st_ino),
+    )
+
+
+def _revalidate_output(output: _PreparedOutput, protected_paths: tuple[Path, ...]) -> None:
+    """Reject path replacement while continuing to rely on the pinned descriptor."""
+
+    try:
+        current = _outside_repository(output.path, protected_paths)
+        parent = os.stat(current.parent, follow_symlinks=False)
+        pinned = os.fstat(output.parent_descriptor)
+    except (OSError, RepositorySecurityError) as exc:
+        raise RepositorySecurityError("artifact output containment changed during scan") from exc
+    if current != output.path or (parent.st_dev, parent.st_ino) != output.parent_identity:
+        raise RepositorySecurityError("artifact output containment changed during scan")
+    if (pinned.st_dev, pinned.st_ino) != output.parent_identity:
+        raise RepositorySecurityError("artifact output descriptor identity changed during scan")
+
+
+def _atomic_write(
+    output: _PreparedOutput,
+    payload: bytes,
+    protected_paths: tuple[Path, ...],
+) -> None:
+    _revalidate_output(output, protected_paths)
+    temporary = f".{output.path.name}.{secrets.token_hex(16)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=output.parent_descriptor)
         with os.fdopen(descriptor, "wb") as stream:
+            descriptor = None
             stream.write(payload)
             stream.write(b"\n")
             stream.flush()
             os.fsync(stream.fileno())
-        temporary_path.replace(path)
-    except Exception:
-        temporary_path.unlink(missing_ok=True)
-        raise
+        _revalidate_output(output, protected_paths)
+        os.replace(
+            temporary,
+            output.path.name,
+            src_dir_fd=output.parent_descriptor,
+            dst_dir_fd=output.parent_descriptor,
+        )
+        os.fsync(output.parent_descriptor)
+    except OSError as exc:
+        raise RepositorySecurityError("artifact write could not be completed safely") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary, dir_fd=output.parent_descriptor)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise RepositorySecurityError("temporary artifact cleanup could not be proven") from exc
 
 
 def _cmd_scan(args: argparse.Namespace) -> int:
     requested = Path(args.repo)
+    snapshot_output: _PreparedOutput | None = None
+    governance_output: _PreparedOutput | None = None
     try:
         root = resolve_repository_root(requested)
         protected_paths = _protected_repository_paths(root)
@@ -120,6 +189,9 @@ def _cmd_scan(args: argparse.Namespace) -> int:
             raise RepositorySecurityError(
                 "snapshot and governance artifacts require distinct output paths"
             )
+        snapshot_output = _prepare_output(snapshot_path, protected_paths)
+        if governance_path is not None:
+            governance_output = _prepare_output(governance_path, protected_paths)
         snapshot = scan_repository(
             requested,
             commit=args.commit,
@@ -140,12 +212,17 @@ def _cmd_scan(args: argparse.Namespace) -> int:
                 clock=clock,
                 id_provider=ids,
             )
-        _atomic_write(snapshot_path, snapshot.canonical_bytes())
-        if governance_path is not None and observation is not None:
-            _atomic_write(governance_path, observation.canonical_bytes())
+        _atomic_write(snapshot_output, snapshot.canonical_bytes(), protected_paths)
+        if governance_output is not None and observation is not None:
+            _atomic_write(governance_output, observation.canonical_bytes(), protected_paths)
     except RepositoryIntelligenceError as exc:
         print(f"repository intelligence blocked: {exc}", file=sys.stderr)
         return 1
+    finally:
+        if governance_output is not None:
+            governance_output.close()
+        if snapshot_output is not None:
+            snapshot_output.close()
     summary = {
         "snapshot_digest": snapshot.snapshot_digest,
         "snapshot_disposition": snapshot.disposition,

--- a/src/pmpe/cli/repository_cmd.py
+++ b/src/pmpe/cli/repository_cmd.py
@@ -1,0 +1,122 @@
+"""Read-only repository-intelligence CLI seam."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from pmpe.repository import (
+    RepositoryIntelligenceError,
+    RepositorySecurityError,
+    ScanConfig,
+    observe_governance,
+    scan_repository,
+)
+
+
+class _ArgumentClock:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def now(self) -> str:
+        return self.value
+
+
+class _ArgumentIds:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def new_id(self) -> str:
+        return self.value
+
+
+def _outside_repository(output: Path, repository: Path) -> Path:
+    resolved = output.expanduser().resolve()
+    root = repository.expanduser().resolve()
+    if resolved == root or resolved.is_relative_to(root):
+        raise RepositorySecurityError(
+            "repository-intelligence artifacts must be written outside the scanned repository"
+        )
+    return resolved
+
+
+def _atomic_write(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.write(b"\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary_path.replace(path)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def _cmd_scan(args: argparse.Namespace) -> int:
+    root = Path(args.repo)
+    try:
+        snapshot_path = _outside_repository(Path(args.snapshot_out), root)
+        governance_path = (
+            _outside_repository(Path(args.governance_out), root) if args.governance_out else None
+        )
+        snapshot = scan_repository(
+            root,
+            commit=args.commit,
+            config=ScanConfig(
+                repository=args.repository,
+                default_branch=args.default_branch,
+            ),
+        )
+        observation = None
+        if governance_path is not None:
+            clock = _ArgumentClock(args.observed_at) if args.observed_at else None
+            ids = _ArgumentIds(args.observation_id) if args.observation_id else None
+            observation = observe_governance(
+                root,
+                repository=args.repository,
+                ref=args.default_branch or args.commit,
+                clock=clock,
+                id_provider=ids,
+            )
+        _atomic_write(snapshot_path, snapshot.canonical_bytes())
+        if governance_path is not None and observation is not None:
+            _atomic_write(governance_path, observation.canonical_bytes())
+    except RepositoryIntelligenceError as exc:
+        print(f"repository intelligence blocked: {exc}", file=sys.stderr)
+        return 1
+    summary = {
+        "snapshot_digest": snapshot.snapshot_digest,
+        "snapshot_disposition": snapshot.disposition,
+        "governance_observation_id": (
+            observation.observation_id if observation is not None else None
+        ),
+    }
+    print(json.dumps(summary, sort_keys=True, separators=(",", ":")))
+    return 0 if snapshot.disposition == "COMPLETE" else 3
+
+
+def register(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    repository = sub.add_parser(
+        "repository", help="collect deterministic read-only repository intelligence"
+    )
+    commands = repository.add_subparsers(dest="repository_command", required=True)
+    scan = commands.add_parser(
+        "scan", help="scan an exact Git commit without executing project code"
+    )
+    scan.add_argument("--repo", required=True)
+    scan.add_argument("--repository", required=True)
+    scan.add_argument("--commit", default="HEAD")
+    scan.add_argument("--default-branch")
+    scan.add_argument("--snapshot-out", required=True)
+    scan.add_argument("--governance-out")
+    scan.add_argument("--observed-at")
+    scan.add_argument("--observation-id")
+    scan.set_defaults(fn=_cmd_scan)

--- a/src/pmpe/cli/repository_cmd.py
+++ b/src/pmpe/cli/repository_cmd.py
@@ -136,6 +136,7 @@ def _cmd_scan(args: argparse.Namespace) -> int:
                 requested,
                 repository=args.repository,
                 ref=args.default_branch or args.commit,
+                snapshot=snapshot,
                 clock=clock,
                 id_provider=ids,
             )

--- a/src/pmpe/cli/repository_cmd.py
+++ b/src/pmpe/cli/repository_cmd.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from pmpe.repository import (
+    RecordedObservationIds,
+    RecordedUtcClock,
     RepositoryIntelligenceError,
     RepositorySecurityError,
     ScanConfig,
@@ -20,22 +22,6 @@ from pmpe.repository import (
     scan_repository,
 )
 from pmpe.repository.governance import GovernanceCommandRunner
-
-
-class _ArgumentClock:
-    def __init__(self, value: str) -> None:
-        self.value = value
-
-    def now(self) -> str:
-        return self.value
-
-
-class _ArgumentIds:
-    def __init__(self, value: str) -> None:
-        self.value = value
-
-    def new_id(self) -> str:
-        return self.value
 
 
 def _git_output(runner: GovernanceCommandRunner, root: Path, *args: str) -> str:
@@ -243,8 +229,8 @@ def _cmd_scan(args: argparse.Namespace) -> int:
         )
         observation = None
         if governance_path is not None:
-            clock = _ArgumentClock(args.observed_at) if args.observed_at else None
-            ids = _ArgumentIds(args.observation_id) if args.observation_id else None
+            clock = RecordedUtcClock(args.observed_at) if args.observed_at else None
+            ids = RecordedObservationIds(args.observation_id) if args.observation_id else None
             observation = observe_governance(
                 requested,
                 repository=args.repository,

--- a/src/pmpe/cli/repository_cmd.py
+++ b/src/pmpe/cli/repository_cmd.py
@@ -96,15 +96,30 @@ class _PreparedOutput:
 def _prepare_output(path: Path, protected_paths: tuple[Path, ...]) -> _PreparedOutput:
     """Open and pin a validated output directory before an untrusted scan runs."""
 
-    validated = _outside_repository(path, protected_paths)
-    validated.parent.mkdir(parents=True, exist_ok=True)
-    validated = _outside_repository(validated, protected_paths)
+    requested = path.expanduser()
+    validated = _outside_repository(requested, protected_paths)
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor: int | None = None
     try:
         descriptor = os.open(validated.parent, flags)
         identity = os.fstat(descriptor)
+        revalidated = _outside_repository(requested, protected_paths)
+        current = os.stat(revalidated.parent, follow_symlinks=False)
     except OSError as exc:
+        if descriptor is not None:
+            os.close(descriptor)
         raise RepositorySecurityError("artifact output directory could not be pinned") from exc
+    except RepositorySecurityError:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise
+    assert descriptor is not None
+    if revalidated != validated or (current.st_dev, current.st_ino) != (
+        identity.st_dev,
+        identity.st_ino,
+    ):
+        os.close(descriptor)
+        raise RepositorySecurityError("artifact output containment changed during preparation")
     reservation = f".pmpe-intelligence-reservation.{secrets.token_hex(16)}"
     reservation_descriptor: int | None = None
     try:

--- a/src/pmpe/repository/__init__.py
+++ b/src/pmpe/repository/__init__.py
@@ -12,6 +12,7 @@ from pmpe.repository.models import AUDIT_CATEGORIES, CommandResult, ScanConfig
 from pmpe.repository.scanner import (
     CancellationSignal,
     RepositoryIntelligenceError,
+    RepositoryScanCancelledError,
     RepositoryScanner,
     RepositorySecurityError,
     resolve_repository_root,
@@ -28,6 +29,7 @@ __all__ = [
     "RecordedUtcClock",
     "RepositoryAdapter",
     "RepositoryIntelligenceError",
+    "RepositoryScanCancelledError",
     "RepositoryScanner",
     "RepositorySecurityError",
     "ScanConfig",

--- a/src/pmpe/repository/__init__.py
+++ b/src/pmpe/repository/__init__.py
@@ -1,0 +1,26 @@
+"""Deterministic repository intelligence public API."""
+
+from pmpe.repository.adapters import RepositoryAdapter, default_adapters, repository_adapter
+from pmpe.repository.governance import GovernanceCollector, observe_governance
+from pmpe.repository.models import AUDIT_CATEGORIES, CommandResult, ScanConfig
+from pmpe.repository.scanner import (
+    RepositoryIntelligenceError,
+    RepositoryScanner,
+    RepositorySecurityError,
+    scan_repository,
+)
+
+__all__ = [
+    "AUDIT_CATEGORIES",
+    "CommandResult",
+    "GovernanceCollector",
+    "RepositoryAdapter",
+    "RepositoryIntelligenceError",
+    "RepositoryScanner",
+    "RepositorySecurityError",
+    "ScanConfig",
+    "default_adapters",
+    "observe_governance",
+    "repository_adapter",
+    "scan_repository",
+]

--- a/src/pmpe/repository/__init__.py
+++ b/src/pmpe/repository/__init__.py
@@ -7,6 +7,7 @@ from pmpe.repository.scanner import (
     RepositoryIntelligenceError,
     RepositoryScanner,
     RepositorySecurityError,
+    resolve_repository_root,
     scan_repository,
 )
 
@@ -22,5 +23,6 @@ __all__ = [
     "default_adapters",
     "observe_governance",
     "repository_adapter",
+    "resolve_repository_root",
     "scan_repository",
 ]

--- a/src/pmpe/repository/__init__.py
+++ b/src/pmpe/repository/__init__.py
@@ -1,7 +1,11 @@
 """Deterministic repository intelligence public API."""
 
 from pmpe.repository.adapters import RepositoryAdapter, default_adapters, repository_adapter
-from pmpe.repository.governance import GovernanceCollector, observe_governance
+from pmpe.repository.governance import (
+    GovernanceCollector,
+    RecordedRemoteProvider,
+    observe_governance,
+)
 from pmpe.repository.models import AUDIT_CATEGORIES, CommandResult, ScanConfig
 from pmpe.repository.scanner import (
     RepositoryIntelligenceError,
@@ -15,6 +19,7 @@ __all__ = [
     "AUDIT_CATEGORIES",
     "CommandResult",
     "GovernanceCollector",
+    "RecordedRemoteProvider",
     "RepositoryAdapter",
     "RepositoryIntelligenceError",
     "RepositoryScanner",

--- a/src/pmpe/repository/__init__.py
+++ b/src/pmpe/repository/__init__.py
@@ -3,11 +3,14 @@
 from pmpe.repository.adapters import RepositoryAdapter, default_adapters, repository_adapter
 from pmpe.repository.governance import (
     GovernanceCollector,
+    RecordedObservationIds,
     RecordedRemoteProvider,
+    RecordedUtcClock,
     observe_governance,
 )
 from pmpe.repository.models import AUDIT_CATEGORIES, CommandResult, ScanConfig
 from pmpe.repository.scanner import (
+    CancellationSignal,
     RepositoryIntelligenceError,
     RepositoryScanner,
     RepositorySecurityError,
@@ -17,9 +20,12 @@ from pmpe.repository.scanner import (
 
 __all__ = [
     "AUDIT_CATEGORIES",
+    "CancellationSignal",
     "CommandResult",
     "GovernanceCollector",
+    "RecordedObservationIds",
     "RecordedRemoteProvider",
+    "RecordedUtcClock",
     "RepositoryAdapter",
     "RepositoryIntelligenceError",
     "RepositoryScanner",

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import configparser
 import fnmatch
 import json
 import re
@@ -14,7 +15,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.9.0"
+DETECTOR_VERSION = "1.10.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -486,7 +487,7 @@ def _topology(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="stack.python",
-    version="1.3.0",
+    version="1.4.0",
     file_patterns=(
         "*.py",
         "**/*.py",
@@ -554,7 +555,56 @@ def _python(context: AdapterContext) -> AdapterResult:
                                 _item(file, "DECLARED_ENTRY_POINT", "stack.python"),
                             )
                         )
+                    tool = parsed.get("tool", {})
+                    if isinstance(tool, dict):
+                        pytest_configuration = tool.get("pytest")
+                        if isinstance(pytest_configuration, dict) and pytest_configuration:
+                            items.append(
+                                (
+                                    "tests_quality",
+                                    _item(file, "TEST_CONFIGURATION", "stack.python"),
+                                )
+                            )
+                        coverage_configuration = tool.get("coverage")
+                        if isinstance(coverage_configuration, dict) and coverage_configuration:
+                            items.append(
+                                (
+                                    "tests_quality",
+                                    _item(file, "COVERAGE_CONFIGURATION", "stack.python"),
+                                )
+                            )
                 except (tomllib.TOMLDecodeError, UnicodeDecodeError, ValueError):
+                    findings.append(
+                        _finding(
+                            "MANIFEST.MALFORMED",
+                            "languages_build_ecosystems",
+                            "A tracked Python manifest cannot be parsed deterministically.",
+                            (file.path,),
+                            "stack.python",
+                            severity="HIGH",
+                            blocking=True,
+                        )
+                    )
+            if name == "setup.cfg" and file.content is not None:
+                try:
+                    configuration = configparser.ConfigParser(interpolation=None)
+                    configuration.read_string(file.content.decode("utf-8"))
+                    sections = {section.lower() for section in configuration.sections()}
+                    if sections & {"pytest", "tool:pytest"}:
+                        items.append(
+                            (
+                                "tests_quality",
+                                _item(file, "TEST_CONFIGURATION", "stack.python"),
+                            )
+                        )
+                    if any(section.startswith("coverage:") for section in sections):
+                        items.append(
+                            (
+                                "tests_quality",
+                                _item(file, "COVERAGE_CONFIGURATION", "stack.python"),
+                            )
+                        )
+                except (configparser.Error, UnicodeDecodeError):
                     findings.append(
                         _finding(
                             "MANIFEST.MALFORMED",
@@ -596,7 +646,7 @@ def _python(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="stack.node-web",
-    version="1.2.0",
+    version="1.3.0",
     file_patterns=(
         "**/*.js",
         "*.js",
@@ -657,6 +707,43 @@ def _node(context: AdapterContext) -> AdapterResult:
                             (
                                 "architecture_boundaries",
                                 _item(file, "DECLARED_RUN_ENTRY_POINT", "stack.node-web"),
+                            )
+                        )
+                    if isinstance(scripts, dict) and any(
+                        isinstance(command, str) and (name == "test" or name.startswith("test:"))
+                        for name, command in scripts.items()
+                    ):
+                        items.append(
+                            (
+                                "tests_quality",
+                                _item(file, "DECLARED_TEST_COMMAND", "stack.node-web"),
+                            )
+                        )
+                    if isinstance(scripts, dict) and any(
+                        isinstance(command, str) and "coverage" in name.lower()
+                        for name, command in scripts.items()
+                    ):
+                        items.append(
+                            (
+                                "tests_quality",
+                                _item(file, "DECLARED_COVERAGE_COMMAND", "stack.node-web"),
+                            )
+                        )
+                    if any(
+                        isinstance(package.get(key), dict) and package[key]
+                        for key in ("ava", "jest", "mocha", "playwright", "vitest")
+                    ):
+                        items.append(
+                            (
+                                "tests_quality",
+                                _item(file, "TEST_CONFIGURATION", "stack.node-web"),
+                            )
+                        )
+                    if isinstance(package.get("nyc"), dict) and package["nyc"]:
+                        items.append(
+                            (
+                                "tests_quality",
+                                _item(file, "COVERAGE_CONFIGURATION", "stack.node-web"),
                             )
                         )
                 except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.27.0"
+DETECTOR_VERSION = "1.28.0"
 
 _GITHUB_EVENTS = frozenset(
     {
@@ -67,6 +67,7 @@ _GITHUB_REMOTE_REUSABLE_WORKFLOW = re.compile(
 _GITHUB_LOCAL_ACTION = re.compile(r"^\./[A-Za-z0-9_./-]+$")
 _GITHUB_REMOTE_ACTION = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_./-]+)?@\S+$")
 _GITHUB_DOCKER_ACTION = re.compile(r"^docker://\S+$")
+_GITHUB_OWNER = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$")
 _GITHUB_REPOSITORY_COMPONENT = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,98}[A-Za-z0-9])?$")
 _GITHUB_REMOTE_REF = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,254}$")
 _GITHUB_PULL_REQUEST_TYPES = frozenset(
@@ -1300,7 +1301,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.13.0",
+    version="1.14.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1728,7 +1729,10 @@ def _github_remote_reference_is_supported(
     parts = target.split("/")
     if len(parts) < 2 or any(not part or part in {".", ".."} for part in parts):
         return False
-    if any(_GITHUB_REPOSITORY_COMPONENT.fullmatch(part) is None for part in parts[:2]):
+    if (
+        _GITHUB_OWNER.fullmatch(parts[0]) is None
+        or _GITHUB_REPOSITORY_COMPONENT.fullmatch(parts[1]) is None
+    ):
         return False
     remaining = parts[2:]
     if reusable_workflow:

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.25.0"
+DETECTOR_VERSION = "1.26.0"
 
 _GITHUB_EVENTS = frozenset(
     {
@@ -67,6 +67,8 @@ _GITHUB_REMOTE_REUSABLE_WORKFLOW = re.compile(
 _GITHUB_LOCAL_ACTION = re.compile(r"^\./[A-Za-z0-9_./-]+$")
 _GITHUB_REMOTE_ACTION = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_./-]+)?@\S+$")
 _GITHUB_DOCKER_ACTION = re.compile(r"^docker://\S+$")
+_GITHUB_REPOSITORY_COMPONENT = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,98}[A-Za-z0-9])?$")
+_GITHUB_REMOTE_REF = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,254}$")
 _GITHUB_PULL_REQUEST_TYPES = frozenset(
     {
         "assigned",
@@ -1298,7 +1300,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.11.0",
+    version="1.12.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1708,11 +1710,36 @@ def _github_reusable_workflow_is_runnable(value: object) -> bool:
     reference = value.strip()
     if _GITHUB_LOCAL_REUSABLE_WORKFLOW.fullmatch(reference) is not None:
         return False
-    if _GITHUB_REMOTE_REUSABLE_WORKFLOW.fullmatch(reference) is not None:
-        path = reference.split("@", 1)[0].split("/", 2)[2]
-    else:
+    return _github_remote_reference_is_supported(reference, reusable_workflow=True)
+
+
+def _github_remote_reference_is_supported(
+    reference: str,
+    *,
+    reusable_workflow: bool,
+) -> bool:
+    target, separator, ref = reference.rpartition("@")
+    if (
+        not separator
+        or _GITHUB_REMOTE_REF.fullmatch(ref) is None
+        or ".." in ref
+        or "//" in ref
+        or ref.endswith(("/", ".", ".lock"))
+    ):
         return False
-    return ".." not in PurePosixPath(path).parts
+    parts = target.split("/")
+    if len(parts) < 2 or any(not part or part in {".", ".."} for part in parts):
+        return False
+    if any(_GITHUB_REPOSITORY_COMPONENT.fullmatch(part) is None for part in parts[:2]):
+        return False
+    remaining = parts[2:]
+    if reusable_workflow:
+        return (
+            len(remaining) == 3
+            and remaining[:2] == [".github", "workflows"]
+            and re.fullmatch(r"[A-Za-z0-9_.-]+\.ya?ml", remaining[2]) is not None
+        )
+    return all(re.fullmatch(r"[A-Za-z0-9_.-]+", part) is not None for part in remaining)
 
 
 def _github_job_is_runnable(value: object) -> bool:
@@ -1796,8 +1823,7 @@ def _github_step_is_runnable(value: object) -> bool:
     if _GITHUB_LOCAL_ACTION.fullmatch(reference) is not None:
         return False
     if _GITHUB_REMOTE_ACTION.fullmatch(reference) is not None:
-        action_path = reference.rsplit("@", 1)[0].split("/", 2)
-        return len(action_path) < 3 or ".." not in PurePosixPath(action_path[2]).parts
+        return _github_remote_reference_is_supported(reference, reusable_workflow=False)
     return _GITHUB_DOCKER_ACTION.fullmatch(reference) is not None
 
 

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -1,0 +1,501 @@
+"""Versioned, deterministic stack adapters for repository evidence."""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+import yaml
+
+from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
+
+
+@dataclass(frozen=True)
+class TrackedFile:
+    path: str
+    mode: str
+    object_id: str
+    digest: str
+    content: bytes | None
+    binary: bool
+    oversized: bool = False
+
+
+@dataclass(frozen=True)
+class AdapterContext:
+    files: tuple[TrackedFile, ...]
+
+    def matching(self, patterns: tuple[str, ...]) -> tuple[TrackedFile, ...]:
+        return tuple(
+            item
+            for item in self.files
+            if any(fnmatch.fnmatch(item.path, pattern) for pattern in patterns)
+        )
+
+
+@dataclass(frozen=True)
+class AdapterResult:
+    items: tuple[tuple[str, EvidenceItem], ...] = ()
+    findings: tuple[Finding, ...] = ()
+    boundaries: tuple[BoundaryCandidate, ...] = ()
+
+
+AdapterEvaluator = Callable[[AdapterContext], AdapterResult]
+
+
+@dataclass(frozen=True)
+class RepositoryAdapter:
+    adapter_id: str
+    version: str
+    file_patterns: tuple[str, ...]
+    supported_categories: tuple[str, ...]
+    evaluator: AdapterEvaluator
+    failure_behavior: str = "VISIBLE_PARTIAL_OR_BLOCKED"
+    detection_logic: str = "TRACKED_PATH_AND_SAFE_STRUCTURE_ONLY"
+    evidence_emitted: str = "DIGEST_BOUND_FILE_EVIDENCE"
+    confidence_semantics: str = "HIGH_EXACT_MEDIUM_HEURISTIC_LOW_SIGNAL"
+
+
+def repository_adapter(
+    *,
+    adapter_id: str,
+    version: str,
+    file_patterns: tuple[str, ...],
+    supported_categories: tuple[str, ...],
+) -> Callable[[AdapterEvaluator], RepositoryAdapter]:
+    """Declare an immutable adapter with visible failure semantics."""
+
+    def decorate(evaluator: AdapterEvaluator) -> RepositoryAdapter:
+        return RepositoryAdapter(
+            adapter_id=adapter_id,
+            version=version,
+            file_patterns=file_patterns,
+            supported_categories=supported_categories,
+            evaluator=evaluator,
+        )
+
+    return decorate
+
+
+def _item(file: TrackedFile, kind: str, detector: str, version: str = "1.0.0") -> EvidenceItem:
+    return EvidenceItem(
+        kind=kind,
+        path=file.path,
+        file_digest=file.digest,
+        detector_id=detector,
+        detector_version=version,
+    )
+
+
+def _finding(
+    code: str,
+    category: str,
+    explanation: str,
+    evidence: tuple[str, ...],
+    detector: str,
+    *,
+    severity: str = "MEDIUM",
+    confidence: str = "HIGH",
+    blocking: bool = False,
+) -> Finding:
+    return Finding(
+        code=code,
+        category=category,
+        severity=severity,
+        confidence=confidence,
+        explanation=explanation,
+        evidence_refs=evidence,
+        detector_id=detector,
+        detector_version="1.0.0",
+        blocking=blocking,
+    )
+
+
+@repository_adapter(
+    adapter_id="core.repository-topology",
+    version="1.0.0",
+    file_patterns=("**/*", "*"),
+    supported_categories=(
+        "repository_topology",
+        "architecture_boundaries",
+        "documentation_governance",
+        "debt_risk",
+    ),
+)
+def _topology(context: AdapterContext) -> AdapterResult:
+    items: list[tuple[str, EvidenceItem]] = []
+    boundaries: list[BoundaryCandidate] = []
+    for file in context.files:
+        name = PurePosixPath(file.path).name
+        lowered = file.path.lower()
+        if file.mode == "160000":
+            kind = "SUBMODULE"
+        elif file.mode == "120000":
+            kind = "SYMLINK"
+        elif file.binary:
+            kind = "BINARY_FILE"
+        elif any(part in {"vendor", "vendored", "node_modules"} for part in file.path.split("/")):
+            kind = "VENDORED_AREA"
+        elif "generated" in file.path.lower() or file.path.endswith("_generated.py"):
+            kind = "GENERATED_AREA"
+        elif name == ".gitignore":
+            kind = "IGNORE_POLICY"
+        elif name == ".gitmodules":
+            kind = "SUBMODULE_CONFIG"
+        elif name in {"package.json", "pyproject.toml", "Cargo.toml", "go.mod"}:
+            kind = "PACKAGE_BOUNDARY_MANIFEST"
+        else:
+            kind = "TRACKED_FILE"
+        items.append(("repository_topology", _item(file, kind, "core.repository-topology")))
+
+        if file.path in {"README.md", "CONTRIBUTING.md", "SECURITY.md"}:
+            items.append(
+                (
+                    "documentation_governance",
+                    _item(file, "POLICY_DOCUMENT", "core.repository-topology"),
+                )
+            )
+        if lowered.startswith("docs/adr/") or "/adr/" in lowered:
+            items.append(
+                ("documentation_governance", _item(file, "ADR", "core.repository-topology"))
+            )
+        if file.path in {".github/CODEOWNERS", "CODEOWNERS"}:
+            items.append(
+                ("documentation_governance", _item(file, "CODEOWNERS", "core.repository-topology"))
+            )
+            items.append(
+                ("security_privacy", _item(file, "OWNERSHIP_CONTROL", "core.repository-topology"))
+            )
+        if lowered.startswith(".github/issue_template/"):
+            items.append(
+                (
+                    "documentation_governance",
+                    _item(file, "ISSUE_TEMPLATE", "core.repository-topology"),
+                )
+            )
+        if lowered in {".github/pull_request_template.md", "pull_request_template.md"}:
+            items.append(
+                (
+                    "documentation_governance",
+                    _item(file, "PR_TEMPLATE", "core.repository-topology"),
+                )
+            )
+
+    roots: dict[tuple[str, str], set[str]] = {}
+    for file in context.files:
+        parts = PurePosixPath(file.path).parts
+        if len(parts) >= 2 and parts[0] in {
+            "src",
+            "packages",
+            "services",
+            "apps",
+            "libraries",
+            "workers",
+        }:
+            root = "/".join(parts[:2])
+            if parts[0] == "services":
+                kind = "SERVICE"
+            elif (
+                parts[0] == "apps"
+                or parts[0] == "packages"
+                and any(candidate.path == f"{root}/package.json" for candidate in context.files)
+            ):
+                kind = "APPLICATION"
+            else:
+                kind = "PACKAGE"
+            roots.setdefault((kind, root), set()).add(file.path)
+    for (kind, root), paths in sorted(roots.items()):
+        boundaries.append(
+            BoundaryCandidate(
+                kind=kind,
+                name=root,
+                evidence_paths=tuple(sorted(paths)),
+                confidence="MEDIUM",
+                detector_id="core.repository-topology",
+                detector_version="1.0.0",
+            )
+        )
+    return AdapterResult(items=tuple(items), boundaries=tuple(boundaries))
+
+
+@repository_adapter(
+    adapter_id="stack.python",
+    version="1.0.0",
+    file_patterns=("**/*.py", "pyproject.toml", "**/requirements*.txt", ".python-version"),
+    supported_categories=("languages_build_ecosystems", "tests_quality", "debt_risk"),
+)
+def _python(context: AdapterContext) -> AdapterResult:
+    items: list[tuple[str, EvidenceItem]] = []
+    for file in context.files:
+        if file.path.endswith(".py"):
+            category = (
+                "tests_quality"
+                if "/test" in f"/{file.path}" or file.path.startswith("tests/")
+                else "languages_build_ecosystems"
+            )
+            kind = "PYTHON_TEST" if category == "tests_quality" else "PYTHON_SOURCE"
+            items.append((category, _item(file, kind, "stack.python")))
+        elif file.path == "pyproject.toml" or file.path.endswith("requirements.txt"):
+            items.append(
+                ("languages_build_ecosystems", _item(file, "PYTHON_MANIFEST", "stack.python"))
+            )
+        elif file.path == ".python-version":
+            items.append(
+                ("languages_build_ecosystems", _item(file, "RUNTIME_VERSION", "stack.python"))
+            )
+    return AdapterResult(items=tuple(items))
+
+
+@repository_adapter(
+    adapter_id="stack.node-web",
+    version="1.0.0",
+    file_patterns=(
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.ts",
+        "**/*.tsx",
+        "**/package.json",
+        "**/package-lock.json",
+        "**/yarn.lock",
+        "**/pnpm-lock.yaml",
+    ),
+    supported_categories=("languages_build_ecosystems", "tests_quality", "debt_risk"),
+)
+def _node(context: AdapterContext) -> AdapterResult:
+    items: list[tuple[str, EvidenceItem]] = []
+    findings: list[Finding] = []
+    lock_types: set[str] = set()
+    runtime_versions: set[str] = set()
+    for file in context.files:
+        name = PurePosixPath(file.path).name
+        if name == "package.json":
+            items.append(
+                ("languages_build_ecosystems", _item(file, "NODE_MANIFEST", "stack.node-web"))
+            )
+            if file.content is not None:
+                try:
+                    package = json.loads(file.content)
+                    engine = package.get("engines", {}).get("node")
+                    if isinstance(engine, str):
+                        runtime_versions.add(engine)
+                except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+                    findings.append(
+                        _finding(
+                            "MANIFEST.MALFORMED",
+                            "languages_build_ecosystems",
+                            "A tracked Node manifest cannot be parsed deterministically.",
+                            (file.path,),
+                            "stack.node-web",
+                            severity="HIGH",
+                            blocking=True,
+                        )
+                    )
+        elif name in {"package-lock.json", "yarn.lock", "pnpm-lock.yaml"}:
+            lock_types.add(name)
+            items.append(("languages_build_ecosystems", _item(file, "LOCKFILE", "stack.node-web")))
+        elif file.path.endswith((".js", ".jsx", ".ts", ".tsx")):
+            category = (
+                "tests_quality"
+                if "test" in name or "spec" in name
+                else "languages_build_ecosystems"
+            )
+            kind = "NODE_TEST" if category == "tests_quality" else "NODE_SOURCE"
+            items.append((category, _item(file, kind, "stack.node-web")))
+    if len(lock_types) > 1:
+        findings.append(
+            _finding(
+                "DEPENDENCY.MULTIPLE_LOCK_ECOSYSTEMS",
+                "debt_risk",
+                "Multiple Node lockfile ecosystems are tracked; this is a drift signal, "
+                "not proof of a defect.",
+                tuple(sorted(lock_types)),
+                "stack.node-web",
+                confidence="MEDIUM",
+            )
+        )
+    if len(runtime_versions) > 1:
+        findings.append(
+            _finding(
+                "RUNTIME.VERSION_DRIFT_SIGNAL",
+                "debt_risk",
+                "Multiple declared Node runtime constraints were observed.",
+                tuple(sorted(runtime_versions)),
+                "stack.node-web",
+                confidence="MEDIUM",
+            )
+        )
+    return AdapterResult(items=tuple(items), findings=tuple(findings))
+
+
+@repository_adapter(
+    adapter_id="stack.docker-compose",
+    version="1.0.0",
+    file_patterns=("**/Dockerfile", "**/Dockerfile.*", "**/compose.y*ml", "**/docker-compose.y*ml"),
+    supported_categories=(
+        "languages_build_ecosystems",
+        "delivery_environments",
+        "observability_operations",
+    ),
+)
+def _containers(context: AdapterContext) -> AdapterResult:
+    items: list[tuple[str, EvidenceItem]] = []
+    for file in context.files:
+        name = PurePosixPath(file.path).name.lower()
+        if "dockerfile" in name:
+            items.append(
+                (
+                    "languages_build_ecosystems",
+                    _item(file, "CONTAINER_BUILD", "stack.docker-compose"),
+                )
+            )
+            items.append(
+                (
+                    "delivery_environments",
+                    _item(file, "CONTAINER_DEFINITION", "stack.docker-compose"),
+                )
+            )
+            if file.content and b"HEALTHCHECK" in file.content:
+                items.append(
+                    (
+                        "observability_operations",
+                        _item(file, "HEALTH_CHECK", "stack.docker-compose"),
+                    )
+                )
+        elif "compose" in name:
+            items.append(
+                ("delivery_environments", _item(file, "LOCAL_COMPOSE", "stack.docker-compose"))
+            )
+    return AdapterResult(items=tuple(items))
+
+
+@repository_adapter(
+    adapter_id="delivery.github-actions",
+    version="1.0.0",
+    file_patterns=(".github/workflows/*.yml", ".github/workflows/*.yaml"),
+    supported_categories=("delivery_environments", "tests_quality", "security_privacy"),
+)
+def _github_actions(context: AdapterContext) -> AdapterResult:
+    items: list[tuple[str, EvidenceItem]] = []
+    findings: list[Finding] = []
+    workflows = [file for file in context.files if file.path.startswith(".github/workflows/")]
+    for file in workflows:
+        workflow_kind = (
+            "RELEASE_WORKFLOW"
+            if any(token in file.path.lower() for token in ("release", "deploy", "publish"))
+            else "CI_WORKFLOW"
+        )
+        items.append(
+            (
+                "delivery_environments",
+                _item(file, workflow_kind, "delivery.github-actions"),
+            )
+        )
+        items.append(("tests_quality", _item(file, "CI_TEST_MAPPING", "delivery.github-actions")))
+        if file.content is not None:
+            try:
+                parsed = yaml.safe_load(file.content)
+                if not isinstance(parsed, dict):
+                    raise ValueError
+            except (yaml.YAMLError, UnicodeDecodeError, ValueError):
+                findings.append(
+                    _finding(
+                        "WORKFLOW.MALFORMED",
+                        "delivery_environments",
+                        "A tracked workflow cannot be parsed deterministically.",
+                        (file.path,),
+                        "delivery.github-actions",
+                        severity="HIGH",
+                        blocking=True,
+                    )
+                )
+        if file.content and re.search(rb"\b(audit|bandit|secret|security)\b", file.content, re.I):
+            items.append(
+                ("security_privacy", _item(file, "SECURITY_GATE", "delivery.github-actions"))
+            )
+        if file.content and re.search(rb"\b(rollback|revert)\b", file.content, re.I):
+            items.append(
+                (
+                    "delivery_environments",
+                    _item(file, "ROLLBACK_MECHANISM", "delivery.github-actions"),
+                )
+            )
+    if not workflows:
+        findings.append(
+            _finding(
+                "DELIVERY.CI_ABSENT",
+                "delivery_environments",
+                "No tracked GitHub Actions workflow was observed.",
+                ("repository:tracked-tree",),
+                "delivery.github-actions",
+            )
+        )
+    return AdapterResult(items=tuple(items), findings=tuple(findings))
+
+
+@repository_adapter(
+    adapter_id="interface.schema-api",
+    version="1.0.0",
+    file_patterns=(
+        "**/*openapi*",
+        "**/schemas/**",
+        "**/migrations/**",
+        "**/generate*",
+        "scripts/**",
+    ),
+    supported_categories=("apis_data", "languages_build_ecosystems"),
+)
+def _interfaces(context: AdapterContext) -> AdapterResult:
+    items: list[tuple[str, EvidenceItem]] = []
+    for file in context.files:
+        lowered = file.path.lower()
+        if "openapi" in lowered:
+            kind = "OPENAPI"
+        elif "/migrations/" in f"/{lowered}":
+            kind = "MIGRATION"
+        elif "generate" in PurePosixPath(lowered).name:
+            kind = "CODE_GENERATOR"
+        elif "/schemas/" in f"/{lowered}" or lowered.endswith(".schema.json"):
+            kind = "SCHEMA"
+        else:
+            continue
+        items.append(("apis_data", _item(file, kind, "interface.schema-api")))
+    return AdapterResult(items=tuple(items))
+
+
+@repository_adapter(
+    adapter_id="repository.pmpe",
+    version="1.0.0",
+    file_patterns=("src/pmpe/**", "state/**", "docs/**"),
+    supported_categories=("architecture_boundaries", "documentation_governance", "debt_risk"),
+)
+def _pmpe(context: AdapterContext) -> AdapterResult:
+    items: list[tuple[str, EvidenceItem]] = []
+    for file in context.files:
+        if file.path.startswith("src/pmpe/"):
+            items.append(("architecture_boundaries", _item(file, "PMPE_MODULE", "repository.pmpe")))
+        elif file.path.startswith("state/"):
+            items.append(
+                ("documentation_governance", _item(file, "DURABLE_STATE", "repository.pmpe"))
+            )
+    return AdapterResult(items=tuple(items))
+
+
+def default_adapters() -> tuple[RepositoryAdapter, ...]:
+    return tuple(
+        sorted(
+            (
+                _topology,
+                _python,
+                _node,
+                _containers,
+                _github_actions,
+                _interfaces,
+                _pmpe,
+            ),
+            key=lambda adapter: adapter.adapter_id,
+        )
+    )

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.14.0"
+DETECTOR_VERSION = "1.15.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -272,9 +272,19 @@ def _api_declaration_kind(path: str) -> str | None:
     if suffix not in {".json", ".yaml", ".yml"}:
         return None
     stem = name[: -len(suffix)]
-    if stem == "openapi" or stem.endswith(".openapi"):
+    if (
+        stem == "openapi"
+        or stem.endswith(".openapi")
+        or stem.startswith(("openapi-", "openapi_"))
+        or stem == "swagger"
+        or stem.startswith(("swagger-", "swagger_"))
+    ):
         return "OPENAPI"
-    if stem == "asyncapi" or stem.endswith(".asyncapi"):
+    if (
+        stem == "asyncapi"
+        or stem.endswith(".asyncapi")
+        or stem.startswith(("asyncapi-", "asyncapi_"))
+    ):
         return "EVENT_CONTRACT"
     return None
 
@@ -1308,12 +1318,18 @@ def _valid_ci_structure(path: str, value: object) -> bool:
 
 @repository_adapter(
     adapter_id="interface.schema-api",
-    version="1.5.0",
+    version="1.6.0",
     file_patterns=(
         "package.json",
         "**/package.json",
         "*openapi*",
         "**/*openapi*",
+        "*swagger*.json",
+        "**/*swagger*.json",
+        "*swagger*.yaml",
+        "**/*swagger*.yaml",
+        "*swagger*.yml",
+        "**/*swagger*.yml",
         "*asyncapi*",
         "**/*asyncapi*",
         "*.proto",
@@ -1507,7 +1523,14 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
             try:
                 text = file.content.decode("utf-8")
                 payload = json.loads(text) if lowered.endswith(".json") else yaml.safe_load(text)
-                version_key = "openapi" if kind == "OPENAPI" else "asyncapi"
+                if kind == "OPENAPI":
+                    version_key = (
+                        "openapi"
+                        if isinstance(payload, dict) and isinstance(payload.get("openapi"), str)
+                        else "swagger"
+                    )
+                else:
+                    version_key = "asyncapi"
                 info = payload.get("info") if isinstance(payload, dict) else None
                 if (
                     not isinstance(payload, dict)
@@ -1520,14 +1543,18 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
                 ):
                     raise ValueError
                 declared_version = str(payload[version_key])
-                supported_version = (
-                    re.fullmatch(r"3\.(?:0|1)\.\d+(?:[-+][0-9A-Za-z.-]+)?", declared_version)
-                    if kind == "OPENAPI"
-                    else re.fullmatch(
+                if kind == "OPENAPI":
+                    version_pattern = (
+                        r"3\.(?:0|1)\.\d+(?:[-+][0-9A-Za-z.-]+)?"
+                        if version_key == "openapi"
+                        else r"2\.0"
+                    )
+                    supported_version = re.fullmatch(version_pattern, declared_version)
+                else:
+                    supported_version = re.fullmatch(
                         r"(?:2\.\d+\.\d+|3\.0\.\d+)(?:[-+][0-9A-Za-z.-]+)?",
                         declared_version,
                     )
-                )
                 if supported_version is None:
                     raise ValueError
                 if kind == "OPENAPI":

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import fnmatch
 import json
 import re
+import tomllib
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import PurePosixPath
@@ -81,13 +82,21 @@ def repository_adapter(
     return decorate
 
 
-def _item(file: TrackedFile, kind: str, detector: str, version: str = "1.0.0") -> EvidenceItem:
+def _item(
+    file: TrackedFile,
+    kind: str,
+    detector: str,
+    version: str = "1.0.0",
+    *,
+    confidence: str = "HIGH",
+) -> EvidenceItem:
     return EvidenceItem(
         kind=kind,
         path=file.path,
         file_digest=file.digest,
         detector_id=detector,
         detector_version=version,
+        confidence=confidence,
     )
 
 
@@ -184,6 +193,45 @@ def _topology(context: AdapterContext) -> AdapterResult:
                     _item(file, "PR_TEMPLATE", "core.repository-topology"),
                 )
             )
+        if any(token in lowered for token in ("/alerts", "/slo", "/metrics", "/traces")):
+            items.append(
+                (
+                    "observability_operations",
+                    _item(
+                        file,
+                        "OBSERVABILITY_CONFIG_SIGNAL",
+                        "core.repository-topology",
+                        confidence="MEDIUM",
+                    ),
+                )
+            )
+        if any(
+            token in lowered
+            for token in ("security", "dependabot", "codeql", "secret-scan", "permissions")
+        ):
+            items.append(
+                (
+                    "security_privacy",
+                    _item(
+                        file,
+                        "SECURITY_CONTROL_SIGNAL",
+                        "core.repository-topology",
+                        confidence="MEDIUM",
+                    ),
+                )
+            )
+        if any(token in lowered for token in ("terraform", "kubernetes", "helm", "/deploy")):
+            items.append(
+                (
+                    "delivery_environments",
+                    _item(
+                        file,
+                        "DEPLOYMENT_DEFINITION_SIGNAL",
+                        "core.repository-topology",
+                        confidence="MEDIUM",
+                    ),
+                )
+            )
 
     roots: dict[tuple[str, str], set[str]] = {}
     for file in context.files:
@@ -230,6 +278,7 @@ def _topology(context: AdapterContext) -> AdapterResult:
 )
 def _python(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
+    findings: list[Finding] = []
     for file in context.files:
         if file.path.endswith(".py"):
             category = (
@@ -239,15 +288,34 @@ def _python(context: AdapterContext) -> AdapterResult:
             )
             kind = "PYTHON_TEST" if category == "tests_quality" else "PYTHON_SOURCE"
             items.append((category, _item(file, kind, "stack.python")))
-        elif file.path == "pyproject.toml" or file.path.endswith("requirements.txt"):
+        elif PurePosixPath(file.path).name == "pyproject.toml" or file.path.endswith(
+            "requirements.txt"
+        ):
             items.append(
                 ("languages_build_ecosystems", _item(file, "PYTHON_MANIFEST", "stack.python"))
             )
+            if PurePosixPath(file.path).name == "pyproject.toml" and file.content is not None:
+                try:
+                    parsed = tomllib.loads(file.content.decode("utf-8"))
+                    if not isinstance(parsed, dict):
+                        raise ValueError
+                except (tomllib.TOMLDecodeError, UnicodeDecodeError, ValueError):
+                    findings.append(
+                        _finding(
+                            "MANIFEST.MALFORMED",
+                            "languages_build_ecosystems",
+                            "A tracked Python manifest cannot be parsed deterministically.",
+                            (file.path,),
+                            "stack.python",
+                            severity="HIGH",
+                            blocking=True,
+                        )
+                    )
         elif file.path == ".python-version":
             items.append(
                 ("languages_build_ecosystems", _item(file, "RUNTIME_VERSION", "stack.python"))
             )
-    return AdapterResult(items=tuple(items))
+    return AdapterResult(items=tuple(items), findings=tuple(findings))
 
 
 @repository_adapter(
@@ -343,6 +411,7 @@ def _node(context: AdapterContext) -> AdapterResult:
 )
 def _containers(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
+    findings: list[Finding] = []
     for file in context.files:
         name = PurePosixPath(file.path).name.lower()
         if "dockerfile" in name:
@@ -369,7 +438,24 @@ def _containers(context: AdapterContext) -> AdapterResult:
             items.append(
                 ("delivery_environments", _item(file, "LOCAL_COMPOSE", "stack.docker-compose"))
             )
-    return AdapterResult(items=tuple(items))
+            if file.content is not None:
+                try:
+                    parsed = yaml.safe_load(file.content)
+                    if not isinstance(parsed, dict):
+                        raise ValueError
+                except (yaml.YAMLError, UnicodeDecodeError, ValueError):
+                    findings.append(
+                        _finding(
+                            "MANIFEST.MALFORMED",
+                            "delivery_environments",
+                            "A tracked Compose manifest cannot be parsed deterministically.",
+                            (file.path,),
+                            "stack.docker-compose",
+                            severity="HIGH",
+                            blocking=True,
+                        )
+                    )
+    return AdapterResult(items=tuple(items), findings=tuple(findings))
 
 
 @repository_adapter(
@@ -394,7 +480,10 @@ def _github_actions(context: AdapterContext) -> AdapterResult:
                 _item(file, workflow_kind, "delivery.github-actions"),
             )
         )
-        items.append(("tests_quality", _item(file, "CI_TEST_MAPPING", "delivery.github-actions")))
+        if file.content and re.search(rb"\b(pytest|vitest|playwright|test)\b", file.content, re.I):
+            items.append(
+                ("tests_quality", _item(file, "CI_TEST_MAPPING", "delivery.github-actions"))
+            )
         if file.content is not None:
             try:
                 parsed = yaml.safe_load(file.content)
@@ -441,6 +530,11 @@ def _github_actions(context: AdapterContext) -> AdapterResult:
     version="1.0.0",
     file_patterns=(
         "**/*openapi*",
+        "**/*asyncapi*",
+        "**/*.proto",
+        "**/*.graphql",
+        "**/*.gql",
+        "**/*.gen.*",
         "**/schemas/**",
         "**/migrations/**",
         "**/generate*",
@@ -454,10 +548,16 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
         lowered = file.path.lower()
         if "openapi" in lowered:
             kind = "OPENAPI"
+        elif "asyncapi" in lowered:
+            kind = "EVENT_CONTRACT"
+        elif lowered.endswith((".proto", ".graphql", ".gql")):
+            kind = "INTERFACE_DEFINITION"
         elif "/migrations/" in f"/{lowered}":
             kind = "MIGRATION"
         elif "generate" in PurePosixPath(lowered).name:
             kind = "CODE_GENERATOR"
+        elif ".gen." in lowered or "generated_client" in lowered:
+            kind = "GENERATED_CLIENT"
         elif "/schemas/" in f"/{lowered}" or lowered.endswith(".schema.json"):
             kind = "SCHEMA"
         else:

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.19.0"
+DETECTOR_VERSION = "1.20.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -1122,7 +1122,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.6.0",
+    version="1.7.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1318,6 +1318,16 @@ def _github_trigger_is_runnable(value: object) -> bool:
     return False
 
 
+def _github_runner_is_runnable(value: object) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return bool(value) and all(isinstance(item, str) and bool(item.strip()) for item in value)
+    if isinstance(value, dict):
+        return any(_ci_action_has_content(value.get(key)) for key in ("group", "labels"))
+    return False
+
+
 def _gitlab_job_is_runnable(job: dict[object, object]) -> bool:
     script = job.get("script")
     if isinstance(script, str) and bool(script.strip()):
@@ -1393,7 +1403,7 @@ def _valid_ci_structure(path: str, value: object) -> bool:
                     isinstance(job.get("uses"), str)
                     and bool(job["uses"].strip())
                     or (
-                        "runs-on" in job
+                        _github_runner_is_runnable(job.get("runs-on"))
                         and isinstance(job.get("steps"), list)
                         and any(
                             isinstance(step, dict)

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.18.0"
+DETECTOR_VERSION = "1.19.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -1122,7 +1122,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.5.0",
+    version="1.6.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1308,6 +1308,16 @@ def _ci_action_has_content(value: object) -> bool:
     return False
 
 
+def _github_trigger_is_runnable(value: object) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(isinstance(item, str) and bool(item.strip()) for item in value)
+    if isinstance(value, dict):
+        return bool(value) and any(isinstance(key, str) and bool(key.strip()) for key in value)
+    return False
+
+
 def _gitlab_job_is_runnable(job: dict[object, object]) -> bool:
     script = job.get("script")
     if isinstance(script, str) and bool(script.strip()):
@@ -1372,7 +1382,7 @@ def _valid_ci_structure(path: str, value: object) -> bool:
         return False
     lowered = path.lower()
     if lowered.startswith(".github/workflows/"):
-        event_declared = "on" in value or True in value
+        event_declared = _github_trigger_is_runnable(value.get("on", value.get(True)))
         jobs = value.get("jobs")
         return (
             event_declared

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -14,7 +14,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.6.0"
+DETECTOR_VERSION = "1.7.0"
 
 
 @dataclass(frozen=True)
@@ -163,7 +163,7 @@ def _test_signal_kind(path: str) -> str | None:
 
 @repository_adapter(
     adapter_id="core.repository-topology",
-    version="1.2.0",
+    version="1.3.0",
     file_patterns=("**/*", "*"),
     supported_categories=(
         "repository_topology",
@@ -366,13 +366,37 @@ def _topology(context: AdapterContext) -> AdapterResult:
             else:
                 kind = "PACKAGE"
             roots.setdefault((kind, root), set()).add(file.path)
+    boundary_roots = {root for _kind, root in roots}
+    for file in context.files:
+        name = PurePosixPath(file.path).name
+        if name not in {"package.json", "pyproject.toml", "Cargo.toml", "go.mod"}:
+            continue
+        parent = PurePosixPath(file.path).parent
+        root = "." if str(parent) == "." else str(parent)
+        matching = next((key for key in roots if key[1] == root), None)
+        if matching is not None:
+            roots[matching].add(file.path)
+        elif root not in boundary_roots:
+            roots[("PACKAGE", root)] = {file.path}
+            boundary_roots.add(root)
     for (kind, root), paths in sorted(roots.items()):
+        evidence_paths = tuple(sorted(paths))
+        confidence = (
+            "HIGH"
+            if evidence_paths
+            and all(
+                PurePosixPath(path).name
+                in {"package.json", "pyproject.toml", "Cargo.toml", "go.mod"}
+                for path in evidence_paths
+            )
+            else "MEDIUM"
+        )
         boundaries.append(
             BoundaryCandidate(
                 kind=kind,
                 name=root,
-                evidence_paths=tuple(sorted(paths)),
-                confidence="MEDIUM",
+                evidence_paths=evidence_paths,
+                confidence=confidence,
                 detector_id="core.repository-topology",
                 detector_version=DETECTOR_VERSION,
             )

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -14,7 +14,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.5.0"
+DETECTOR_VERSION = "1.6.0"
 
 
 @dataclass(frozen=True)
@@ -163,7 +163,7 @@ def _test_signal_kind(path: str) -> str | None:
 
 @repository_adapter(
     adapter_id="core.repository-topology",
-    version="1.1.0",
+    version="1.2.0",
     file_patterns=("**/*", "*"),
     supported_categories=(
         "repository_topology",
@@ -276,7 +276,19 @@ def _topology(context: AdapterContext) -> AdapterResult:
                     _item(file, "PR_TEMPLATE", "core.repository-topology"),
                 )
             )
-        if any(token in lowered for token in ("/alerts", "/slo", "/metrics", "/traces")):
+        if any(
+            token in lowered
+            for token in (
+                "/alerts",
+                "/slo",
+                "/metrics",
+                "/traces",
+                "prometheus",
+                "grafana",
+                "opentelemetry",
+                "otel",
+            )
+        ):
             items.append(
                 (
                     "observability_operations",
@@ -298,6 +310,21 @@ def _topology(context: AdapterContext) -> AdapterResult:
                     _item(
                         file,
                         "SECURITY_CONTROL_SIGNAL",
+                        "core.repository-topology",
+                        confidence="MEDIUM",
+                    ),
+                )
+            )
+        if any(
+            token in lowered
+            for token in ("privacy", "data-retention", "data_retention", "gdpr", "pii")
+        ):
+            items.append(
+                (
+                    "security_privacy",
+                    _item(
+                        file,
+                        "PRIVACY_CONTROL_SIGNAL",
                         "core.repository-topology",
                         confidence="MEDIUM",
                     ),
@@ -932,7 +959,7 @@ def _valid_ci_structure(path: str, value: object) -> bool:
 
 @repository_adapter(
     adapter_id="interface.schema-api",
-    version="1.2.0",
+    version="1.3.0",
     file_patterns=(
         "*openapi*",
         "**/*openapi*",
@@ -944,6 +971,8 @@ def _valid_ci_structure(path: str, value: object) -> bool:
         "**/*.graphql",
         "*.gql",
         "**/*.gql",
+        "*.sql",
+        "**/*.sql",
         "*.gen.*",
         "**/*.gen.*",
         "schemas/**",
@@ -971,6 +1000,9 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
             confidence = "MEDIUM"
         elif "/migrations/" in f"/{lowered}":
             kind = "MIGRATION_SIGNAL"
+            confidence = "MEDIUM"
+        elif lowered.endswith(".sql"):
+            kind = "DATABASE_SCHEMA_SIGNAL"
             confidence = "MEDIUM"
         elif "generate" in PurePosixPath(lowered).name:
             kind = "CODE_GENERATOR_SIGNAL"

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.23.0"
+DETECTOR_VERSION = "1.24.0"
 
 _GITHUB_EVENTS = frozenset(
     {
@@ -141,6 +141,58 @@ _GITHUB_STEP_KEYS = frozenset(
         "timeout-minutes",
     }
 )
+
+
+class _UniqueGithubWorkflowLoader(yaml.SafeLoader):
+    """Parse GitHub workflow YAML without YAML 1.1 booleans or duplicate keys."""
+
+
+_UniqueGithubWorkflowLoader.yaml_implicit_resolvers = {
+    key: [resolver for resolver in resolvers if resolver[0] != "tag:yaml.org,2002:bool"]
+    for key, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+_GITHUB_BOOLEAN_RESOLVER = (
+    "tag:yaml.org,2002:bool",
+    re.compile(r"^(?:true|false|True|False|TRUE|FALSE)$"),
+)
+for _github_boolean_initial in "tTfF":
+    _UniqueGithubWorkflowLoader.yaml_implicit_resolvers.setdefault(
+        _github_boolean_initial, []
+    ).append(_GITHUB_BOOLEAN_RESOLVER)
+
+
+def _construct_unique_github_mapping(
+    loader: yaml.SafeLoader,
+    node: yaml.MappingNode,
+    deep: bool = False,
+) -> dict[object, object]:
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable mapping key",
+                key_node.start_mark,
+            ) from exc
+        if duplicate:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueGithubWorkflowLoader.yaml_constructors = {
+    **yaml.SafeLoader.yaml_constructors,
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG: _construct_unique_github_mapping,
+}
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -1245,7 +1297,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.9.0",
+    version="1.10.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1266,7 +1318,11 @@ def _ci_workflows(context: AdapterContext) -> AdapterResult:
         parsed: object | None = None
         if file.content is not None and file.path.endswith((".yml", ".yaml")):
             try:
-                parsed = yaml.safe_load(file.content)
+                parsed = (
+                    yaml.load(file.content, Loader=_UniqueGithubWorkflowLoader)
+                    if file.path.startswith(".github/workflows/")
+                    else yaml.safe_load(file.content)
+                )
                 if not isinstance(parsed, dict):
                     raise ValueError
             except (yaml.YAMLError, UnicodeDecodeError, ValueError):

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.16.0"
+DETECTOR_VERSION = "1.17.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -1122,7 +1122,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.3.0",
+    version="1.4.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1304,7 +1304,31 @@ def _valid_ci_structure(path: str, value: object) -> bool:
     lowered = path.lower()
     if lowered.startswith(".github/workflows/"):
         event_declared = "on" in value or True in value
-        return event_declared and isinstance(value.get("jobs"), dict) and bool(value["jobs"])
+        jobs = value.get("jobs")
+        return (
+            event_declared
+            and isinstance(jobs, dict)
+            and any(
+                isinstance(job, dict)
+                and (
+                    isinstance(job.get("uses"), str)
+                    and bool(job["uses"].strip())
+                    or (
+                        "runs-on" in job
+                        and isinstance(job.get("steps"), list)
+                        and any(
+                            isinstance(step, dict)
+                            and any(
+                                isinstance(step.get(action), str) and bool(step[action].strip())
+                                for action in ("run", "uses")
+                            )
+                            for step in job["steps"]
+                        )
+                    )
+                )
+                for job in jobs.values()
+            )
+        )
     if lowered == ".gitlab-ci.yml":
         reserved = {
             "default",
@@ -1327,14 +1351,48 @@ def _valid_ci_structure(path: str, value: object) -> bool:
             for key, item in value.items()
         )
     if lowered == ".circleci/config.yml":
-        return "version" in value and any(key in value for key in ("jobs", "workflows"))
+        jobs = value.get("jobs")
+        return (
+            "version" in value
+            and isinstance(jobs, dict)
+            and any(
+                isinstance(job, dict)
+                and isinstance(job.get("steps"), list)
+                and any(
+                    isinstance(step, str)
+                    or isinstance(step, dict)
+                    and any(action in step for action in ("run", "checkout", "setup_remote_docker"))
+                    for step in job["steps"]
+                )
+                for job in jobs.values()
+            )
+        )
     if lowered == "azure-pipelines.yml":
         return any(
             isinstance(value.get(key), list) and bool(value[key])
             for key in ("jobs", "stages", "steps")
         )
     if lowered == "bitbucket-pipelines.yml":
-        return isinstance(value.get("pipelines"), dict) and bool(value["pipelines"])
+        pipelines = value.get("pipelines")
+        pending = [pipelines]
+        visited = 0
+        while pending:
+            current = pending.pop()
+            visited += 1
+            if visited > 50_000:
+                return False
+            if isinstance(current, dict):
+                step = current.get("step")
+                if (
+                    isinstance(step, dict)
+                    and isinstance(step.get("script"), list)
+                    and bool(step["script"])
+                ):
+                    return True
+                pending.extend(current.values())
+            elif isinstance(current, list):
+                pending.extend(current)
+        return False
     return False
 
 

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.15.0"
+DETECTOR_VERSION = "1.16.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -1122,7 +1122,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.2.0",
+    version="1.3.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1306,11 +1306,33 @@ def _valid_ci_structure(path: str, value: object) -> bool:
         event_declared = "on" in value or True in value
         return event_declared and isinstance(value.get("jobs"), dict) and bool(value["jobs"])
     if lowered == ".gitlab-ci.yml":
-        return any(isinstance(item, dict) for item in value.values())
+        reserved = {
+            "default",
+            "include",
+            "stages",
+            "variables",
+            "workflow",
+            "image",
+            "services",
+            "before_script",
+            "after_script",
+            "cache",
+            "pages",
+        }
+        return any(
+            key not in reserved
+            and not key.startswith(".")
+            and isinstance(item, dict)
+            and any(action in item for action in ("script", "trigger"))
+            for key, item in value.items()
+        )
     if lowered == ".circleci/config.yml":
         return "version" in value and any(key in value for key in ("jobs", "workflows"))
     if lowered == "azure-pipelines.yml":
-        return any(key in value for key in ("jobs", "stages", "steps"))
+        return any(
+            isinstance(value.get(key), list) and bool(value[key])
+            for key in ("jobs", "stages", "steps")
+        )
     if lowered == "bitbucket-pipelines.yml":
         return isinstance(value.get("pipelines"), dict) and bool(value["pipelines"])
     return False

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -14,7 +14,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.8.0"
+DETECTOR_VERSION = "1.9.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -180,9 +180,39 @@ def _test_signal_kind(path: str) -> str | None:
     return "TEST_FILE_SIGNAL"
 
 
+def _test_configuration_kind(path: str) -> str | None:
+    """Classify explicit test and coverage configuration without executing it."""
+
+    name = PurePosixPath(path).name.lower()
+    if name in {"pytest.ini", "tox.ini", "noxfile.py", "conftest.py"} or any(
+        fnmatch.fnmatch(name, pattern)
+        for pattern in (
+            "jest.config.*",
+            "karma.conf.*",
+            "playwright.config.*",
+            "vitest.config.*",
+        )
+    ):
+        return "TEST_CONFIGURATION"
+    if name in {".coveragerc", ".nycrc", "coverage.ini", "coverage.toml"} or any(
+        fnmatch.fnmatch(name, pattern) for pattern in (".codecov.*", "codecov.*", "nyc.config.*")
+    ):
+        return "COVERAGE_CONFIGURATION"
+    return None
+
+
+def _entry_point_signal_kind(path: str) -> str | None:
+    """Return a bounded conventional entry-point signal, never a recommendation."""
+
+    name = PurePosixPath(path).name.lower()
+    if name in {"__main__.py", "app.py", "cli.py", "main.py", "manage.py", "server.py"}:
+        return "ENTRY_POINT_FILE_SIGNAL"
+    return None
+
+
 @repository_adapter(
     adapter_id="core.repository-topology",
-    version="1.4.0",
+    version="1.5.0",
     file_patterns=("**/*", "*"),
     supported_categories=(
         "repository_topology",
@@ -192,6 +222,7 @@ def _test_signal_kind(path: str) -> str | None:
         "debt_risk",
         "observability_operations",
         "security_privacy",
+        "tests_quality",
     ),
 )
 def _topology(context: AdapterContext) -> AdapterResult:
@@ -220,6 +251,28 @@ def _topology(context: AdapterContext) -> AdapterResult:
         else:
             kind = "TRACKED_FILE"
         items.append(("repository_topology", _item(file, kind, "core.repository-topology")))
+
+        test_configuration_kind = _test_configuration_kind(file.path)
+        if test_configuration_kind is not None:
+            items.append(
+                (
+                    "tests_quality",
+                    _item(file, test_configuration_kind, "core.repository-topology"),
+                )
+            )
+        entry_point_kind = _entry_point_signal_kind(file.path)
+        if entry_point_kind is not None:
+            items.append(
+                (
+                    "architecture_boundaries",
+                    _item(
+                        file,
+                        entry_point_kind,
+                        "core.repository-topology",
+                        confidence="MEDIUM",
+                    ),
+                )
+            )
 
         if file.path in {"README.md", "CONTRIBUTING.md", "SECURITY.md"}:
             items.append(
@@ -433,7 +486,7 @@ def _topology(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="stack.python",
-    version="1.2.0",
+    version="1.3.0",
     file_patterns=(
         "*.py",
         "**/*.py",
@@ -458,7 +511,12 @@ def _topology(context: AdapterContext) -> AdapterResult:
         ".python-version",
         "**/.python-version",
     ),
-    supported_categories=("languages_build_ecosystems", "tests_quality", "debt_risk"),
+    supported_categories=(
+        "languages_build_ecosystems",
+        "architecture_boundaries",
+        "tests_quality",
+        "debt_risk",
+    ),
 )
 def _python(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
@@ -485,6 +543,17 @@ def _python(context: AdapterContext) -> AdapterResult:
                     parsed = tomllib.loads(file.content.decode("utf-8"))
                     if not isinstance(parsed, dict):
                         raise ValueError
+                    project = parsed.get("project", {})
+                    if isinstance(project, dict) and any(
+                        isinstance(project.get(key), dict) and project[key]
+                        for key in ("scripts", "gui-scripts")
+                    ):
+                        items.append(
+                            (
+                                "architecture_boundaries",
+                                _item(file, "DECLARED_ENTRY_POINT", "stack.python"),
+                            )
+                        )
                 except (tomllib.TOMLDecodeError, UnicodeDecodeError, ValueError):
                     findings.append(
                         _finding(
@@ -527,7 +596,7 @@ def _python(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="stack.node-web",
-    version="1.1.0",
+    version="1.2.0",
     file_patterns=(
         "**/*.js",
         "*.js",
@@ -546,7 +615,12 @@ def _python(context: AdapterContext) -> AdapterResult:
         "pnpm-lock.yaml",
         "**/pnpm-lock.yaml",
     ),
-    supported_categories=("languages_build_ecosystems", "tests_quality", "debt_risk"),
+    supported_categories=(
+        "languages_build_ecosystems",
+        "architecture_boundaries",
+        "tests_quality",
+        "debt_risk",
+    ),
 )
 def _node(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
@@ -562,9 +636,29 @@ def _node(context: AdapterContext) -> AdapterResult:
             if file.content is not None:
                 try:
                     package = json.loads(file.content)
+                    if not isinstance(package, dict):
+                        raise AttributeError
                     engine = package.get("engines", {}).get("node")
                     if isinstance(engine, str):
                         runtime_declarations[file.path] = engine
+                    if any(
+                        package.get(key) not in (None, "", {}, [])
+                        for key in ("bin", "main", "module", "exports")
+                    ):
+                        items.append(
+                            (
+                                "architecture_boundaries",
+                                _item(file, "DECLARED_ENTRY_POINT", "stack.node-web"),
+                            )
+                        )
+                    scripts = package.get("scripts", {})
+                    if isinstance(scripts, dict) and isinstance(scripts.get("start"), str):
+                        items.append(
+                            (
+                                "architecture_boundaries",
+                                _item(file, "DECLARED_RUN_ENTRY_POINT", "stack.node-web"),
+                            )
+                        )
                 except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
                     findings.append(
                         _finding(

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -15,7 +15,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.10.0"
+DETECTOR_VERSION = "1.11.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -487,7 +487,7 @@ def _topology(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="stack.python",
-    version="1.4.0",
+    version="1.5.0",
     file_patterns=(
         "*.py",
         "**/*.py",
@@ -547,12 +547,28 @@ def _python(context: AdapterContext) -> AdapterResult:
                     project = parsed.get("project", {})
                     if isinstance(project, dict) and any(
                         isinstance(project.get(key), dict) and project[key]
-                        for key in ("scripts", "gui-scripts")
+                        for key in ("scripts", "gui-scripts", "entry-points")
                     ):
                         items.append(
                             (
                                 "architecture_boundaries",
                                 _item(file, "DECLARED_ENTRY_POINT", "stack.python"),
+                            )
+                        )
+                    dynamic = project.get("dynamic", []) if isinstance(project, dict) else []
+                    if isinstance(dynamic, list) and any(
+                        item in {"scripts", "gui-scripts", "entry-points"} for item in dynamic
+                    ):
+                        findings.append(
+                            _finding(
+                                "ARCHITECTURE.DYNAMIC_ENTRY_POINTS_UNSUPPORTED",
+                                "architecture_boundaries",
+                                "Dynamic Python entry-point declarations are not executed or "
+                                "inferred by the read-only scanner.",
+                                (file.path,),
+                                "stack.python",
+                                severity="HIGH",
+                                blocking=True,
                             )
                         )
                     tool = parsed.get("tool", {})
@@ -590,6 +606,13 @@ def _python(context: AdapterContext) -> AdapterResult:
                     configuration = configparser.ConfigParser(interpolation=None)
                     configuration.read_string(file.content.decode("utf-8"))
                     sections = {section.lower() for section in configuration.sections()}
+                    if "options.entry_points" in sections:
+                        items.append(
+                            (
+                                "architecture_boundaries",
+                                _item(file, "DECLARED_ENTRY_POINT", "stack.python"),
+                            )
+                        )
                     if sections & {"pytest", "tool:pytest"}:
                         items.append(
                             (
@@ -616,6 +639,19 @@ def _python(context: AdapterContext) -> AdapterResult:
                             blocking=True,
                         )
                     )
+            if name == "setup.py":
+                findings.append(
+                    _finding(
+                        "ARCHITECTURE.DYNAMIC_ENTRY_POINTS_UNSUPPORTED",
+                        "architecture_boundaries",
+                        "Executable setup.py entry-point declarations are not executed or "
+                        "inferred by the read-only scanner.",
+                        (file.path,),
+                        "stack.python",
+                        severity="HIGH",
+                        blocking=True,
+                    )
+                )
         elif file.path.endswith(".py"):
             test_kind = _test_signal_kind(file.path)
             if test_kind is None:

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -53,6 +53,7 @@ class TrackedFile:
 @dataclass(frozen=True)
 class AdapterContext:
     files: tuple[TrackedFile, ...]
+    repository_files: tuple[TrackedFile, ...] = ()
 
     def matching(self, patterns: tuple[str, ...]) -> tuple[TrackedFile, ...]:
         return tuple(
@@ -261,6 +262,21 @@ def _openapi_typescript_relationship(command: str) -> tuple[str, str] | None:
     if len(positional) != 1 or output is None:
         return None
     return positional[0], output
+
+
+def _api_declaration_kind(path: str) -> str | None:
+    """Return a declaration kind only for supported API document filenames."""
+
+    name = PurePosixPath(path).name.lower()
+    suffix = PurePosixPath(name).suffix
+    if suffix not in {".json", ".yaml", ".yml"}:
+        return None
+    stem = name[: -len(suffix)]
+    if stem == "openapi" or stem.endswith(".openapi"):
+        return "OPENAPI"
+    if stem == "asyncapi" or stem.endswith(".asyncapi"):
+        return "EVENT_CONTRACT"
+    return None
 
 
 @repository_adapter(
@@ -1315,7 +1331,7 @@ def _valid_ci_structure(path: str, value: object) -> bool:
 def _interfaces(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
     findings: list[Finding] = []
-    files_by_path = {file.path: file for file in context.files}
+    files_by_path = {file.path: file for file in (context.repository_files or context.files)}
     for file in context.files:
         lowered = file.path.lower()
         confidence = "HIGH"
@@ -1393,7 +1409,7 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
                         )
                     )
             continue
-        if lowered.endswith("/scripts/export_openapi.py"):
+        if lowered == "scripts/export_openapi.py" or lowered.endswith("/scripts/export_openapi.py"):
             target_path = str(PurePosixPath(file.path).parent.parent / "openapi.json")
             target = files_by_path.get(target_path)
             content = (
@@ -1440,10 +1456,9 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
                 )
             )
             continue
-        if "openapi" in lowered:
-            kind = "OPENAPI"
-        elif "asyncapi" in lowered:
-            kind = "EVENT_CONTRACT"
+        declaration_kind = _api_declaration_kind(lowered)
+        if declaration_kind is not None:
+            kind = declaration_kind
         elif lowered.endswith((".proto", ".graphql", ".gql")):
             kind = "INTERFACE_DEFINITION_SIGNAL"
             confidence = "MEDIUM"

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.24.0"
+DETECTOR_VERSION = "1.25.0"
 
 _GITHUB_EVENTS = frozenset(
     {
@@ -58,7 +58,8 @@ _GITHUB_EVENTS = frozenset(
         "workflow_run",
     }
 )
-_GITHUB_LOCAL_REUSABLE_WORKFLOW = re.compile(r"^\./\.github/workflows/[A-Za-z0-9_./-]+\.ya?ml$")
+_GITHUB_DIRECT_WORKFLOW_PATH = re.compile(r"^\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml$")
+_GITHUB_LOCAL_REUSABLE_WORKFLOW = re.compile(r"^\./\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml$")
 _GITHUB_REMOTE_REUSABLE_WORKFLOW = re.compile(
     r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/\.github/workflows/"
     r"[A-Za-z0-9_./-]+\.ya?ml@\S+$"
@@ -111,7 +112,7 @@ _GITHUB_PERMISSION_SCOPES = frozenset(
     }
 )
 _GITHUB_TOP_LEVEL_KEYS = frozenset(
-    {True, "on", "name", "run-name", "permissions", "env", "defaults", "concurrency", "jobs"}
+    {"on", "name", "run-name", "permissions", "env", "defaults", "concurrency", "jobs"}
 )
 _GITHUB_INLINE_JOB_KEYS = frozenset(
     {
@@ -1297,7 +1298,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.10.0",
+    version="1.11.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1706,8 +1707,8 @@ def _github_reusable_workflow_is_runnable(value: object) -> bool:
         return False
     reference = value.strip()
     if _GITHUB_LOCAL_REUSABLE_WORKFLOW.fullmatch(reference) is not None:
-        path = reference.removeprefix("./")
-    elif _GITHUB_REMOTE_REUSABLE_WORKFLOW.fullmatch(reference) is not None:
+        return False
+    if _GITHUB_REMOTE_REUSABLE_WORKFLOW.fullmatch(reference) is not None:
         path = reference.split("@", 1)[0].split("/", 2)[2]
     else:
         return False
@@ -1793,7 +1794,7 @@ def _github_step_is_runnable(value: object) -> bool:
         return False
     reference = uses.strip()
     if _GITHUB_LOCAL_ACTION.fullmatch(reference) is not None:
-        return ".." not in PurePosixPath(reference.removeprefix("./")).parts
+        return False
     if _GITHUB_REMOTE_ACTION.fullmatch(reference) is not None:
         action_path = reference.rsplit("@", 1)[0].split("/", 2)
         return len(action_path) < 3 or ".." not in PurePosixPath(action_path[2]).parts
@@ -1801,7 +1802,7 @@ def _github_step_is_runnable(value: object) -> bool:
 
 
 def _github_workflow_is_runnable(value: dict[object, object]) -> bool:
-    if not set(value) <= _GITHUB_TOP_LEVEL_KEYS or ("on" in value and True in value):
+    if not set(value) <= _GITHUB_TOP_LEVEL_KEYS:
         return False
     for key in ("name", "run-name"):
         item = value.get(key)
@@ -1815,7 +1816,7 @@ def _github_workflow_is_runnable(value: dict[object, object]) -> bool:
         return False
     if "concurrency" in value and not _github_concurrency_is_supported(value["concurrency"]):
         return False
-    event = value.get("on", value.get(True))
+    event = value.get("on")
     jobs = value.get("jobs")
     if not (
         _github_trigger_is_runnable(event)
@@ -1853,7 +1854,7 @@ def _valid_ci_structure(path: str, value: object) -> bool:
     if not isinstance(value, dict) or not value:
         return False
     lowered = path.lower()
-    if lowered.startswith(".github/workflows/"):
+    if _GITHUB_DIRECT_WORKFLOW_PATH.fullmatch(lowered) is not None:
         return _github_workflow_is_runnable(value)
     return False
 

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.13.0"
+DETECTOR_VERSION = "1.14.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -281,7 +281,7 @@ def _api_declaration_kind(path: str) -> str | None:
 
 @repository_adapter(
     adapter_id="core.repository-topology",
-    version="1.5.0",
+    version="1.6.0",
     file_patterns=("**/*", "*"),
     supported_categories=(
         "repository_topology",
@@ -507,10 +507,19 @@ def _topology(context: AdapterContext) -> AdapterResult:
             "apps",
             "libraries",
             "workers",
+            "infra",
+            "infrastructure",
+            "ops",
         }:
             root = "/".join(parts[:2])
             if parts[0] == "services":
                 kind = "SERVICE"
+            elif parts[0] == "workers":
+                kind = "WORKER"
+            elif parts[0] == "libraries":
+                kind = "LIBRARY"
+            elif parts[0] in {"infra", "infrastructure", "ops"}:
+                kind = "INFRASTRUCTURE_AREA"
             elif (
                 parts[0] == "apps"
                 or parts[0] == "packages"
@@ -1299,7 +1308,7 @@ def _valid_ci_structure(path: str, value: object) -> bool:
 
 @repository_adapter(
     adapter_id="interface.schema-api",
-    version="1.4.0",
+    version="1.5.0",
     file_patterns=(
         "package.json",
         "**/package.json",
@@ -1450,6 +1459,7 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
                             target,
                             "CODE_GENERATION_OUTPUT",
                             "interface.schema-api",
+                            confidence="MEDIUM",
                             location=location,
                         ),
                     ),
@@ -1481,6 +1491,18 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
             continue
         if kind in {"OPENAPI", "EVENT_CONTRACT"}:
             if file.content is None or file.binary:
+                findings.append(
+                    _finding(
+                        "INTERFACE.DECLARATION_INVALID",
+                        "apis_data",
+                        "A recognized tracked API declaration is unavailable as bounded UTF-8 "
+                        "text; no API evidence was inferred from it.",
+                        (file.path,),
+                        "interface.schema-api",
+                        severity="HIGH",
+                        blocking=True,
+                    )
+                )
                 continue
             try:
                 text = file.content.decode("utf-8")

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -124,6 +124,37 @@ def _finding(
     )
 
 
+def _test_signal_kind(path: str) -> str | None:
+    """Classify conventional test paths/names as medium-confidence signals only."""
+
+    pure = PurePosixPath(path)
+    lowered_parts = tuple(part.lower() for part in pure.parts)
+    name = pure.name.lower()
+    in_test_area = any(part in {"test", "tests", "__tests__"} for part in lowered_parts[:-1])
+    named_test = (
+        name.startswith("test_")
+        or name.endswith("_test.py")
+        or any(marker in name for marker in (".test.", ".spec."))
+    )
+    if not (in_test_area or named_test):
+        return None
+    if "unit" in lowered_parts:
+        return "UNIT_TEST_FILE_SIGNAL"
+    if "integration" in lowered_parts:
+        return "INTEGRATION_TEST_FILE_SIGNAL"
+    if "e2e" in lowered_parts or "end_to_end" in lowered_parts:
+        return "E2E_TEST_FILE_SIGNAL"
+    if "contract" in lowered_parts or "contract" in name:
+        return "CONTRACT_TEST_FILE_SIGNAL"
+    if "security" in lowered_parts or "security" in name:
+        return "SECURITY_TEST_FILE_SIGNAL"
+    if any(token in lowered_parts for token in ("performance", "perf", "benchmarks")):
+        return "PERFORMANCE_TEST_FILE_SIGNAL"
+    if "mutation" in lowered_parts or "mutation" in name:
+        return "MUTATION_TEST_FILE_SIGNAL"
+    return "TEST_FILE_SIGNAL"
+
+
 @repository_adapter(
     adapter_id="core.repository-topology",
     version="1.0.0",
@@ -281,13 +312,26 @@ def _python(context: AdapterContext) -> AdapterResult:
     findings: list[Finding] = []
     for file in context.files:
         if file.path.endswith(".py"):
-            category = (
-                "tests_quality"
-                if "/test" in f"/{file.path}" or file.path.startswith("tests/")
-                else "languages_build_ecosystems"
-            )
-            kind = "PYTHON_TEST" if category == "tests_quality" else "PYTHON_SOURCE"
-            items.append((category, _item(file, kind, "stack.python")))
+            test_kind = _test_signal_kind(file.path)
+            if test_kind is None:
+                items.append(
+                    (
+                        "languages_build_ecosystems",
+                        _item(file, "PYTHON_SOURCE", "stack.python"),
+                    )
+                )
+            else:
+                items.append(
+                    (
+                        "tests_quality",
+                        _item(
+                            file,
+                            test_kind,
+                            "stack.python",
+                            confidence="MEDIUM",
+                        ),
+                    )
+                )
         elif PurePosixPath(file.path).name == "pyproject.toml" or file.path.endswith(
             "requirements.txt"
         ):
@@ -336,8 +380,8 @@ def _python(context: AdapterContext) -> AdapterResult:
 def _node(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
     findings: list[Finding] = []
-    lock_types: set[str] = set()
-    runtime_versions: set[str] = set()
+    lock_paths: dict[str, list[str]] = {}
+    runtime_declarations: dict[str, str] = {}
     for file in context.files:
         name = PurePosixPath(file.path).name
         if name == "package.json":
@@ -349,7 +393,7 @@ def _node(context: AdapterContext) -> AdapterResult:
                     package = json.loads(file.content)
                     engine = package.get("engines", {}).get("node")
                     if isinstance(engine, str):
-                        runtime_versions.add(engine)
+                        runtime_declarations[file.path] = engine
                 except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
                     findings.append(
                         _finding(
@@ -363,35 +407,48 @@ def _node(context: AdapterContext) -> AdapterResult:
                         )
                     )
         elif name in {"package-lock.json", "yarn.lock", "pnpm-lock.yaml"}:
-            lock_types.add(name)
+            lock_paths.setdefault(name, []).append(file.path)
             items.append(("languages_build_ecosystems", _item(file, "LOCKFILE", "stack.node-web")))
         elif file.path.endswith((".js", ".jsx", ".ts", ".tsx")):
-            category = (
-                "tests_quality"
-                if "test" in name or "spec" in name
-                else "languages_build_ecosystems"
-            )
-            kind = "NODE_TEST" if category == "tests_quality" else "NODE_SOURCE"
-            items.append((category, _item(file, kind, "stack.node-web")))
-    if len(lock_types) > 1:
+            test_kind = _test_signal_kind(file.path)
+            if test_kind is None:
+                items.append(
+                    (
+                        "languages_build_ecosystems",
+                        _item(file, "NODE_SOURCE", "stack.node-web"),
+                    )
+                )
+            else:
+                items.append(
+                    (
+                        "tests_quality",
+                        _item(
+                            file,
+                            test_kind,
+                            "stack.node-web",
+                            confidence="MEDIUM",
+                        ),
+                    )
+                )
+    if len(lock_paths) > 1:
         findings.append(
             _finding(
                 "DEPENDENCY.MULTIPLE_LOCK_ECOSYSTEMS",
                 "debt_risk",
                 "Multiple Node lockfile ecosystems are tracked; this is a drift signal, "
                 "not proof of a defect.",
-                tuple(sorted(lock_types)),
+                tuple(sorted(path for paths in lock_paths.values() for path in paths)),
                 "stack.node-web",
                 confidence="MEDIUM",
             )
         )
-    if len(runtime_versions) > 1:
+    if len(set(runtime_declarations.values())) > 1:
         findings.append(
             _finding(
                 "RUNTIME.VERSION_DRIFT_SIGNAL",
                 "debt_risk",
                 "Multiple declared Node runtime constraints were observed.",
-                tuple(sorted(runtime_versions)),
+                tuple(sorted(runtime_declarations)),
                 "stack.node-web",
                 confidence="MEDIUM",
             )

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.17.0"
+DETECTOR_VERSION = "1.18.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -1122,7 +1122,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.4.0",
+    version="1.5.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1298,6 +1298,75 @@ def _structured_text(value: object) -> str:
     return "\n".join(strings)
 
 
+def _ci_action_has_content(value: object) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(_ci_action_has_content(item) for item in value)
+    if isinstance(value, dict):
+        return bool(value) and any(_ci_action_has_content(item) for item in value.values())
+    return False
+
+
+def _gitlab_job_is_runnable(job: dict[object, object]) -> bool:
+    script = job.get("script")
+    if isinstance(script, str) and bool(script.strip()):
+        return True
+    if isinstance(script, list) and any(
+        isinstance(item, str) and bool(item.strip()) for item in script
+    ):
+        return True
+    trigger = job.get("trigger")
+    if isinstance(trigger, str):
+        return bool(trigger.strip())
+    return isinstance(trigger, dict) and any(
+        _ci_action_has_content(trigger.get(key)) for key in ("project", "include")
+    )
+
+
+def _circle_step_is_runnable(step: object) -> bool:
+    if isinstance(step, str):
+        return bool(step.strip())
+    if not isinstance(step, dict):
+        return False
+    run = step.get("run")
+    if isinstance(run, str) and bool(run.strip()):
+        return True
+    if isinstance(run, dict) and _ci_action_has_content(run.get("command")):
+        return True
+    return any(
+        key in step and (step[key] is None or _ci_action_has_content(step[key]))
+        for key in ("checkout", "setup_remote_docker")
+    )
+
+
+def _azure_tree_contains_action(value: object) -> bool:
+    pending = [value]
+    visited = 0
+    while pending:
+        current = pending.pop()
+        visited += 1
+        if visited > 50_000:
+            return False
+        if isinstance(current, dict):
+            if any(
+                _ci_action_has_content(current.get(key))
+                for key in ("script", "bash", "pwsh", "powershell", "task", "template")
+            ):
+                return True
+            checkout = current.get("checkout")
+            if (
+                isinstance(checkout, str)
+                and checkout.strip()
+                and checkout.strip().lower() != "none"
+            ):
+                return True
+            pending.extend(current[key] for key in ("jobs", "stages", "steps") if key in current)
+        elif isinstance(current, list):
+            pending.extend(current)
+    return False
+
+
 def _valid_ci_structure(path: str, value: object) -> bool:
     if not isinstance(value, dict) or not value:
         return False
@@ -1347,7 +1416,7 @@ def _valid_ci_structure(path: str, value: object) -> bool:
             key not in reserved
             and not key.startswith(".")
             and isinstance(item, dict)
-            and any(action in item for action in ("script", "trigger"))
+            and _gitlab_job_is_runnable(item)
             for key, item in value.items()
         )
     if lowered == ".circleci/config.yml":
@@ -1358,20 +1427,12 @@ def _valid_ci_structure(path: str, value: object) -> bool:
             and any(
                 isinstance(job, dict)
                 and isinstance(job.get("steps"), list)
-                and any(
-                    isinstance(step, str)
-                    or isinstance(step, dict)
-                    and any(action in step for action in ("run", "checkout", "setup_remote_docker"))
-                    for step in job["steps"]
-                )
+                and any(_circle_step_is_runnable(step) for step in job["steps"])
                 for job in jobs.values()
             )
         )
     if lowered == "azure-pipelines.yml":
-        return any(
-            isinstance(value.get(key), list) and bool(value[key])
-            for key in ("jobs", "stages", "steps")
-        )
+        return _azure_tree_contains_action(value)
     if lowered == "bitbucket-pipelines.yml":
         pipelines = value.get("pipelines")
         pending = [pipelines]
@@ -1386,7 +1447,12 @@ def _valid_ci_structure(path: str, value: object) -> bool:
                 if (
                     isinstance(step, dict)
                     and isinstance(step.get("script"), list)
-                    and bool(step["script"])
+                    and any(
+                        _ci_action_has_content(item)
+                        if not isinstance(item, dict)
+                        else _ci_action_has_content(item.get("pipe"))
+                        for item in step["script"]
+                    )
                 ):
                     return True
                 pending.extend(current.values())

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -14,7 +14,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.4.0"
+DETECTOR_VERSION = "1.5.0"
 
 
 @dataclass(frozen=True)
@@ -355,14 +355,30 @@ def _topology(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="stack.python",
-    version="1.1.0",
+    version="1.2.0",
     file_patterns=(
         "*.py",
         "**/*.py",
         "pyproject.toml",
+        "**/pyproject.toml",
         "requirements*.txt",
         "**/requirements*.txt",
+        "requirements*.lock",
+        "**/requirements*.lock",
+        "Pipfile",
+        "**/Pipfile",
+        "Pipfile.lock",
+        "**/Pipfile.lock",
+        "poetry.lock",
+        "**/poetry.lock",
+        "setup.cfg",
+        "**/setup.cfg",
+        "setup.py",
+        "**/setup.py",
+        "uv.lock",
+        "**/uv.lock",
         ".python-version",
+        "**/.python-version",
     ),
     supported_categories=("languages_build_ecosystems", "tests_quality", "debt_risk"),
 )
@@ -370,7 +386,40 @@ def _python(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
     findings: list[Finding] = []
     for file in context.files:
-        if file.path.endswith(".py"):
+        name = PurePosixPath(file.path).name
+        is_requirement_manifest = name.startswith("requirements") and name.endswith(
+            (".txt", ".lock")
+        )
+        if name in {"Pipfile.lock", "poetry.lock", "uv.lock"} or (
+            is_requirement_manifest and name.endswith(".lock")
+        ):
+            items.append(
+                ("languages_build_ecosystems", _item(file, "PYTHON_LOCKFILE", "stack.python"))
+            )
+        elif name in {"Pipfile", "pyproject.toml", "setup.cfg", "setup.py"} or (
+            is_requirement_manifest and name.endswith(".txt")
+        ):
+            items.append(
+                ("languages_build_ecosystems", _item(file, "PYTHON_MANIFEST", "stack.python"))
+            )
+            if name in {"Pipfile", "pyproject.toml"} and file.content is not None:
+                try:
+                    parsed = tomllib.loads(file.content.decode("utf-8"))
+                    if not isinstance(parsed, dict):
+                        raise ValueError
+                except (tomllib.TOMLDecodeError, UnicodeDecodeError, ValueError):
+                    findings.append(
+                        _finding(
+                            "MANIFEST.MALFORMED",
+                            "languages_build_ecosystems",
+                            "A tracked Python manifest cannot be parsed deterministically.",
+                            (file.path,),
+                            "stack.python",
+                            severity="HIGH",
+                            blocking=True,
+                        )
+                    )
+        elif file.path.endswith(".py"):
             test_kind = _test_signal_kind(file.path)
             if test_kind is None:
                 items.append(
@@ -391,30 +440,7 @@ def _python(context: AdapterContext) -> AdapterResult:
                         ),
                     )
                 )
-        elif PurePosixPath(file.path).name == "pyproject.toml" or file.path.endswith(
-            "requirements.txt"
-        ):
-            items.append(
-                ("languages_build_ecosystems", _item(file, "PYTHON_MANIFEST", "stack.python"))
-            )
-            if PurePosixPath(file.path).name == "pyproject.toml" and file.content is not None:
-                try:
-                    parsed = tomllib.loads(file.content.decode("utf-8"))
-                    if not isinstance(parsed, dict):
-                        raise ValueError
-                except (tomllib.TOMLDecodeError, UnicodeDecodeError, ValueError):
-                    findings.append(
-                        _finding(
-                            "MANIFEST.MALFORMED",
-                            "languages_build_ecosystems",
-                            "A tracked Python manifest cannot be parsed deterministically.",
-                            (file.path,),
-                            "stack.python",
-                            severity="HIGH",
-                            blocking=True,
-                        )
-                    )
-        elif file.path == ".python-version":
+        elif name == ".python-version":
             items.append(
                 ("languages_build_ecosystems", _item(file, "RUNTIME_VERSION", "stack.python"))
             )

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -14,7 +14,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.2.0"
+DETECTOR_VERSION = "1.3.0"
 
 
 @dataclass(frozen=True)
@@ -651,14 +651,32 @@ def _containers(context: AdapterContext) -> AdapterResult:
                     _item(file, "CONTAINER_DEFINITION", "stack.docker-compose"),
                 )
             )
-            if file.content and any(
-                line.lstrip().upper().startswith(b"HEALTHCHECK ")
-                for line in file.content.splitlines()
-            ):
+            health_instructions = (
+                tuple(
+                    line.lstrip().upper()
+                    for line in file.content.splitlines()
+                    if line.lstrip().upper().startswith(b"HEALTHCHECK ")
+                )
+                if file.content
+                else ()
+            )
+            if any(line != b"HEALTHCHECK NONE" for line in health_instructions):
                 items.append(
                     (
                         "observability_operations",
                         _item(file, "HEALTH_CHECK", "stack.docker-compose"),
+                    )
+                )
+            elif health_instructions:
+                items.append(
+                    (
+                        "observability_operations",
+                        _item(
+                            file,
+                            "HEALTH_CHECK_DISABLED_SIGNAL",
+                            "stack.docker-compose",
+                            confidence="MEDIUM",
+                        ),
                     )
                 )
         elif "compose" in name:
@@ -703,25 +721,8 @@ def _ci_workflows(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
     findings: list[Finding] = []
     workflows = list(context.files)
+    verified_workflows = 0
     for file in workflows:
-        items.append(
-            (
-                "delivery_environments",
-                _item(file, "CI_WORKFLOW", "delivery.ci"),
-            )
-        )
-        if any(token in file.path.lower() for token in ("release", "deploy", "publish")):
-            items.append(
-                (
-                    "delivery_environments",
-                    _item(
-                        file,
-                        "RELEASE_WORKFLOW_SIGNAL",
-                        "delivery.ci",
-                        confidence="MEDIUM",
-                    ),
-                )
-            )
         parsed: object | None = None
         if file.content is not None and file.path.endswith((".yml", ".yaml")):
             try:
@@ -741,7 +742,64 @@ def _ci_workflows(context: AdapterContext) -> AdapterResult:
                     )
                 )
                 continue
-        signals = _structured_text(parsed) if parsed is not None else ""
+        if parsed is None or not _valid_ci_structure(file.path, parsed):
+            items.append(
+                (
+                    "delivery_environments",
+                    _item(
+                        file,
+                        "CI_CONFIGURATION_SIGNAL",
+                        "delivery.ci",
+                        confidence="MEDIUM",
+                    ),
+                )
+            )
+            findings.append(
+                _finding(
+                    "WORKFLOW.STRUCTURE_UNPROVEN",
+                    "delivery_environments",
+                    "A tracked CI configuration could not be proven to contain the required "
+                    "provider structure; it remains a signal, not a verified workflow.",
+                    (file.path,),
+                    "delivery.ci",
+                    confidence="MEDIUM",
+                )
+            )
+            continue
+        verified_workflows += 1
+        items.append(
+            (
+                "delivery_environments",
+                _item(file, "CI_WORKFLOW", "delivery.ci"),
+            )
+        )
+        if any(token in file.path.lower() for token in ("release", "deploy", "publish")):
+            items.append(
+                (
+                    "delivery_environments",
+                    _item(
+                        file,
+                        "RELEASE_WORKFLOW_SIGNAL",
+                        "delivery.ci",
+                        confidence="MEDIUM",
+                    ),
+                )
+            )
+        try:
+            signals = _structured_text(parsed)
+        except ValueError:
+            findings.append(
+                _finding(
+                    "WORKFLOW.STRUCTURE_BUDGET_EXCEEDED",
+                    "delivery_environments",
+                    "Parsed workflow structure exceeded the deterministic adapter budget.",
+                    (file.path,),
+                    "delivery.ci",
+                    severity="HIGH",
+                    blocking=True,
+                )
+            )
+            continue
         if re.search(r"\b(pytest|vitest|playwright|test)\b", signals, re.I):
             items.append(
                 (
@@ -781,7 +839,7 @@ def _ci_workflows(context: AdapterContext) -> AdapterResult:
                     ),
                 )
             )
-    if not workflows:
+    if not verified_workflows:
         findings.append(
             _finding(
                 "DELIVERY.CI_ABSENT",
@@ -799,17 +857,46 @@ def _structured_text(value: object) -> str:
 
     pending = [value]
     strings: list[str] = []
+    seen: set[int] = set()
+    visited = 0
     while pending:
         current = pending.pop()
+        visited += 1
+        if visited > 50_000:
+            raise ValueError("workflow structure budget exceeded")
         if isinstance(current, dict):
+            if id(current) in seen:
+                continue
+            seen.add(id(current))
             for key, item in current.items():
                 strings.append(str(key))
                 pending.append(item)
         elif isinstance(current, list):
+            if id(current) in seen:
+                continue
+            seen.add(id(current))
             pending.extend(current)
         elif isinstance(current, (str, int, float, bool)):
             strings.append(str(current))
     return "\n".join(strings)
+
+
+def _valid_ci_structure(path: str, value: object) -> bool:
+    if not isinstance(value, dict) or not value:
+        return False
+    lowered = path.lower()
+    if lowered.startswith(".github/workflows/"):
+        event_declared = "on" in value or True in value
+        return event_declared and isinstance(value.get("jobs"), dict) and bool(value["jobs"])
+    if lowered == ".gitlab-ci.yml":
+        return any(isinstance(item, dict) for item in value.values())
+    if lowered == ".circleci/config.yml":
+        return "version" in value and any(key in value for key in ("jobs", "workflows"))
+    if lowered == "azure-pipelines.yml":
+        return any(key in value for key in ("jobs", "stages", "steps"))
+    if lowered == "bitbucket-pipelines.yml":
+        return isinstance(value.get("pipelines"), dict) and bool(value["pipelines"])
+    return False
 
 
 @repository_adapter(
@@ -843,20 +930,26 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
     findings: list[Finding] = []
     for file in context.files:
         lowered = file.path.lower()
+        confidence = "HIGH"
         if "openapi" in lowered:
             kind = "OPENAPI"
         elif "asyncapi" in lowered:
             kind = "EVENT_CONTRACT"
         elif lowered.endswith((".proto", ".graphql", ".gql")):
-            kind = "INTERFACE_DEFINITION"
+            kind = "INTERFACE_DEFINITION_SIGNAL"
+            confidence = "MEDIUM"
         elif "/migrations/" in f"/{lowered}":
-            kind = "MIGRATION"
+            kind = "MIGRATION_SIGNAL"
+            confidence = "MEDIUM"
         elif "generate" in PurePosixPath(lowered).name:
-            kind = "CODE_GENERATOR"
+            kind = "CODE_GENERATOR_SIGNAL"
+            confidence = "MEDIUM"
         elif ".gen." in lowered or "generated_client" in lowered:
-            kind = "GENERATED_CLIENT"
+            kind = "GENERATED_CLIENT_SIGNAL"
+            confidence = "MEDIUM"
         elif "/schemas/" in f"/{lowered}" or lowered.endswith(".schema.json"):
-            kind = "SCHEMA"
+            kind = "SCHEMA_SIGNAL"
+            confidence = "MEDIUM"
         else:
             continue
         if kind in {"OPENAPI", "EVENT_CONTRACT"}:
@@ -872,10 +965,32 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
                     or not isinstance(payload.get(version_key), str)
                     or not isinstance(info, dict)
                     or not isinstance(info.get("title"), str)
+                    or not info["title"].strip()
                     or not isinstance(info.get("version"), str)
+                    or not info["version"].strip()
                 ):
                     raise ValueError
-                if kind == "OPENAPI" and not isinstance(payload.get("paths"), dict):
+                declared_version = str(payload[version_key])
+                supported_version = (
+                    re.fullmatch(r"3\.(?:0|1)\.\d+(?:[-+][0-9A-Za-z.-]+)?", declared_version)
+                    if kind == "OPENAPI"
+                    else re.fullmatch(
+                        r"(?:2\.\d+\.\d+|3\.0\.\d+)(?:[-+][0-9A-Za-z.-]+)?",
+                        declared_version,
+                    )
+                )
+                if supported_version is None:
+                    raise ValueError
+                if kind == "OPENAPI":
+                    paths = payload.get("paths")
+                    if not isinstance(paths, dict) or any(
+                        not isinstance(path, str)
+                        or not path.startswith("/")
+                        or not isinstance(operation, dict)
+                        for path, operation in paths.items()
+                    ):
+                        raise ValueError
+                elif not isinstance(payload.get("channels"), dict):
                     raise ValueError
             except (json.JSONDecodeError, UnicodeDecodeError, yaml.YAMLError, ValueError):
                 findings.append(
@@ -891,7 +1006,34 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
                     )
                 )
                 continue
-        items.append(("apis_data", _item(file, kind, "interface.schema-api")))
+        elif lowered.endswith(".schema.json"):
+            if file.content is None or file.binary:
+                continue
+            try:
+                schema = json.loads(file.content)
+                if not isinstance(schema, dict) or not isinstance(schema.get("$schema"), str):
+                    raise ValueError
+            except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+                findings.append(
+                    _finding(
+                        "INTERFACE.DECLARATION_INVALID",
+                        "apis_data",
+                        "A tracked JSON Schema declaration is malformed or lacks a dialect.",
+                        (file.path,),
+                        "interface.schema-api",
+                        severity="HIGH",
+                        blocking=True,
+                    )
+                )
+                continue
+            kind = "JSON_SCHEMA"
+            confidence = "HIGH"
+        items.append(
+            (
+                "apis_data",
+                _item(file, kind, "interface.schema-api", confidence=confidence),
+            )
+        )
     return AdapterResult(items=tuple(items), findings=tuple(findings))
 
 

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.22.0"
+DETECTOR_VERSION = "1.23.0"
 
 _GITHUB_EVENTS = frozenset(
     {
@@ -92,6 +92,24 @@ _GITHUB_PULL_REQUEST_TYPES = frozenset(
     }
 )
 _GITHUB_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+_GITHUB_PERMISSION_SCOPES = frozenset(
+    {
+        "actions",
+        "attestations",
+        "checks",
+        "contents",
+        "deployments",
+        "discussions",
+        "id-token",
+        "issues",
+        "models",
+        "packages",
+        "pages",
+        "pull-requests",
+        "security-events",
+        "statuses",
+    }
+)
 _GITHUB_TOP_LEVEL_KEYS = frozenset(
     {True, "on", "name", "run-name", "permissions", "env", "defaults", "concurrency", "jobs"}
 )
@@ -1425,7 +1443,7 @@ def _github_permissions_are_supported(value: object) -> bool:
         return value in {"read-all", "write-all"}
     return isinstance(value, dict) and all(
         isinstance(key, str)
-        and _GITHUB_IDENTIFIER.fullmatch(key) is not None
+        and key in _GITHUB_PERMISSION_SCOPES
         and isinstance(item, str)
         and item in {"read", "write", "none"}
         for key, item in value.items()
@@ -1493,14 +1511,19 @@ def _github_strategy_is_supported(value: object) -> bool:
         and max_parallel > 0
         and isinstance(matrix, dict)
         and bool(matrix)
-        and all(
-            isinstance(key, str)
-            and _GITHUB_IDENTIFIER.fullmatch(key) is not None
-            and isinstance(items, list)
-            and bool(items)
-            and all(isinstance(item, (str, int, float, bool)) for item in items)
-            for key, items in matrix.items()
+        and all(_github_matrix_entry_is_supported(key, items) for key, items in matrix.items())
+    )
+
+
+def _github_matrix_entry_is_supported(key: object, items: object) -> bool:
+    if not isinstance(key, str) or not isinstance(items, list) or not items:
+        return False
+    if key in {"include", "exclude"}:
+        return all(
+            isinstance(item, dict) and bool(item) and _github_scalar_mapping(item) for item in items
         )
+    return _GITHUB_IDENTIFIER.fullmatch(key) is not None and all(
+        isinstance(item, (str, int, float, bool)) for item in items
     )
 
 
@@ -1738,7 +1761,7 @@ def _github_workflow_is_runnable(value: dict[object, object]) -> bool:
         return False
     event = value.get("on", value.get(True))
     jobs = value.get("jobs")
-    return (
+    if not (
         _github_trigger_is_runnable(event)
         and isinstance(jobs, dict)
         and bool(jobs)
@@ -1748,7 +1771,26 @@ def _github_workflow_is_runnable(value: dict[object, object]) -> bool:
             and _github_job_is_runnable(job)
             for job_id, job in jobs.items()
         )
-    )
+    ):
+        return False
+    job_ids = set(jobs)
+    dependencies: dict[str, set[str]] = {}
+    for job_id, job in jobs.items():
+        assert isinstance(job_id, str) and isinstance(job, dict)
+        needs = job.get("needs")
+        required = {needs} if isinstance(needs, str) else set(needs or ())
+        if not required <= job_ids or job_id in required:
+            return False
+        dependencies[job_id] = required
+    remaining = set(job_ids)
+    completed: set[str] = set()
+    while remaining:
+        ready = {job_id for job_id in remaining if dependencies[job_id] <= completed}
+        if not ready:
+            return False
+        completed.update(ready)
+        remaining.difference_update(ready)
+    return True
 
 
 def _valid_ci_structure(path: str, value: object) -> bool:

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.26.0"
+DETECTOR_VERSION = "1.27.0"
 
 _GITHUB_EVENTS = frozenset(
     {
@@ -1300,7 +1300,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.12.0",
+    version="1.13.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1722,9 +1722,7 @@ def _github_remote_reference_is_supported(
     if (
         not separator
         or _GITHUB_REMOTE_REF.fullmatch(ref) is None
-        or ".." in ref
-        or "//" in ref
-        or ref.endswith(("/", ".", ".lock"))
+        or not _git_reference_is_valid(ref)
     ):
         return False
     parts = target.split("/")
@@ -1740,6 +1738,22 @@ def _github_remote_reference_is_supported(
             and re.fullmatch(r"[A-Za-z0-9_.-]+\.ya?ml", remaining[2]) is not None
         )
     return all(re.fullmatch(r"[A-Za-z0-9_.-]+", part) is not None for part in remaining)
+
+
+def _git_reference_is_valid(ref: str) -> bool:
+    """Apply Git's ref-name safety rules without executing Git during detection."""
+
+    if ref == "@" or ref.startswith(("-", "/")) or ref.endswith("/"):
+        return False
+    if ".." in ref or "//" in ref or "@{" in ref:
+        return False
+    if any(ord(char) < 32 or ord(char) == 127 or char in " ~^:?*[\\" for char in ref):
+        return False
+    components = ref.split("/")
+    return all(
+        component and not component.startswith(".") and not component.endswith((".", ".lock"))
+        for component in components
+    )
 
 
 def _github_job_is_runnable(value: object) -> bool:

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,80 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.20.0"
+DETECTOR_VERSION = "1.21.0"
+
+_GITHUB_EVENTS = frozenset(
+    {
+        "branch_protection_rule",
+        "check_run",
+        "check_suite",
+        "create",
+        "delete",
+        "deployment",
+        "deployment_status",
+        "discussion",
+        "discussion_comment",
+        "fork",
+        "gollum",
+        "issue_comment",
+        "issues",
+        "label",
+        "merge_group",
+        "milestone",
+        "page_build",
+        "project",
+        "project_card",
+        "project_column",
+        "public",
+        "pull_request",
+        "pull_request_review",
+        "pull_request_review_comment",
+        "pull_request_target",
+        "push",
+        "registry_package",
+        "release",
+        "repository_dispatch",
+        "schedule",
+        "status",
+        "watch",
+        "workflow_call",
+        "workflow_dispatch",
+        "workflow_run",
+    }
+)
+_GITHUB_LOCAL_REUSABLE_WORKFLOW = re.compile(r"^\./\.github/workflows/[A-Za-z0-9_./-]+\.ya?ml$")
+_GITHUB_REMOTE_REUSABLE_WORKFLOW = re.compile(
+    r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/\.github/workflows/"
+    r"[A-Za-z0-9_./-]+\.ya?ml@\S+$"
+)
+_GITHUB_LOCAL_ACTION = re.compile(r"^\./[A-Za-z0-9_./-]+$")
+_GITHUB_REMOTE_ACTION = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_./-]+)?@\S+$")
+_GITHUB_DOCKER_ACTION = re.compile(r"^docker://\S+$")
+_GITHUB_PULL_REQUEST_TYPES = frozenset(
+    {
+        "assigned",
+        "auto_merge_disabled",
+        "auto_merge_enabled",
+        "closed",
+        "converted_to_draft",
+        "demilestoned",
+        "dequeued",
+        "edited",
+        "enqueued",
+        "labeled",
+        "locked",
+        "milestoned",
+        "opened",
+        "ready_for_review",
+        "reopened",
+        "review_request_removed",
+        "review_requested",
+        "synchronize",
+        "unassigned",
+        "unlabeled",
+        "unlocked",
+    }
+)
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -1122,7 +1195,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.7.0",
+    version="1.8.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1308,13 +1381,73 @@ def _ci_action_has_content(value: object) -> bool:
     return False
 
 
+def _nonempty_string_list(value: object) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(item, str) and bool(item.strip()) for item in value)
+    )
+
+
+def _github_event_configuration_is_supported(event: str, value: object) -> bool:
+    if value is None:
+        return True
+    if event == "schedule":
+        return (
+            isinstance(value, list)
+            and bool(value)
+            and all(
+                isinstance(item, dict)
+                and set(item) == {"cron"}
+                and isinstance(item["cron"], str)
+                and bool(item["cron"].strip())
+                for item in value
+            )
+        )
+    if event in {"workflow_call", "workflow_dispatch"}:
+        return isinstance(value, dict) and not value
+    if not isinstance(value, dict):
+        return False
+    permitted = (
+        {"branches", "branches-ignore", "paths", "paths-ignore", "tags", "tags-ignore"}
+        if event == "push"
+        else {"branches", "branches-ignore", "paths", "paths-ignore", "types"}
+        if event in {"pull_request", "pull_request_target"}
+        else {"branches", "branches-ignore", "types", "workflows"}
+        if event == "workflow_run"
+        else {"types"}
+        if event == "repository_dispatch"
+        else set()
+    )
+    if not set(value) <= permitted or not all(
+        _nonempty_string_list(item) for item in value.values()
+    ):
+        return False
+    types = value.get("types")
+    if types is None or event == "repository_dispatch":
+        return True
+    allowed_types = (
+        _GITHUB_PULL_REQUEST_TYPES
+        if event in {"pull_request", "pull_request_target"}
+        else {"completed", "in_progress", "requested"}
+    )
+    return all(item in allowed_types for item in types)
+
+
 def _github_trigger_is_runnable(value: object) -> bool:
     if isinstance(value, str):
-        return bool(value.strip())
+        return value.strip() in _GITHUB_EVENTS
     if isinstance(value, list):
-        return any(isinstance(item, str) and bool(item.strip()) for item in value)
+        return bool(value) and all(
+            isinstance(item, str) and item.strip() in _GITHUB_EVENTS for item in value
+        )
     if isinstance(value, dict):
-        return bool(value) and any(isinstance(key, str) and bool(key.strip()) for key in value)
+        return bool(value) and all(
+            isinstance(event, str)
+            and event.strip() in _GITHUB_EVENTS
+            and _github_event_configuration_is_supported(event.strip(), configuration)
+            for event, configuration in value.items()
+        )
     return False
 
 
@@ -1322,10 +1455,72 @@ def _github_runner_is_runnable(value: object) -> bool:
     if isinstance(value, str):
         return bool(value.strip())
     if isinstance(value, list):
-        return bool(value) and all(isinstance(item, str) and bool(item.strip()) for item in value)
+        return _nonempty_string_list(value)
     if isinstance(value, dict):
-        return any(_ci_action_has_content(value.get(key)) for key in ("group", "labels"))
+        if not value or not set(value) <= {"group", "labels"}:
+            return False
+        group = value.get("group")
+        labels = value.get("labels")
+        return (
+            (group is None or isinstance(group, str) and bool(group.strip()))
+            and (
+                labels is None
+                or isinstance(labels, str)
+                and bool(labels.strip())
+                or _nonempty_string_list(labels)
+            )
+            and (group is not None or labels is not None)
+        )
     return False
+
+
+def _github_reusable_workflow_is_runnable(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    reference = value.strip()
+    if _GITHUB_LOCAL_REUSABLE_WORKFLOW.fullmatch(reference) is not None:
+        path = reference.removeprefix("./")
+    elif _GITHUB_REMOTE_REUSABLE_WORKFLOW.fullmatch(reference) is not None:
+        path = reference.split("@", 1)[0].split("/", 2)[2]
+    else:
+        return False
+    return ".." not in PurePosixPath(path).parts
+
+
+def _github_job_is_runnable(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if "uses" in value:
+        return (
+            "runs-on" not in value
+            and "steps" not in value
+            and _github_reusable_workflow_is_runnable(value.get("uses"))
+        )
+    steps = value.get("steps")
+    return (
+        _github_runner_is_runnable(value.get("runs-on"))
+        and isinstance(steps, list)
+        and bool(steps)
+        and all(_github_step_is_runnable(step) for step in steps)
+    )
+
+
+def _github_step_is_runnable(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    run = value.get("run")
+    uses = value.get("uses")
+    if run is not None:
+        return uses is None and isinstance(run, str) and bool(run.strip())
+    if not isinstance(uses, str):
+        return False
+    reference = uses.strip()
+    if _GITHUB_LOCAL_ACTION.fullmatch(reference) is not None:
+        return ".." not in PurePosixPath(reference.removeprefix("./")).parts
+    if _GITHUB_REMOTE_ACTION.fullmatch(reference) is not None:
+        action_path = reference.rsplit("@", 1)[0].split("/", 2)
+        return len(action_path) < 3 or ".." not in PurePosixPath(action_path[2]).parts
+    return _GITHUB_DOCKER_ACTION.fullmatch(reference) is not None
 
 
 def _gitlab_job_is_runnable(job: dict[object, object]) -> bool:
@@ -1397,26 +1592,8 @@ def _valid_ci_structure(path: str, value: object) -> bool:
         return (
             event_declared
             and isinstance(jobs, dict)
-            and any(
-                isinstance(job, dict)
-                and (
-                    isinstance(job.get("uses"), str)
-                    and bool(job["uses"].strip())
-                    or (
-                        _github_runner_is_runnable(job.get("runs-on"))
-                        and isinstance(job.get("steps"), list)
-                        and any(
-                            isinstance(step, dict)
-                            and any(
-                                isinstance(step.get(action), str) and bool(step[action].strip())
-                                for action in ("run", "uses")
-                            )
-                            for step in job["steps"]
-                        )
-                    )
-                )
-                for job in jobs.values()
-            )
+            and bool(jobs)
+            and all(_github_job_is_runnable(job) for job in jobs.values())
         )
     if lowered == ".gitlab-ci.yml":
         reserved = {

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -14,6 +14,8 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
+DETECTOR_VERSION = "1.1.0"
+
 
 @dataclass(frozen=True)
 class TrackedFile:
@@ -86,9 +88,10 @@ def _item(
     file: TrackedFile,
     kind: str,
     detector: str,
-    version: str = "1.0.0",
+    version: str = DETECTOR_VERSION,
     *,
     confidence: str = "HIGH",
+    location: str = "file",
 ) -> EvidenceItem:
     return EvidenceItem(
         kind=kind,
@@ -96,6 +99,7 @@ def _item(
         file_digest=file.digest,
         detector_id=detector,
         detector_version=version,
+        location=location,
         confidence=confidence,
     )
 
@@ -119,7 +123,7 @@ def _finding(
         explanation=explanation,
         evidence_refs=evidence,
         detector_id=detector,
-        detector_version="1.0.0",
+        detector_version=DETECTOR_VERSION,
         blocking=blocking,
     )
 
@@ -157,7 +161,7 @@ def _test_signal_kind(path: str) -> str | None:
 
 @repository_adapter(
     adapter_id="core.repository-topology",
-    version="1.0.0",
+    version="1.1.0",
     file_patterns=("**/*", "*"),
     supported_categories=(
         "repository_topology",
@@ -169,6 +173,7 @@ def _test_signal_kind(path: str) -> str | None:
 def _topology(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
     boundaries: list[BoundaryCandidate] = []
+    findings: list[Finding] = []
     for file in context.files:
         name = PurePosixPath(file.path).name
         lowered = file.path.lower()
@@ -210,6 +215,48 @@ def _topology(context: AdapterContext) -> AdapterResult:
             items.append(
                 ("security_privacy", _item(file, "OWNERSHIP_CONTROL", "core.repository-topology"))
             )
+            if file.content is not None:
+                try:
+                    for line in file.content.decode("utf-8").splitlines():
+                        stripped = line.strip()
+                        if not stripped or stripped.startswith("#"):
+                            continue
+                        codeowners_parts = stripped.split()
+                        if len(codeowners_parts) < 2:
+                            findings.append(
+                                _finding(
+                                    "OWNERSHIP.CODEOWNERS_MALFORMED",
+                                    "architecture_boundaries",
+                                    "A CODEOWNERS rule has no declared owner.",
+                                    (file.path,),
+                                    "core.repository-topology",
+                                    severity="HIGH",
+                                    blocking=True,
+                                )
+                            )
+                            continue
+                        boundaries.append(
+                            BoundaryCandidate(
+                                kind="OWNERSHIP_AREA",
+                                name=codeowners_parts[0],
+                                evidence_paths=(file.path,),
+                                confidence="HIGH",
+                                detector_id="core.repository-topology",
+                                detector_version=DETECTOR_VERSION,
+                            )
+                        )
+                except UnicodeDecodeError:
+                    findings.append(
+                        _finding(
+                            "OWNERSHIP.CODEOWNERS_MALFORMED",
+                            "architecture_boundaries",
+                            "CODEOWNERS is not valid UTF-8.",
+                            (file.path,),
+                            "core.repository-topology",
+                            severity="HIGH",
+                            blocking=True,
+                        )
+                    )
         if lowered.startswith(".github/issue_template/"):
             items.append(
                 (
@@ -298,13 +345,20 @@ def _topology(context: AdapterContext) -> AdapterResult:
                 detector_version="1.0.0",
             )
         )
-    return AdapterResult(items=tuple(items), boundaries=tuple(boundaries))
+    return AdapterResult(items=tuple(items), findings=tuple(findings), boundaries=tuple(boundaries))
 
 
 @repository_adapter(
     adapter_id="stack.python",
-    version="1.0.0",
-    file_patterns=("**/*.py", "pyproject.toml", "**/requirements*.txt", ".python-version"),
+    version="1.1.0",
+    file_patterns=(
+        "*.py",
+        "**/*.py",
+        "pyproject.toml",
+        "requirements*.txt",
+        "**/requirements*.txt",
+        ".python-version",
+    ),
     supported_categories=("languages_build_ecosystems", "tests_quality", "debt_risk"),
 )
 def _python(context: AdapterContext) -> AdapterResult:
@@ -364,15 +418,23 @@ def _python(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="stack.node-web",
-    version="1.0.0",
+    version="1.1.0",
     file_patterns=(
         "**/*.js",
+        "*.js",
         "**/*.jsx",
+        "*.jsx",
         "**/*.ts",
+        "*.ts",
         "**/*.tsx",
+        "*.tsx",
+        "package.json",
         "**/package.json",
+        "package-lock.json",
         "**/package-lock.json",
+        "yarn.lock",
         "**/yarn.lock",
+        "pnpm-lock.yaml",
         "**/pnpm-lock.yaml",
     ),
     supported_categories=("languages_build_ecosystems", "tests_quality", "debt_risk"),
@@ -457,9 +519,103 @@ def _node(context: AdapterContext) -> AdapterResult:
 
 
 @repository_adapter(
+    adapter_id="integration.manifest-declarations",
+    version="1.1.0",
+    file_patterns=(
+        "pyproject.toml",
+        "**/pyproject.toml",
+        "package.json",
+        "**/package.json",
+        "*openapi*.json",
+        "**/*openapi*.json",
+        "*openapi*.yaml",
+        "*openapi*.yml",
+        "**/*openapi*.yaml",
+        "**/*openapi*.yml",
+    ),
+    supported_categories=("integrations",),
+)
+def _integration_declarations(context: AdapterContext) -> AdapterResult:
+    items: list[tuple[str, EvidenceItem]] = []
+    for file in context.files:
+        if file.content is None or file.binary:
+            continue
+        name = PurePosixPath(file.path).name
+        try:
+            if name == "pyproject.toml":
+                payload = tomllib.loads(file.content.decode("utf-8"))
+                dependencies = payload.get("project", {}).get("dependencies", [])
+                if isinstance(dependencies, list):
+                    for index, dependency in enumerate(dependencies):
+                        if isinstance(dependency, str):
+                            items.append(
+                                (
+                                    "integrations",
+                                    _item(
+                                        file,
+                                        "EXTERNAL_DEPENDENCY_DECLARATION",
+                                        "integration.manifest-declarations",
+                                        confidence="LOW",
+                                        location=f"project.dependencies[{index}]",
+                                    ),
+                                )
+                            )
+            elif name == "package.json":
+                payload = json.loads(file.content)
+                for group in ("dependencies", "optionalDependencies", "peerDependencies"):
+                    dependencies = payload.get(group, {})
+                    if isinstance(dependencies, dict):
+                        for dependency in sorted(dependencies):
+                            items.append(
+                                (
+                                    "integrations",
+                                    _item(
+                                        file,
+                                        "EXTERNAL_DEPENDENCY_DECLARATION",
+                                        "integration.manifest-declarations",
+                                        confidence="LOW",
+                                        location=f"{group}.{dependency}",
+                                    ),
+                                )
+                            )
+            elif "openapi" in name.lower():
+                text = file.content.decode("utf-8")
+                payload = json.loads(text) if name.endswith(".json") else yaml.safe_load(text)
+                servers = payload.get("servers", []) if isinstance(payload, dict) else []
+                if isinstance(servers, list):
+                    for index, server in enumerate(servers):
+                        if isinstance(server, dict) and isinstance(server.get("url"), str):
+                            items.append(
+                                (
+                                    "integrations",
+                                    _item(
+                                        file,
+                                        "EXTERNAL_API_SERVER_DECLARATION",
+                                        "integration.manifest-declarations",
+                                        confidence="MEDIUM",
+                                        location=f"servers[{index}]",
+                                    ),
+                                )
+                            )
+        except (json.JSONDecodeError, tomllib.TOMLDecodeError, UnicodeDecodeError, yaml.YAMLError):
+            # The owning stack/schema adapter emits the canonical malformed-input finding.
+            continue
+    return AdapterResult(items=tuple(items))
+
+
+@repository_adapter(
     adapter_id="stack.docker-compose",
-    version="1.0.0",
-    file_patterns=("**/Dockerfile", "**/Dockerfile.*", "**/compose.y*ml", "**/docker-compose.y*ml"),
+    version="1.1.0",
+    file_patterns=(
+        "Dockerfile",
+        "Dockerfile.*",
+        "compose.y*ml",
+        "docker-compose.y*ml",
+        "**/Dockerfile",
+        "**/Dockerfile.*",
+        "**/compose.y*ml",
+        "**/docker-compose.y*ml",
+    ),
     supported_categories=(
         "languages_build_ecosystems",
         "delivery_environments",
@@ -516,15 +672,23 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 
 @repository_adapter(
-    adapter_id="delivery.github-actions",
-    version="1.0.0",
-    file_patterns=(".github/workflows/*.yml", ".github/workflows/*.yaml"),
+    adapter_id="delivery.ci",
+    version="1.1.0",
+    file_patterns=(
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml",
+        ".gitlab-ci.yml",
+        ".circleci/config.yml",
+        "azure-pipelines.yml",
+        "bitbucket-pipelines.yml",
+        "Jenkinsfile",
+    ),
     supported_categories=("delivery_environments", "tests_quality", "security_privacy"),
 )
-def _github_actions(context: AdapterContext) -> AdapterResult:
+def _ci_workflows(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
     findings: list[Finding] = []
-    workflows = [file for file in context.files if file.path.startswith(".github/workflows/")]
+    workflows = list(context.files)
     for file in workflows:
         workflow_kind = (
             "RELEASE_WORKFLOW"
@@ -534,14 +698,12 @@ def _github_actions(context: AdapterContext) -> AdapterResult:
         items.append(
             (
                 "delivery_environments",
-                _item(file, workflow_kind, "delivery.github-actions"),
+                _item(file, workflow_kind, "delivery.ci"),
             )
         )
         if file.content and re.search(rb"\b(pytest|vitest|playwright|test)\b", file.content, re.I):
-            items.append(
-                ("tests_quality", _item(file, "CI_TEST_MAPPING", "delivery.github-actions"))
-            )
-        if file.content is not None:
+            items.append(("tests_quality", _item(file, "CI_TEST_MAPPING", "delivery.ci")))
+        if file.content is not None and file.path.endswith((".yml", ".yaml")):
             try:
                 parsed = yaml.safe_load(file.content)
                 if not isinstance(parsed, dict):
@@ -553,20 +715,18 @@ def _github_actions(context: AdapterContext) -> AdapterResult:
                         "delivery_environments",
                         "A tracked workflow cannot be parsed deterministically.",
                         (file.path,),
-                        "delivery.github-actions",
+                        "delivery.ci",
                         severity="HIGH",
                         blocking=True,
                     )
                 )
         if file.content and re.search(rb"\b(audit|bandit|secret|security)\b", file.content, re.I):
-            items.append(
-                ("security_privacy", _item(file, "SECURITY_GATE", "delivery.github-actions"))
-            )
+            items.append(("security_privacy", _item(file, "SECURITY_GATE", "delivery.ci")))
         if file.content and re.search(rb"\b(rollback|revert)\b", file.content, re.I):
             items.append(
                 (
                     "delivery_environments",
-                    _item(file, "ROLLBACK_MECHANISM", "delivery.github-actions"),
+                    _item(file, "ROLLBACK_MECHANISM", "delivery.ci"),
                 )
             )
     if not workflows:
@@ -574,9 +734,9 @@ def _github_actions(context: AdapterContext) -> AdapterResult:
             _finding(
                 "DELIVERY.CI_ABSENT",
                 "delivery_environments",
-                "No tracked GitHub Actions workflow was observed.",
+                "No tracked supported CI workflow was observed.",
                 ("repository:tracked-tree",),
-                "delivery.github-actions",
+                "delivery.ci",
             )
         )
     return AdapterResult(items=tuple(items), findings=tuple(findings))
@@ -584,16 +744,25 @@ def _github_actions(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="interface.schema-api",
-    version="1.0.0",
+    version="1.1.0",
     file_patterns=(
+        "*openapi*",
         "**/*openapi*",
+        "*asyncapi*",
         "**/*asyncapi*",
+        "*.proto",
         "**/*.proto",
+        "*.graphql",
         "**/*.graphql",
+        "*.gql",
         "**/*.gql",
+        "*.gen.*",
         "**/*.gen.*",
+        "schemas/**",
         "**/schemas/**",
+        "migrations/**",
         "**/migrations/**",
+        "generate*",
         "**/generate*",
         "scripts/**",
     ),
@@ -625,7 +794,7 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="repository.pmpe",
-    version="1.0.0",
+    version="1.1.0",
     file_patterns=("src/pmpe/**", "state/**", "docs/**"),
     supported_categories=("architecture_boundaries", "documentation_governance", "debt_risk"),
 )
@@ -648,8 +817,9 @@ def default_adapters() -> tuple[RepositoryAdapter, ...]:
                 _topology,
                 _python,
                 _node,
+                _integration_declarations,
                 _containers,
-                _github_actions,
+                _ci_workflows,
                 _interfaces,
                 _pmpe,
             ),

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -14,7 +14,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.3.0"
+DETECTOR_VERSION = "1.4.0"
 
 
 @dataclass(frozen=True)
@@ -57,6 +57,7 @@ class RepositoryAdapter:
     file_patterns: tuple[str, ...]
     supported_categories: tuple[str, ...]
     evaluator: AdapterEvaluator
+    detector_version: str = DETECTOR_VERSION
     failure_behavior: str = "VISIBLE_PARTIAL_OR_BLOCKED"
     detection_logic: str = "TRACKED_PATH_AND_SAFE_STRUCTURE_ONLY"
     evidence_emitted: str = "DIGEST_BOUND_FILE_EVIDENCE"
@@ -79,6 +80,7 @@ def repository_adapter(
             file_patterns=file_patterns,
             supported_categories=supported_categories,
             evaluator=evaluator,
+            detector_version=DETECTOR_VERSION,
         )
 
     return decorate
@@ -166,8 +168,11 @@ def _test_signal_kind(path: str) -> str | None:
     supported_categories=(
         "repository_topology",
         "architecture_boundaries",
+        "delivery_environments",
         "documentation_governance",
         "debt_risk",
+        "observability_operations",
+        "security_privacy",
     ),
 )
 def _topology(context: AdapterContext) -> AdapterResult:
@@ -342,7 +347,7 @@ def _topology(context: AdapterContext) -> AdapterResult:
                 evidence_paths=tuple(sorted(paths)),
                 confidence="MEDIUM",
                 detector_id="core.repository-topology",
-                detector_version="1.0.0",
+                detector_version=DETECTOR_VERSION,
             )
         )
     return AdapterResult(items=tuple(items), findings=tuple(findings), boundaries=tuple(boundaries))

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -17,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.21.0"
+DETECTOR_VERSION = "1.22.0"
 
 _GITHUB_EVENTS = frozenset(
     {
@@ -89,6 +89,38 @@ _GITHUB_PULL_REQUEST_TYPES = frozenset(
         "unassigned",
         "unlabeled",
         "unlocked",
+    }
+)
+_GITHUB_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+_GITHUB_TOP_LEVEL_KEYS = frozenset(
+    {True, "on", "name", "run-name", "permissions", "env", "defaults", "concurrency", "jobs"}
+)
+_GITHUB_INLINE_JOB_KEYS = frozenset(
+    {
+        "name",
+        "if",
+        "runs-on",
+        "timeout-minutes",
+        "steps",
+        "strategy",
+        "defaults",
+        "needs",
+    }
+)
+_GITHUB_REUSABLE_JOB_KEYS = frozenset({"name", "if", "needs", "uses", "with", "secrets"})
+_GITHUB_STEP_KEYS = frozenset(
+    {
+        "name",
+        "id",
+        "if",
+        "uses",
+        "run",
+        "with",
+        "env",
+        "working-directory",
+        "shell",
+        "continue-on-error",
+        "timeout-minutes",
     }
 )
 
@@ -1195,7 +1227,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.8.0",
+    version="1.9.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -1371,22 +1403,132 @@ def _structured_text(value: object) -> str:
     return "\n".join(strings)
 
 
-def _ci_action_has_content(value: object) -> bool:
-    if isinstance(value, str):
-        return bool(value.strip())
-    if isinstance(value, list):
-        return any(_ci_action_has_content(item) for item in value)
-    if isinstance(value, dict):
-        return bool(value) and any(_ci_action_has_content(item) for item in value.values())
-    return False
-
-
 def _nonempty_string_list(value: object) -> bool:
     return (
         isinstance(value, list)
         and bool(value)
         and all(isinstance(item, str) and bool(item.strip()) for item in value)
     )
+
+
+def _github_scalar_mapping(value: object) -> bool:
+    return isinstance(value, dict) and all(
+        isinstance(key, str)
+        and bool(key.strip())
+        and (item is None or isinstance(item, (str, int, float, bool)))
+        for key, item in value.items()
+    )
+
+
+def _github_permissions_are_supported(value: object) -> bool:
+    if isinstance(value, str):
+        return value in {"read-all", "write-all"}
+    return isinstance(value, dict) and all(
+        isinstance(key, str)
+        and _GITHUB_IDENTIFIER.fullmatch(key) is not None
+        and isinstance(item, str)
+        and item in {"read", "write", "none"}
+        for key, item in value.items()
+    )
+
+
+def _github_concurrency_is_supported(value: object) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if not isinstance(value, dict) or not set(value) <= {"group", "cancel-in-progress"}:
+        return False
+    group = value.get("group")
+    cancel = value.get("cancel-in-progress", False)
+    return (
+        isinstance(group, str)
+        and bool(group.strip())
+        and (isinstance(cancel, bool) or isinstance(cancel, str) and bool(cancel.strip()))
+    )
+
+
+def _github_defaults_are_supported(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != {"run"}:
+        return False
+    run = value.get("run")
+    return (
+        isinstance(run, dict)
+        and bool(run)
+        and set(run) <= {"shell", "working-directory"}
+        and all(isinstance(item, str) and bool(item.strip()) for item in run.values())
+    )
+
+
+def _github_needs_are_supported(value: object) -> bool:
+    if isinstance(value, str):
+        return _GITHUB_IDENTIFIER.fullmatch(value) is not None
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(
+            isinstance(item, str) and _GITHUB_IDENTIFIER.fullmatch(item) is not None
+            for item in value
+        )
+    )
+
+
+def _github_strategy_is_supported(value: object) -> bool:
+    if (
+        not isinstance(value, dict)
+        or not value
+        or not set(value)
+        <= {
+            "matrix",
+            "fail-fast",
+            "max-parallel",
+        }
+    ):
+        return False
+    fail_fast = value.get("fail-fast", True)
+    max_parallel = value.get("max-parallel", 1)
+    matrix = value.get("matrix")
+    return (
+        isinstance(fail_fast, bool)
+        and isinstance(max_parallel, int)
+        and not isinstance(max_parallel, bool)
+        and max_parallel > 0
+        and isinstance(matrix, dict)
+        and bool(matrix)
+        and all(
+            isinstance(key, str)
+            and _GITHUB_IDENTIFIER.fullmatch(key) is not None
+            and isinstance(items, list)
+            and bool(items)
+            and all(isinstance(item, (str, int, float, bool)) for item in items)
+            for key, items in matrix.items()
+        )
+    )
+
+
+def _github_cron_is_supported(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    fields = value.split()
+    limits = ((0, 59), (0, 23), (1, 31), (1, 12), (0, 7))
+    if len(fields) != len(limits):
+        return False
+    for field, (minimum, maximum) in zip(fields, limits, strict=True):
+        if re.fullmatch(r"[0-9*/,-]+", field) is None:
+            return False
+        for segment in field.split(","):
+            base, separator, step = segment.partition("/")
+            if separator and (not step.isdigit() or int(step) <= 0):
+                return False
+            if base == "*":
+                continue
+            endpoints = base.split("-")
+            if len(endpoints) not in {1, 2} or not all(item.isdigit() for item in endpoints):
+                return False
+            numbers = [int(item) for item in endpoints]
+            if not all(minimum <= item <= maximum for item in numbers):
+                return False
+            if len(numbers) == 2 and numbers[0] > numbers[1]:
+                return False
+    return True
 
 
 def _github_event_configuration_is_supported(event: str, value: object) -> bool:
@@ -1399,8 +1541,7 @@ def _github_event_configuration_is_supported(event: str, value: object) -> bool:
             and all(
                 isinstance(item, dict)
                 and set(item) == {"cron"}
-                and isinstance(item["cron"], str)
-                and bool(item["cron"].strip())
+                and _github_cron_is_supported(item["cron"])
                 for item in value
             )
         )
@@ -1423,6 +1564,13 @@ def _github_event_configuration_is_supported(event: str, value: object) -> bool:
         _nonempty_string_list(item) for item in value.values()
     ):
         return False
+    for positive, negative in (
+        ("branches", "branches-ignore"),
+        ("paths", "paths-ignore"),
+        ("tags", "tags-ignore"),
+    ):
+        if positive in value and negative in value:
+            return False
     types = value.get("types")
     if types is None or event == "repository_dispatch":
         return True
@@ -1490,15 +1638,40 @@ def _github_reusable_workflow_is_runnable(value: object) -> bool:
 def _github_job_is_runnable(value: object) -> bool:
     if not isinstance(value, dict):
         return False
+    name = value.get("name")
+    condition = value.get("if")
+    needs = value.get("needs")
+    if name is not None and (not isinstance(name, str) or not name.strip()):
+        return False
+    if condition is not None and (not isinstance(condition, str) or not condition.strip()):
+        return False
+    if needs is not None and not _github_needs_are_supported(needs):
+        return False
     if "uses" in value:
         return (
-            "runs-on" not in value
-            and "steps" not in value
+            bool(value)
+            and set(value) <= _GITHUB_REUSABLE_JOB_KEYS
             and _github_reusable_workflow_is_runnable(value.get("uses"))
+            and ("with" not in value or _github_scalar_mapping(value["with"]))
+            and (
+                "secrets" not in value
+                or value["secrets"] == "inherit"
+                or _github_scalar_mapping(value["secrets"])
+            )
         )
+    if not set(value) <= _GITHUB_INLINE_JOB_KEYS:
+        return False
+    timeout = value.get("timeout-minutes", 1)
+    strategy = value.get("strategy")
+    defaults = value.get("defaults")
     steps = value.get("steps")
     return (
-        _github_runner_is_runnable(value.get("runs-on"))
+        isinstance(timeout, int)
+        and not isinstance(timeout, bool)
+        and timeout > 0
+        and (strategy is None or _github_strategy_is_supported(strategy))
+        and (defaults is None or _github_defaults_are_supported(defaults))
+        and _github_runner_is_runnable(value.get("runs-on"))
         and isinstance(steps, list)
         and bool(steps)
         and all(_github_step_is_runnable(step) for step in steps)
@@ -1506,7 +1679,32 @@ def _github_job_is_runnable(value: object) -> bool:
 
 
 def _github_step_is_runnable(value: object) -> bool:
-    if not isinstance(value, dict):
+    if not isinstance(value, dict) or not value or not set(value) <= _GITHUB_STEP_KEYS:
+        return False
+    name = value.get("name")
+    step_id = value.get("id")
+    condition = value.get("if")
+    for key in ("working-directory", "shell"):
+        item = value.get(key)
+        if item is not None and (not isinstance(item, str) or not item.strip()):
+            return False
+    if name is not None and (not isinstance(name, str) or not name.strip()):
+        return False
+    if step_id is not None and (
+        not isinstance(step_id, str) or _GITHUB_IDENTIFIER.fullmatch(step_id) is None
+    ):
+        return False
+    if condition is not None and (not isinstance(condition, str) or not condition.strip()):
+        return False
+    if "with" in value and not _github_scalar_mapping(value["with"]):
+        return False
+    if "env" in value and not _github_scalar_mapping(value["env"]):
+        return False
+    continue_on_error = value.get("continue-on-error", False)
+    timeout = value.get("timeout-minutes", 1)
+    if not isinstance(continue_on_error, bool) or (
+        not isinstance(timeout, int) or isinstance(timeout, bool) or timeout <= 0
+    ):
         return False
     run = value.get("run")
     uses = value.get("uses")
@@ -1523,63 +1721,34 @@ def _github_step_is_runnable(value: object) -> bool:
     return _GITHUB_DOCKER_ACTION.fullmatch(reference) is not None
 
 
-def _gitlab_job_is_runnable(job: dict[object, object]) -> bool:
-    script = job.get("script")
-    if isinstance(script, str) and bool(script.strip()):
-        return True
-    if isinstance(script, list) and any(
-        isinstance(item, str) and bool(item.strip()) for item in script
-    ):
-        return True
-    trigger = job.get("trigger")
-    if isinstance(trigger, str):
-        return bool(trigger.strip())
-    return isinstance(trigger, dict) and any(
-        _ci_action_has_content(trigger.get(key)) for key in ("project", "include")
-    )
-
-
-def _circle_step_is_runnable(step: object) -> bool:
-    if isinstance(step, str):
-        return bool(step.strip())
-    if not isinstance(step, dict):
+def _github_workflow_is_runnable(value: dict[object, object]) -> bool:
+    if not set(value) <= _GITHUB_TOP_LEVEL_KEYS or ("on" in value and True in value):
         return False
-    run = step.get("run")
-    if isinstance(run, str) and bool(run.strip()):
-        return True
-    if isinstance(run, dict) and _ci_action_has_content(run.get("command")):
-        return True
-    return any(
-        key in step and (step[key] is None or _ci_action_has_content(step[key]))
-        for key in ("checkout", "setup_remote_docker")
-    )
-
-
-def _azure_tree_contains_action(value: object) -> bool:
-    pending = [value]
-    visited = 0
-    while pending:
-        current = pending.pop()
-        visited += 1
-        if visited > 50_000:
+    for key in ("name", "run-name"):
+        item = value.get(key)
+        if item is not None and (not isinstance(item, str) or not item.strip()):
             return False
-        if isinstance(current, dict):
-            if any(
-                _ci_action_has_content(current.get(key))
-                for key in ("script", "bash", "pwsh", "powershell", "task", "template")
-            ):
-                return True
-            checkout = current.get("checkout")
-            if (
-                isinstance(checkout, str)
-                and checkout.strip()
-                and checkout.strip().lower() != "none"
-            ):
-                return True
-            pending.extend(current[key] for key in ("jobs", "stages", "steps") if key in current)
-        elif isinstance(current, list):
-            pending.extend(current)
-    return False
+    if "permissions" in value and not _github_permissions_are_supported(value["permissions"]):
+        return False
+    if "env" in value and not _github_scalar_mapping(value["env"]):
+        return False
+    if "defaults" in value and not _github_defaults_are_supported(value["defaults"]):
+        return False
+    if "concurrency" in value and not _github_concurrency_is_supported(value["concurrency"]):
+        return False
+    event = value.get("on", value.get(True))
+    jobs = value.get("jobs")
+    return (
+        _github_trigger_is_runnable(event)
+        and isinstance(jobs, dict)
+        and bool(jobs)
+        and all(
+            isinstance(job_id, str)
+            and _GITHUB_IDENTIFIER.fullmatch(job_id) is not None
+            and _github_job_is_runnable(job)
+            for job_id, job in jobs.items()
+        )
+    )
 
 
 def _valid_ci_structure(path: str, value: object) -> bool:
@@ -1587,75 +1756,7 @@ def _valid_ci_structure(path: str, value: object) -> bool:
         return False
     lowered = path.lower()
     if lowered.startswith(".github/workflows/"):
-        event_declared = _github_trigger_is_runnable(value.get("on", value.get(True)))
-        jobs = value.get("jobs")
-        return (
-            event_declared
-            and isinstance(jobs, dict)
-            and bool(jobs)
-            and all(_github_job_is_runnable(job) for job in jobs.values())
-        )
-    if lowered == ".gitlab-ci.yml":
-        reserved = {
-            "default",
-            "include",
-            "stages",
-            "variables",
-            "workflow",
-            "image",
-            "services",
-            "before_script",
-            "after_script",
-            "cache",
-            "pages",
-        }
-        return any(
-            key not in reserved
-            and not key.startswith(".")
-            and isinstance(item, dict)
-            and _gitlab_job_is_runnable(item)
-            for key, item in value.items()
-        )
-    if lowered == ".circleci/config.yml":
-        jobs = value.get("jobs")
-        return (
-            "version" in value
-            and isinstance(jobs, dict)
-            and any(
-                isinstance(job, dict)
-                and isinstance(job.get("steps"), list)
-                and any(_circle_step_is_runnable(step) for step in job["steps"])
-                for job in jobs.values()
-            )
-        )
-    if lowered == "azure-pipelines.yml":
-        return _azure_tree_contains_action(value)
-    if lowered == "bitbucket-pipelines.yml":
-        pipelines = value.get("pipelines")
-        pending = [pipelines]
-        visited = 0
-        while pending:
-            current = pending.pop()
-            visited += 1
-            if visited > 50_000:
-                return False
-            if isinstance(current, dict):
-                step = current.get("step")
-                if (
-                    isinstance(step, dict)
-                    and isinstance(step.get("script"), list)
-                    and any(
-                        _ci_action_has_content(item)
-                        if not isinstance(item, dict)
-                        else _ci_action_has_content(item.get("pipe"))
-                        for item in step["script"]
-                    )
-                ):
-                    return True
-                pending.extend(current.values())
-            elif isinstance(current, list):
-                pending.extend(current)
-        return False
+        return _github_workflow_is_runnable(value)
     return False
 
 

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -15,7 +15,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.11.0"
+DETECTOR_VERSION = "1.12.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -487,10 +487,12 @@ def _topology(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="stack.python",
-    version="1.5.0",
+    version="1.6.0",
     file_patterns=(
         "*.py",
         "**/*.py",
+        "*.pyi",
+        "**/*.pyi",
         "pyproject.toml",
         "**/pyproject.toml",
         "requirements*.txt",
@@ -652,16 +654,15 @@ def _python(context: AdapterContext) -> AdapterResult:
                         blocking=True,
                     )
                 )
-        elif file.path.endswith(".py"):
-            test_kind = _test_signal_kind(file.path)
-            if test_kind is None:
-                items.append(
-                    (
-                        "languages_build_ecosystems",
-                        _item(file, "PYTHON_SOURCE", "stack.python"),
-                    )
+        elif file.path.endswith((".py", ".pyi")):
+            items.append(
+                (
+                    "languages_build_ecosystems",
+                    _item(file, "PYTHON_SOURCE", "stack.python"),
                 )
-            else:
+            )
+            test_kind = _test_signal_kind(file.path)
+            if test_kind is not None:
                 items.append(
                     (
                         "tests_quality",
@@ -682,10 +683,14 @@ def _python(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="stack.node-web",
-    version="1.3.0",
+    version="1.4.0",
     file_patterns=(
         "**/*.js",
         "*.js",
+        "**/*.mjs",
+        "*.mjs",
+        "**/*.cjs",
+        "*.cjs",
         "**/*.jsx",
         "*.jsx",
         "**/*.ts",
@@ -797,16 +802,15 @@ def _node(context: AdapterContext) -> AdapterResult:
         elif name in {"package-lock.json", "yarn.lock", "pnpm-lock.yaml"}:
             lock_paths.setdefault(name, []).append(file.path)
             items.append(("languages_build_ecosystems", _item(file, "LOCKFILE", "stack.node-web")))
-        elif file.path.endswith((".js", ".jsx", ".ts", ".tsx")):
-            test_kind = _test_signal_kind(file.path)
-            if test_kind is None:
-                items.append(
-                    (
-                        "languages_build_ecosystems",
-                        _item(file, "NODE_SOURCE", "stack.node-web"),
-                    )
+        elif file.path.endswith((".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx")):
+            items.append(
+                (
+                    "languages_build_ecosystems",
+                    _item(file, "NODE_SOURCE", "stack.node-web"),
                 )
-            else:
+            )
+            test_kind = _test_signal_kind(file.path)
+            if test_kind is not None:
                 items.append(
                     (
                         "tests_quality",

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -14,7 +14,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.1.0"
+DETECTOR_VERSION = "1.2.0"
 
 
 @dataclass(frozen=True)
@@ -520,7 +520,7 @@ def _node(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="integration.manifest-declarations",
-    version="1.1.0",
+    version="1.2.0",
     file_patterns=(
         "pyproject.toml",
         "**/pyproject.toml",
@@ -537,6 +537,7 @@ def _node(context: AdapterContext) -> AdapterResult:
 )
 def _integration_declarations(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
+    findings: list[Finding] = []
     for file in context.files:
         if file.content is None or file.binary:
             continue
@@ -598,9 +599,19 @@ def _integration_declarations(context: AdapterContext) -> AdapterResult:
                                 )
                             )
         except (json.JSONDecodeError, tomllib.TOMLDecodeError, UnicodeDecodeError, yaml.YAMLError):
-            # The owning stack/schema adapter emits the canonical malformed-input finding.
-            continue
-    return AdapterResult(items=tuple(items))
+            findings.append(
+                _finding(
+                    "INTEGRATION.DECLARATION_MALFORMED",
+                    "integrations",
+                    "A tracked integration declaration cannot be parsed; no integration "
+                    "evidence was inferred from it.",
+                    (file.path,),
+                    "integration.manifest-declarations",
+                    severity="HIGH",
+                    blocking=True,
+                )
+            )
+    return AdapterResult(items=tuple(items), findings=tuple(findings))
 
 
 @repository_adapter(
@@ -640,7 +651,10 @@ def _containers(context: AdapterContext) -> AdapterResult:
                     _item(file, "CONTAINER_DEFINITION", "stack.docker-compose"),
                 )
             )
-            if file.content and b"HEALTHCHECK" in file.content:
+            if file.content and any(
+                line.lstrip().upper().startswith(b"HEALTHCHECK ")
+                for line in file.content.splitlines()
+            ):
                 items.append(
                     (
                         "observability_operations",
@@ -673,7 +687,7 @@ def _containers(context: AdapterContext) -> AdapterResult:
 
 @repository_adapter(
     adapter_id="delivery.ci",
-    version="1.1.0",
+    version="1.2.0",
     file_patterns=(
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml",
@@ -690,19 +704,25 @@ def _ci_workflows(context: AdapterContext) -> AdapterResult:
     findings: list[Finding] = []
     workflows = list(context.files)
     for file in workflows:
-        workflow_kind = (
-            "RELEASE_WORKFLOW"
-            if any(token in file.path.lower() for token in ("release", "deploy", "publish"))
-            else "CI_WORKFLOW"
-        )
         items.append(
             (
                 "delivery_environments",
-                _item(file, workflow_kind, "delivery.ci"),
+                _item(file, "CI_WORKFLOW", "delivery.ci"),
             )
         )
-        if file.content and re.search(rb"\b(pytest|vitest|playwright|test)\b", file.content, re.I):
-            items.append(("tests_quality", _item(file, "CI_TEST_MAPPING", "delivery.ci")))
+        if any(token in file.path.lower() for token in ("release", "deploy", "publish")):
+            items.append(
+                (
+                    "delivery_environments",
+                    _item(
+                        file,
+                        "RELEASE_WORKFLOW_SIGNAL",
+                        "delivery.ci",
+                        confidence="MEDIUM",
+                    ),
+                )
+            )
+        parsed: object | None = None
         if file.content is not None and file.path.endswith((".yml", ".yaml")):
             try:
                 parsed = yaml.safe_load(file.content)
@@ -720,13 +740,45 @@ def _ci_workflows(context: AdapterContext) -> AdapterResult:
                         blocking=True,
                     )
                 )
-        if file.content and re.search(rb"\b(audit|bandit|secret|security)\b", file.content, re.I):
-            items.append(("security_privacy", _item(file, "SECURITY_GATE", "delivery.ci")))
-        if file.content and re.search(rb"\b(rollback|revert)\b", file.content, re.I):
+                continue
+        signals = _structured_text(parsed) if parsed is not None else ""
+        if re.search(r"\b(pytest|vitest|playwright|test)\b", signals, re.I):
+            items.append(
+                (
+                    "tests_quality",
+                    _item(
+                        file,
+                        "CI_TEST_MAPPING_SIGNAL",
+                        "delivery.ci",
+                        confidence="MEDIUM",
+                        location="parsed-workflow",
+                    ),
+                )
+            )
+        if re.search(r"\b(audit|bandit|secret|security)\b", signals, re.I):
+            items.append(
+                (
+                    "security_privacy",
+                    _item(
+                        file,
+                        "SECURITY_CONTROL_SIGNAL",
+                        "delivery.ci",
+                        confidence="MEDIUM",
+                        location="parsed-workflow",
+                    ),
+                )
+            )
+        if re.search(r"\b(rollback|revert)\b", signals, re.I):
             items.append(
                 (
                     "delivery_environments",
-                    _item(file, "ROLLBACK_MECHANISM", "delivery.ci"),
+                    _item(
+                        file,
+                        "ROLLBACK_SIGNAL",
+                        "delivery.ci",
+                        confidence="MEDIUM",
+                        location="parsed-workflow",
+                    ),
                 )
             )
     if not workflows:
@@ -742,9 +794,27 @@ def _ci_workflows(context: AdapterContext) -> AdapterResult:
     return AdapterResult(items=tuple(items), findings=tuple(findings))
 
 
+def _structured_text(value: object) -> str:
+    """Return only parsed keys/scalars; comments and unparsed source never become controls."""
+
+    pending = [value]
+    strings: list[str] = []
+    while pending:
+        current = pending.pop()
+        if isinstance(current, dict):
+            for key, item in current.items():
+                strings.append(str(key))
+                pending.append(item)
+        elif isinstance(current, list):
+            pending.extend(current)
+        elif isinstance(current, (str, int, float, bool)):
+            strings.append(str(current))
+    return "\n".join(strings)
+
+
 @repository_adapter(
     adapter_id="interface.schema-api",
-    version="1.1.0",
+    version="1.2.0",
     file_patterns=(
         "*openapi*",
         "**/*openapi*",
@@ -770,6 +840,7 @@ def _ci_workflows(context: AdapterContext) -> AdapterResult:
 )
 def _interfaces(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
+    findings: list[Finding] = []
     for file in context.files:
         lowered = file.path.lower()
         if "openapi" in lowered:
@@ -788,8 +859,40 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
             kind = "SCHEMA"
         else:
             continue
+        if kind in {"OPENAPI", "EVENT_CONTRACT"}:
+            if file.content is None or file.binary:
+                continue
+            try:
+                text = file.content.decode("utf-8")
+                payload = json.loads(text) if lowered.endswith(".json") else yaml.safe_load(text)
+                version_key = "openapi" if kind == "OPENAPI" else "asyncapi"
+                info = payload.get("info") if isinstance(payload, dict) else None
+                if (
+                    not isinstance(payload, dict)
+                    or not isinstance(payload.get(version_key), str)
+                    or not isinstance(info, dict)
+                    or not isinstance(info.get("title"), str)
+                    or not isinstance(info.get("version"), str)
+                ):
+                    raise ValueError
+                if kind == "OPENAPI" and not isinstance(payload.get("paths"), dict):
+                    raise ValueError
+            except (json.JSONDecodeError, UnicodeDecodeError, yaml.YAMLError, ValueError):
+                findings.append(
+                    _finding(
+                        "INTERFACE.DECLARATION_INVALID",
+                        "apis_data",
+                        "A tracked API declaration is malformed or lacks required structural "
+                        "identity; no API evidence was inferred from it.",
+                        (file.path,),
+                        "interface.schema-api",
+                        severity="HIGH",
+                        blocking=True,
+                    )
+                )
+                continue
         items.append(("apis_data", _item(file, kind, "interface.schema-api")))
-    return AdapterResult(items=tuple(items))
+    return AdapterResult(items=tuple(items), findings=tuple(findings))
 
 
 @repository_adapter(

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -14,7 +14,26 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.7.0"
+DETECTOR_VERSION = "1.8.0"
+
+_PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
+    {
+        "package.json",
+        "pyproject.toml",
+        "Cargo.toml",
+        "go.mod",
+        "Pipfile",
+        "setup.cfg",
+        "setup.py",
+    }
+)
+
+
+def _is_package_boundary_manifest(path: str) -> bool:
+    name = PurePosixPath(path).name
+    return name in _PACKAGE_BOUNDARY_MANIFEST_NAMES or (
+        name.startswith("requirements") and name.endswith(".txt")
+    )
 
 
 @dataclass(frozen=True)
@@ -163,7 +182,7 @@ def _test_signal_kind(path: str) -> str | None:
 
 @repository_adapter(
     adapter_id="core.repository-topology",
-    version="1.3.0",
+    version="1.4.0",
     file_patterns=("**/*", "*"),
     supported_categories=(
         "repository_topology",
@@ -196,7 +215,7 @@ def _topology(context: AdapterContext) -> AdapterResult:
             kind = "IGNORE_POLICY"
         elif name == ".gitmodules":
             kind = "SUBMODULE_CONFIG"
-        elif name in {"package.json", "pyproject.toml", "Cargo.toml", "go.mod"}:
+        elif _is_package_boundary_manifest(file.path):
             kind = "PACKAGE_BOUNDARY_MANIFEST"
         else:
             kind = "TRACKED_FILE"
@@ -342,6 +361,19 @@ def _topology(context: AdapterContext) -> AdapterResult:
                     ),
                 )
             )
+        if name == ".env" or name.startswith(".env."):
+            items.append(
+                (
+                    "delivery_environments",
+                    _item(file, "ENVIRONMENT_CONFIGURATION_SHAPE", "core.repository-topology"),
+                )
+            )
+            items.append(
+                (
+                    "security_privacy",
+                    _item(file, "SECRET_CONFIGURATION_BOUNDARY", "core.repository-topology"),
+                )
+            )
 
     roots: dict[tuple[str, str], set[str]] = {}
     for file in context.files:
@@ -368,8 +400,7 @@ def _topology(context: AdapterContext) -> AdapterResult:
             roots.setdefault((kind, root), set()).add(file.path)
     boundary_roots = {root for _kind, root in roots}
     for file in context.files:
-        name = PurePosixPath(file.path).name
-        if name not in {"package.json", "pyproject.toml", "Cargo.toml", "go.mod"}:
+        if not _is_package_boundary_manifest(file.path):
             continue
         parent = PurePosixPath(file.path).parent
         root = "." if str(parent) == "." else str(parent)
@@ -384,11 +415,7 @@ def _topology(context: AdapterContext) -> AdapterResult:
         confidence = (
             "HIGH"
             if evidence_paths
-            and all(
-                PurePosixPath(path).name
-                in {"package.json", "pyproject.toml", "Cargo.toml", "go.mod"}
-                for path in evidence_paths
-            )
+            and all(_is_package_boundary_manifest(path) for path in evidence_paths)
             else "MEDIUM"
         )
         boundaries.append(

--- a/src/pmpe/repository/adapters.py
+++ b/src/pmpe/repository/adapters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import configparser
 import fnmatch
 import json
+import posixpath
 import re
+import shlex
 import tomllib
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -15,7 +17,7 @@ import yaml
 
 from pmpe.repository.models import BoundaryCandidate, EvidenceItem, Finding
 
-DETECTOR_VERSION = "1.12.0"
+DETECTOR_VERSION = "1.13.0"
 
 _PACKAGE_BOUNDARY_MANIFEST_NAMES = frozenset(
     {
@@ -209,6 +211,56 @@ def _entry_point_signal_kind(path: str) -> str | None:
     if name in {"__main__.py", "app.py", "cli.py", "main.py", "manage.py", "server.py"}:
         return "ENTRY_POINT_FILE_SIGNAL"
     return None
+
+
+def _manifest_relative_path(manifest_path: str, declared_path: str) -> str | None:
+    """Resolve a simple manifest-relative path without allowing root escape."""
+
+    if (
+        not declared_path
+        or "\0" in declared_path
+        or "\\" in declared_path
+        or PurePosixPath(declared_path).is_absolute()
+    ):
+        return None
+    parent = str(PurePosixPath(manifest_path).parent)
+    resolved = posixpath.normpath(posixpath.join(parent, declared_path))
+    if resolved in {"", ".", ".."} or resolved.startswith("../"):
+        return None
+    return resolved
+
+
+def _openapi_typescript_relationship(command: str) -> tuple[str, str] | None:
+    """Parse the supported data-only openapi-typescript invocation shape."""
+
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return None
+    if tokens[:1] == ["npx"]:
+        tokens = tokens[1:]
+    if not tokens or tokens[0] != "openapi-typescript":
+        return None
+    if any(token in {"&&", "||", ";", "|", ">", ">>"} for token in tokens):
+        return None
+    output: str | None = None
+    positional: list[str] = []
+    index = 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token in {"-o", "--output"}:
+            if output is not None or index + 1 >= len(tokens):
+                return None
+            output = tokens[index + 1]
+            index += 2
+            continue
+        if token.startswith("-"):
+            return None
+        positional.append(token)
+        index += 1
+    if len(positional) != 1 or output is None:
+        return None
+    return positional[0], output
 
 
 @repository_adapter(
@@ -1231,8 +1283,10 @@ def _valid_ci_structure(path: str, value: object) -> bool:
 
 @repository_adapter(
     adapter_id="interface.schema-api",
-    version="1.3.0",
+    version="1.4.0",
     file_patterns=(
+        "package.json",
+        "**/package.json",
         "*openapi*",
         "**/*openapi*",
         "*asyncapi*",
@@ -1254,15 +1308,138 @@ def _valid_ci_structure(path: str, value: object) -> bool:
         "generate*",
         "**/generate*",
         "scripts/**",
+        "**/scripts/**",
     ),
     supported_categories=("apis_data", "languages_build_ecosystems"),
 )
 def _interfaces(context: AdapterContext) -> AdapterResult:
     items: list[tuple[str, EvidenceItem]] = []
     findings: list[Finding] = []
+    files_by_path = {file.path: file for file in context.files}
     for file in context.files:
         lowered = file.path.lower()
         confidence = "HIGH"
+        location = "file"
+        if PurePosixPath(lowered).name == "package.json":
+            if file.content is None or file.binary:
+                continue
+            try:
+                manifest = json.loads(file.content)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            scripts = manifest.get("scripts") if isinstance(manifest, dict) else None
+            if not isinstance(scripts, dict):
+                continue
+            for script_name, command in sorted(scripts.items()):
+                if not isinstance(script_name, str) or not isinstance(command, str):
+                    continue
+                codegen_relevant = "openapi-typescript" in command or (
+                    "api" in script_name.lower() and "generat" in script_name.lower()
+                )
+                if not codegen_relevant:
+                    continue
+                relationship = _openapi_typescript_relationship(command)
+                if relationship is None:
+                    findings.append(
+                        _finding(
+                            "INTERFACE.CODEGEN_RELATIONSHIP_UNSUPPORTED",
+                            "apis_data",
+                            "A tracked API-client generation declaration cannot be represented "
+                            "by the supported deterministic command grammar.",
+                            (file.path,),
+                            "interface.schema-api",
+                            severity="HIGH",
+                            blocking=True,
+                        )
+                    )
+                    continue
+                raw_input, raw_output = relationship
+                input_path = _manifest_relative_path(file.path, raw_input)
+                output_path = _manifest_relative_path(file.path, raw_output)
+                if (
+                    input_path is None
+                    or output_path is None
+                    or input_path not in files_by_path
+                    or output_path not in files_by_path
+                ):
+                    findings.append(
+                        _finding(
+                            "INTERFACE.CODEGEN_RELATIONSHIP_INCOMPLETE",
+                            "apis_data",
+                            "A tracked API-client generation declaration does not bind one "
+                            "existing tracked input to one existing tracked output.",
+                            (file.path,),
+                            "interface.schema-api",
+                            severity="HIGH",
+                            blocking=True,
+                        )
+                    )
+                    continue
+                relationship_location = f"{file.path}#scripts.{script_name}"
+                for related, kind in (
+                    (file, "CODE_GENERATION_DECLARATION"),
+                    (files_by_path[input_path], "CODE_GENERATION_INPUT"),
+                    (files_by_path[output_path], "CODE_GENERATION_OUTPUT"),
+                ):
+                    items.append(
+                        (
+                            "apis_data",
+                            _item(
+                                related,
+                                kind,
+                                "interface.schema-api",
+                                location=relationship_location,
+                            ),
+                        )
+                    )
+            continue
+        if lowered.endswith("/scripts/export_openapi.py"):
+            target_path = str(PurePosixPath(file.path).parent.parent / "openapi.json")
+            target = files_by_path.get(target_path)
+            content = (
+                file.content.decode("utf-8", errors="strict")
+                if file.content is not None and not file.binary
+                else ""
+            )
+            if target is None or "openapi.json" not in content or "write_text" not in content:
+                findings.append(
+                    _finding(
+                        "INTERFACE.CODEGEN_RELATIONSHIP_INCOMPLETE",
+                        "apis_data",
+                        "The tracked OpenAPI export entry point does not bind to its expected "
+                        "tracked OpenAPI output using a supported deterministic signal.",
+                        tuple(sorted({file.path, target_path})),
+                        "interface.schema-api",
+                        severity="HIGH",
+                        blocking=True,
+                    )
+                )
+                continue
+            location = f"{file.path}#export"
+            items.extend(
+                (
+                    (
+                        "apis_data",
+                        _item(
+                            file,
+                            "CODE_GENERATOR_SIGNAL",
+                            "interface.schema-api",
+                            confidence="MEDIUM",
+                            location=location,
+                        ),
+                    ),
+                    (
+                        "apis_data",
+                        _item(
+                            target,
+                            "CODE_GENERATION_OUTPUT",
+                            "interface.schema-api",
+                            location=location,
+                        ),
+                    ),
+                )
+            )
+            continue
         if "openapi" in lowered:
             kind = "OPENAPI"
         elif "asyncapi" in lowered:
@@ -1366,7 +1543,13 @@ def _interfaces(context: AdapterContext) -> AdapterResult:
         items.append(
             (
                 "apis_data",
-                _item(file, kind, "interface.schema-api", confidence=confidence),
+                _item(
+                    file,
+                    kind,
+                    "interface.schema-api",
+                    confidence=confidence,
+                    location=location,
+                ),
             )
         )
     return AdapterResult(items=tuple(items), findings=tuple(findings))

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import re
 import selectors
+import signal
 import subprocess
 import time
 import uuid
@@ -35,7 +36,7 @@ from pmpe.repository.scanner import (
     RepositorySecurityError,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.1.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.2.0"
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
 _SAFE_REF = re.compile(r"^(?:HEAD|[A-Za-z0-9][A-Za-z0-9._/-]{0,255})$")
 
@@ -85,8 +86,13 @@ class UuidObservationIds:
 class GovernanceCommandRunner:
     """Allowlisted local Git observation commands with mutation subcommands refused."""
 
-    identity = "git-governance-readonly/1.1.0"
-    _allowed = {"status", "rev-parse", "for-each-ref", "rev-list", "worktree"}
+    identity = "git-governance-readonly/1.2.0"
+    _allowed = {"config", "status", "rev-parse", "for-each-ref", "rev-list", "worktree"}
+    _filter_probe = (
+        "--name-only",
+        "--get-regexp",
+        r"^filter\..*\.(clean|smudge|process)$",
+    )
 
     def __init__(self, *, max_output_bytes: int = 8_000_000) -> None:
         self.max_output_bytes = max_output_bytes
@@ -101,6 +107,8 @@ class GovernanceCommandRunner:
     ) -> CommandResult:
         if len(args) < 2 or args[0] != "git" or args[1] not in self._allowed:
             raise RepositorySecurityError("command is outside the governance read-only allowlist")
+        if args[1] == "config" and args[2:] != self._filter_probe:
+            raise RepositorySecurityError("Git configuration reads are outside the safe probe")
         if args[1] == "worktree" and (len(args) < 3 or args[2] != "list"):
             raise RepositorySecurityError("mutating Git worktree command was refused")
         safe_environment = {
@@ -110,13 +118,19 @@ class GovernanceCommandRunner:
             "GIT_TERMINAL_PROMPT": "0",
             "GIT_OPTIONAL_LOCKS": "0",
             "GIT_NO_LAZY_FETCH": "1",
-            "GIT_CONFIG_COUNT": "3",
+            "GIT_CONFIG_COUNT": "6",
             "GIT_CONFIG_KEY_0": "core.fsmonitor",
             "GIT_CONFIG_VALUE_0": "false",
             "GIT_CONFIG_KEY_1": "core.untrackedCache",
             "GIT_CONFIG_VALUE_1": "false",
             "GIT_CONFIG_KEY_2": "core.preloadIndex",
             "GIT_CONFIG_VALUE_2": "false",
+            "GIT_CONFIG_KEY_3": "core.attributesFile",
+            "GIT_CONFIG_VALUE_3": os.devnull,
+            "GIT_CONFIG_KEY_4": "core.excludesFile",
+            "GIT_CONFIG_VALUE_4": os.devnull,
+            "GIT_CONFIG_KEY_5": "submodule.recurse",
+            "GIT_CONFIG_VALUE_5": "false",
             "LC_ALL": "C",
         }
         try:
@@ -126,6 +140,7 @@ class GovernanceCommandRunner:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 env=safe_environment,
+                start_new_session=True,
             )
         except OSError:
             raise
@@ -143,25 +158,23 @@ class GovernanceCommandRunner:
             while True:
                 if cancellation is not None and cancellation.cancelled():
                     cancelled = True
-                    process.terminate()
+                    _signal_process_group(process, signal.SIGTERM)
                     break
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     timed_out = True
-                    process.kill()
+                    _signal_process_group(process, signal.SIGKILL)
                     break
-                events = selector.select(remaining)
+                events = selector.select(min(remaining, 0.1))
                 if not events:
-                    timed_out = True
-                    process.kill()
-                    break
+                    continue
                 chunk = os.read(process.stdout.fileno(), 65_536)
                 if not chunk:
                     break
                 payload.extend(chunk)
                 if len(payload) > self.max_output_bytes:
                     output_exceeded = True
-                    process.terminate()
+                    _signal_process_group(process, signal.SIGTERM)
                     break
         finally:
             selector.close()
@@ -169,7 +182,7 @@ class GovernanceCommandRunner:
         try:
             returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
         except subprocess.TimeoutExpired:
-            process.kill()
+            _signal_process_group(process, signal.SIGKILL)
             returncode = process.wait()
             timed_out = True
         return CommandResult(
@@ -179,6 +192,22 @@ class GovernanceCommandRunner:
             stderr=b"",
             timed_out=timed_out,
         )
+
+
+def _signal_process_group(process: subprocess.Popen[bytes], action: signal.Signals) -> None:
+    """Stop the isolated Git process group, including any unexpected descendant."""
+
+    try:
+        os.killpg(process.pid, action)
+    except ProcessLookupError:
+        return
+    except PermissionError:
+        # Content filters are refused and submodule recursion is disabled before
+        # mutable observation, so the allowlisted Git parent is the only expected
+        # process on hosts that prohibit group signalling.
+        process.send_signal(action)
+    except OSError as exc:
+        raise RepositorySecurityError("bounded Git process group could not be terminated") from exc
 
 
 def _decode(result: CommandResult) -> str:
@@ -448,7 +477,27 @@ class GovernanceCollector:
         ):
             raise RepositoryIntelligenceError("governance observation budgets must be positive")
         root = Path(repository_root).resolve()
-        status_raw = self._run(root, "status", "--porcelain=v1", "--untracked-files=all")
+        filter_probe = self._execute(
+            root,
+            ("git", "config", *GovernanceCommandRunner._filter_probe),
+        )
+        if filter_probe.timed_out:
+            raise RepositoryIntelligenceError("Git content-filter safety probe timed out")
+        if filter_probe.returncode == 126:
+            raise RepositoryIntelligenceError("governance observation was cancelled")
+        if filter_probe.returncode == 0:
+            raise RepositorySecurityError(
+                "repository-defined Git content filters prevent a code-free governance scan"
+            )
+        if filter_probe.returncode != 1:
+            raise RepositoryIntelligenceError("Git content-filter safety could not be proven")
+        status_raw = self._run(
+            root,
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignore-submodules=all",
+        )
         head_sha = self._run(root, "rev-parse", "HEAD").strip()
         if not re.fullmatch(r"[0-9a-f]{40}", head_sha):
             raise RepositoryIntelligenceError("local Git HEAD is malformed")

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import multiprocessing
 import os
 import re
 import selectors
@@ -10,6 +11,7 @@ import signal
 import subprocess
 import time
 import uuid
+from contextlib import suppress
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
@@ -36,8 +38,10 @@ from pmpe.repository.scanner import (
     RepositorySecurityError,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.3.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.4.0"
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
+_REQUIRED_GOVERNANCE_FACTS = frozenset({"branch_protection", "review_policy"})
+_OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
 _SAFE_REF = re.compile(r"^(?:HEAD|[A-Za-z0-9][A-Za-z0-9._/-]{0,255})$")
 
 
@@ -46,6 +50,15 @@ def _valid_ref(value: str) -> bool:
         bool(_SAFE_REF.fullmatch(value))
         and not any(marker in value for marker in ("..", "@{", "//", "\\"))
         and not value.endswith(("/", ".", ".lock"))
+    )
+
+
+def _valid_object_id(value: str, object_format: str) -> bool:
+    length = _OBJECT_FORMAT_LENGTH.get(object_format)
+    return (
+        length is not None
+        and len(value) == length
+        and all(character in "0123456789abcdef" for character in value)
     )
 
 
@@ -83,10 +96,65 @@ class UuidObservationIds:
         return f"OBS-{uuid.uuid4()}"
 
 
+class _SharedCancellation:
+    def __init__(self, event: Any) -> None:
+        self._event = event
+
+    def cancelled(self) -> bool:
+        return bool(self._event.is_set())
+
+
+def _remote_provider_worker(
+    connection: Any,
+    provider: RemoteProvider,
+    repository: str,
+    ref: str,
+    timeout_seconds: int,
+    max_output_bytes: int,
+    max_items: int,
+    cancellation_event: Any,
+) -> None:
+    """Run injected remote I/O in a killable, output-bounded process."""
+
+    try:
+        os.setsid()
+        safe_path = os.environ.get("PATH", "/usr/bin:/bin")
+        os.environ.clear()
+        os.environ.update(
+            {
+                "PATH": safe_path,
+                "LC_ALL": "C",
+                "GIT_TERMINAL_PROMPT": "0",
+            }
+        )
+        connection.send(("READY", None))
+        result = provider.collect(
+            repository,
+            ref,
+            timeout_seconds=timeout_seconds,
+            max_output_bytes=max_output_bytes,
+            max_items=max_items,
+            cancellation=_SharedCancellation(cancellation_event),
+        )
+        if not isinstance(result, dict):
+            raise TypeError("remote provider result must be an object")
+        _bounded_remote_shape(result, max_bytes=max_output_bytes, max_items=max_items)
+        connection.send(("RESULT", result))
+    except PermissionError:
+        connection.send(("PERMISSION", None))
+    except BaseException as exc:
+        # Exception text can contain credentials. Only the safe type identity crosses
+        # the process boundary and is later sanitized before persistence.
+        with suppress(BrokenPipeError, EOFError, OSError):
+            connection.send(("ERROR", type(exc).__name__))
+    finally:
+        connection.close()
+
+
 class GovernanceCommandRunner:
     """Allowlisted local Git observation commands with mutation subcommands refused."""
 
-    identity = "git-governance-readonly/1.3.0"
+    identity = "git-governance-readonly/1.4.0"
     _allowed = {
         "config",
         "status",
@@ -191,10 +259,17 @@ class GovernanceCommandRunner:
             selector.close()
             process.stdout.close()
         try:
-            returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
+            returncode = process.wait(
+                timeout=(
+                    0.25 if cancelled or output_exceeded else max(0.1, deadline - time.monotonic())
+                )
+            )
         except subprocess.TimeoutExpired:
             _signal_process_group(process, signal.SIGKILL)
-            returncode = process.wait()
+            try:
+                returncode = process.wait(timeout=1.0)
+            except subprocess.TimeoutExpired as exc:
+                raise RepositorySecurityError("bounded Git process could not be reaped") from exc
             timed_out = True
         return CommandResult(
             args=args,
@@ -212,13 +287,22 @@ def _signal_process_group(process: subprocess.Popen[bytes], action: signal.Signa
         os.killpg(process.pid, action)
     except ProcessLookupError:
         return
-    except PermissionError:
-        # Content filters are refused and submodule recursion is disabled before
-        # mutable observation, so the allowlisted Git parent is the only expected
-        # process on hosts that prohibit group signalling.
-        process.send_signal(action)
-    except OSError as exc:
-        raise RepositorySecurityError("bounded Git process group could not be terminated") from exc
+    except OSError:
+        # Content filters are refused and submodule recursion is disabled. Always
+        # fall back to the parent and let the caller prove it was reaped.
+        try:
+            process.send_signal(action)
+        except ProcessLookupError:
+            return
+        except OSError:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                return
+            except OSError as exc:
+                raise RepositorySecurityError(
+                    "bounded Git process group and parent could not be terminated"
+                ) from exc
 
 
 def _decode(result: CommandResult) -> str:
@@ -266,6 +350,55 @@ def _bounded_remote_shape(value: Any, *, max_bytes: int, max_items: int) -> None
             raise RepositoryIntelligenceError("remote observation contains an unsupported value")
         if encoded_bytes > max_bytes:
             raise RepositoryIntelligenceError("remote observation byte budget was exceeded")
+
+
+def _stop_remote_process(process: Any) -> None:
+    """Terminate and reap the isolated provider process and its descendants."""
+
+    if not process.is_alive():
+        process.join(timeout=0.1)
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        process.terminate()
+    process.join(timeout=0.25)
+    if process.is_alive():
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            process.kill()
+        process.join(timeout=1.0)
+    if process.is_alive():
+        raise RepositorySecurityError("bounded remote provider process could not be reaped")
+
+
+def _governance_content_is_complete(value: dict[str, Any]) -> bool:
+    if not _REQUIRED_GOVERNANCE_FACTS.issubset(value):
+        return False
+    if any(value[fact] in ({}, [], "") for fact in _REQUIRED_GOVERNANCE_FACTS):
+        return False
+    pending: list[Any] = [value]
+    visited = 0
+    while pending:
+        current = pending.pop()
+        visited += 1
+        if visited > 20_000:
+            return False
+        if current is None:
+            return False
+        if isinstance(current, str) and current.strip().upper() in {
+            "UNKNOWN",
+            "UNSUPPORTED",
+            "BLOCKED",
+            "UNAVAILABLE",
+        }:
+            return False
+        if isinstance(current, dict):
+            pending.extend(current.values())
+        elif isinstance(current, (list, tuple)):
+            pending.extend(current)
+    return True
 
 
 def _pagination_is_complete(
@@ -389,8 +522,16 @@ class GovernanceCollector:
         self._commands = 0
         self._local_unknowns: list[UnknownFact] = []
 
+    def _is_cancelled(self) -> bool:
+        if self.cancellation is None:
+            return False
+        try:
+            return self.cancellation.cancelled()
+        except Exception:
+            return True
+
     def _execute(self, root: Path, command: tuple[str, ...]) -> CommandResult:
-        if self.cancellation is not None and self.cancellation.cancelled():
+        if self._is_cancelled():
             raise RepositoryIntelligenceError("governance observation was cancelled")
         if self._commands >= self.max_commands:
             raise RepositoryIntelligenceError("governance command budget was exhausted")
@@ -418,6 +559,82 @@ class GovernanceCollector:
             return _decode(result)
         except (FileNotFoundError, OSError) as exc:
             raise RepositoryIntelligenceError("local Git observation is unavailable") from exc
+
+    def _collect_remote_bounded(self, ref: str) -> dict[str, Any]:
+        if self.remote_provider is None:
+            raise RepositoryIntelligenceError("no remote provider was configured")
+        if not hasattr(os, "fork") or not hasattr(os, "setsid"):
+            raise RepositoryIntelligenceError(
+                "bounded remote provider execution is unsupported on this platform"
+            )
+        context = multiprocessing.get_context("fork")
+        receiver, sender = context.Pipe(duplex=False)
+        cancellation_event = context.Event()
+        process = context.Process(
+            target=_remote_provider_worker,
+            args=(
+                sender,
+                self.remote_provider,
+                self.repository,
+                ref,
+                self.timeout,
+                self.max_output_bytes,
+                self.max_remote_items,
+                cancellation_event,
+            ),
+            daemon=True,
+            name="pmpe-readonly-remote-provider",
+        )
+        try:
+            process.start()
+        except (OSError, RuntimeError) as exc:
+            receiver.close()
+            sender.close()
+            raise RepositoryIntelligenceError(
+                "bounded remote provider process could not start"
+            ) from exc
+        sender.close()
+        deadline = time.monotonic() + self.timeout
+        ready = False
+        try:
+            while True:
+                if self._is_cancelled():
+                    cancellation_event.set()
+                    raise RepositoryIntelligenceError(
+                        "bounded remote provider observation was cancelled"
+                    )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise RepositoryIntelligenceError("bounded remote provider timed out")
+                if receiver.poll(min(remaining, 0.05)):
+                    try:
+                        status, payload = receiver.recv()
+                    except EOFError as exc:
+                        raise RepositoryIntelligenceError(
+                            "bounded remote provider exited without evidence"
+                        ) from exc
+                    if status == "READY":
+                        ready = True
+                        continue
+                    if not ready:
+                        raise RepositoryIntelligenceError(
+                            "bounded remote provider isolation was not established"
+                        )
+                    if status == "RESULT" and isinstance(payload, dict):
+                        return cast(dict[str, Any], payload)
+                    if status == "PERMISSION":
+                        raise PermissionError("bounded remote provider denied access")
+                    safe_type = payload if isinstance(payload, str) else "UnknownError"
+                    raise RepositoryIntelligenceError(
+                        f"bounded remote provider failed safely: {safe_type}"
+                    )
+                if not process.is_alive():
+                    raise RepositoryIntelligenceError(
+                        "bounded remote provider exited without complete evidence"
+                    )
+        finally:
+            receiver.close()
+            _stop_remote_process(process)
 
     def _branches(self, root: Path, ref: str) -> tuple[BranchObservation, ...]:
         raw = self._run(
@@ -525,6 +742,12 @@ class GovernanceCollector:
             )
         if filter_probe.returncode != 1:
             raise RepositoryIntelligenceError("Git content-filter safety could not be proven")
+        object_format = self._run(root, "rev-parse", "--show-object-format").strip()
+        object_length = _OBJECT_FORMAT_LENGTH.get(object_format)
+        if object_length is None:
+            raise RepositoryIntelligenceError(
+                f"Git object format {object_format!r} is explicitly unsupported"
+            )
         index_listing = self._run(root, "ls-files", "--stage", "-z")
         gitlinks = 0
         for record in index_listing.split("\0"):
@@ -535,7 +758,9 @@ class GovernanceCollector:
             if separator != "\t" or len(fields) != 3:
                 raise RepositoryIntelligenceError("Git index metadata is malformed")
             mode, object_id, stage = fields
-            if not re.fullmatch(r"[0-7]{6}", mode) or not re.fullmatch(r"[0-9a-f]{40}", object_id):
+            if not re.fullmatch(r"[0-7]{6}", mode) or not _valid_object_id(
+                object_id, object_format
+            ):
                 raise RepositoryIntelligenceError("Git index metadata is malformed")
             if stage != "0":
                 self._local_unknowns.append(
@@ -566,7 +791,7 @@ class GovernanceCollector:
             "--ignore-submodules=all",
         )
         head_sha = self._run(root, "rev-parse", "HEAD").strip()
-        if not re.fullmatch(r"[0-9a-f]{40}", head_sha):
+        if not _valid_object_id(head_sha, object_format):
             raise RepositoryIntelligenceError("local Git HEAD is malformed")
         index_dirty = False
         worktree_dirty = False
@@ -584,9 +809,15 @@ class GovernanceCollector:
             worktree_dirty=worktree_dirty,
             untracked=untracked,
             head_sha=head_sha,
+            git_object_format=object_format,
         )
         branches = self._branches(root, ref)
         worktrees = self._worktrees(root)
+        if any(not _valid_object_id(item.sha, object_format) for item in branches) or any(
+            item.head_sha != "UNKNOWN" and not _valid_object_id(item.head_sha, object_format)
+            for item in worktrees
+        ):
+            raise RepositoryIntelligenceError("local Git reference identity is malformed")
         observed_at = self.clock.now()
         observation_id = self.id_provider.new_id()
         observed_at_value = _parse_utc(observed_at, field="observation time")
@@ -614,19 +845,7 @@ class GovernanceCollector:
             tool_identity = self.remote_provider.tool_identity
             api_version = self.remote_provider.api_version
             try:
-                raw_remote = self.remote_provider.collect(
-                    self.repository,
-                    ref,
-                    timeout_seconds=self.timeout,
-                    max_output_bytes=self.max_output_bytes,
-                    max_items=self.max_remote_items,
-                    cancellation=self.cancellation,
-                )
-                _bounded_remote_shape(
-                    raw_remote,
-                    max_bytes=self.max_output_bytes,
-                    max_items=self.max_remote_items,
-                )
+                raw_remote = self._collect_remote_bounded(ref)
             except (PermissionError, OSError):
                 disposition = "BLOCKED"
                 unknowns = (
@@ -685,6 +904,7 @@ class GovernanceCollector:
                         for item in sanitized_remote.get("issues", [])
                     )
                     governance = cast(dict[str, Any], sanitized_remote.get("governance", {}))
+                    governance_complete = _governance_content_is_complete(governance)
                     provenance = tuple(
                         QueryProvenance(
                             surface=str(item["surface"]),
@@ -705,9 +925,9 @@ class GovernanceCollector:
                         for item in sanitized_remote.get("unknowns", [])
                     )
                     if any(
-                        not re.fullmatch(r"[0-9a-f]{40}", item.sha) for item in remote_branches
+                        not _valid_object_id(item.sha, object_format) for item in remote_branches
                     ) or any(
-                        not re.fullmatch(r"[0-9a-f]{40}", item.head) for item in pull_requests
+                        not _valid_object_id(item.head, object_format) for item in pull_requests
                     ):
                         raise ValueError("remote commit identity is malformed")
                     if any(
@@ -764,7 +984,32 @@ class GovernanceCollector:
                                 ),
                             ),
                         )
+                    if not governance_complete:
+                        disposition = "BLOCKED"
+                        unknowns = (
+                            *unknowns,
+                            UnknownFact(
+                                fact="remote_governance_completeness",
+                                status="BLOCKED",
+                                reason=(
+                                    "Required branch-protection or review-policy facts are "
+                                    "missing, empty, or explicitly unknown."
+                                ),
+                            ),
+                        )
 
+        if self._is_cancelled() and not any(
+            item.fact == "observation_cancellation" for item in unknowns
+        ):
+            disposition = "BLOCKED"
+            unknowns = (
+                *unknowns,
+                UnknownFact(
+                    fact="observation_cancellation",
+                    status="BLOCKED",
+                    reason="Mutable governance observation was cancelled before finalization.",
+                ),
+            )
         collector_digest = _governance_implementation_digest()
         inputs = {
             "repository": self.repository,
@@ -824,6 +1069,22 @@ class GovernanceCollector:
             sanitized = cast(dict[str, Any], self.redactor.sanitize(draft.as_dict()))
         except (RedactionError, Exception) as exc:
             raise RepositorySecurityError("observation redaction failed") from exc
+        if self._is_cancelled() and not any(
+            item.get("fact") == "observation_cancellation"
+            for item in cast(list[dict[str, Any]], sanitized["unknowns"])
+        ):
+            cast(list[dict[str, Any]], sanitized["unknowns"]).append(
+                {
+                    "fact": "observation_cancellation",
+                    "status": "BLOCKED",
+                    "reason": "Mutable governance observation was cancelled before finalization.",
+                }
+            )
+            sanitized["unknowns"] = sorted(
+                cast(list[dict[str, Any]], sanitized["unknowns"]),
+                key=lambda item: (item["fact"], item["status"], item["reason"]),
+            )
+            sanitized["disposition"] = "BLOCKED"
         sanitized["observation_output_digest"] = canonical_digest(
             {key: value for key, value in sanitized.items() if key != "observation_output_digest"}
         )

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -17,6 +17,7 @@ from contextlib import suppress
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Protocol, cast, final
 
 from pmpe.contracts.canonical import canonical_digest
@@ -41,6 +42,7 @@ from pmpe.repository.scanner import (
     RepositoryIntelligenceError,
     RepositorySecurityError,
     _cancellation_requested,
+    _implementation_module_evidence,
     _implementation_source_evidence,
     _spawn_guarded_git,
     _stop_guarded_process_group,
@@ -54,6 +56,23 @@ GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.redaction",
     "repository.scanner",
     "contracts.canonical",
+)
+_GOVERNANCE_IMPLEMENTATION_PATHS = MappingProxyType(
+    {
+        "repository.governance": Path(__file__).resolve(),
+        "repository.models": Path(__file__).resolve().parent / "models.py",
+        "repository.redaction": Path(__file__).resolve().parent / "redaction.py",
+        "repository.scanner": Path(__file__).resolve().parent / "scanner.py",
+        "contracts.canonical": Path(__file__).resolve().parent.parent
+        / "contracts"
+        / "canonical.py",
+    }
+)
+_GOVERNANCE_IMPORTED_SOURCE_DIGESTS = MappingProxyType(
+    {
+        name: "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+        for name, path in _GOVERNANCE_IMPLEMENTATION_PATHS.items()
+    }
 )
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
 _GOVERNANCE_SCHEMA_VERSION = "pmpe.repository-governance/v2"
@@ -910,26 +929,10 @@ def _validate_remote_payload_types(value: dict[str, Any]) -> None:
 def _governance_implementation_digest(
     extension_evidence: tuple[dict[str, str], ...] = (),
 ) -> str:
-    package_root = Path(__file__).resolve().parent
-    sources = {
-        "repository.governance": package_root / "governance.py",
-        "repository.models": package_root / "models.py",
-        "repository.redaction": package_root / "redaction.py",
-        "repository.scanner": package_root / "scanner.py",
-        "contracts.canonical": package_root.parent / "contracts" / "canonical.py",
-    }
-    try:
-        evidence: list[dict[str, str]] = [
-            {
-                "module": name,
-                "source_digest": "sha256:" + hashlib.sha256(sources[name].read_bytes()).hexdigest(),
-            }
-            for name in GOVERNANCE_IMPLEMENTATION_MODULES
-        ]
-    except OSError as exc:
-        raise RepositoryIntelligenceError(
-            "governance implementation bytes are unavailable for provenance binding"
-        ) from exc
+    evidence = _implementation_module_evidence(
+        _GOVERNANCE_IMPLEMENTATION_PATHS,
+        _GOVERNANCE_IMPORTED_SOURCE_DIGESTS,
+    )
     evidence.extend(extension_evidence)
     return canonical_digest(
         sorted(evidence, key=lambda item: (item.get("label", ""), item["module"]))
@@ -1022,6 +1025,10 @@ class GovernanceCollector:
             )
         if command_runner is not None and type(command_runner) is not GovernanceCommandRunner:
             raise RepositorySecurityError("governance observations require the sealed Git reader")
+        if command_runner is not None and command_runner.max_output_bytes != max_output_bytes:
+            raise RepositorySecurityError(
+                "governance command runner output budget must match the recorded collector budget"
+            )
         if redactor is not None:
             raise RepositorySecurityError(
                 "governance observations use only the sealed fixed state-free redaction policy"

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -41,9 +41,12 @@ from pmpe.repository.scanner import (
     RepositorySecurityError,
     _cancellation_requested,
     _implementation_source_evidence,
+    _spawn_guarded_git,
+    _stop_guarded_process_group,
+    _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.7.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.8.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -54,6 +57,21 @@ GOVERNANCE_IMPLEMENTATION_MODULES = (
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
 _REQUIRED_GOVERNANCE_FACTS = frozenset({"branch_protection", "review_policy"})
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
+_REMOTE_PAYLOAD_FIELDS = frozenset(
+    {
+        "complete",
+        "repository",
+        "ref",
+        "observed_at",
+        "coverage",
+        "remote_branches",
+        "pull_requests",
+        "issues",
+        "governance",
+        "query_provenance",
+        "unknowns",
+    }
+)
 _SAFE_REF = re.compile(r"^(?:HEAD|[A-Za-z0-9][A-Za-z0-9._/-]{0,255})$")
 
 
@@ -128,8 +146,10 @@ def _remote_provider_worker(
 ) -> None:
     """Run injected remote I/O in a killable, output-bounded process."""
 
+    isolated = False
     try:
         os.setsid()
+        isolated = True
         safe_path = os.environ.get("PATH", "/usr/bin:/bin")
         os.environ.clear()
         os.environ.update(
@@ -170,12 +190,15 @@ def _remote_provider_worker(
             connection.send_bytes(b"ERROR\0" + type(exc).__name__.encode("ascii", errors="replace"))
     finally:
         connection.close()
+        if isolated:
+            while True:
+                signal.pause()
 
 
 class GovernanceCommandRunner:
     """Allowlisted local Git observation commands with mutation subcommands refused."""
 
-    identity = "git-governance-readonly/1.6.0"
+    identity = "git-governance-readonly/1.7.0"
     _allowed = {
         "config",
         "status",
@@ -233,19 +256,9 @@ class GovernanceCommandRunner:
             "GIT_CONFIG_VALUE_5": "false",
             "LC_ALL": "C",
         }
-        try:
-            process = subprocess.Popen(
-                args,
-                cwd=cwd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
-                env=safe_environment,
-                start_new_session=True,
-            )
-        except OSError:
-            raise
+        process, guard = _spawn_guarded_git(args, cwd, safe_environment)
         if process.stdout is None:
-            process.kill()
+            _stop_guarded_process_group(process, guard)
             raise RepositoryIntelligenceError("governance command output is unavailable")
         selector = selectors.DefaultSelector()
         selector.register(process.stdout, selectors.EVENT_READ)
@@ -274,26 +287,14 @@ class GovernanceCommandRunner:
                     output_exceeded = True
                     break
         except BaseException:
-            _stop_governance_process_group(process)
+            _stop_guarded_process_group(process, guard)
             raise
         finally:
             selector.close()
             process.stdout.close()
-        if cancelled or output_exceeded or timed_out:
-            _stop_governance_process_group(process)
-            returncode = process.returncode
-        else:
-            try:
-                returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
-            except subprocess.TimeoutExpired:
-                timed_out = True
-                _stop_governance_process_group(process)
-                returncode = process.returncode
-            else:
-                if not _signal_process_group(process, signal.SIGKILL):
-                    raise RepositorySecurityError(
-                        "governance Git descendant termination could not be proven"
-                    )
+        _stop_guarded_process_group(process, guard)
+        returncode = process.returncode
+        assert returncode is not None
         return CommandResult(
             args=args,
             returncode=126 if cancelled else 125 if output_exceeded else returncode,
@@ -334,21 +335,6 @@ def _signal_process_group(process: subprocess.Popen[bytes], action: signal.Signa
                     "bounded Git process group and parent could not be terminated"
                 ) from exc
         return False
-
-
-def _stop_governance_process_group(process: subprocess.Popen[bytes]) -> None:
-    """Terminate, fence, and reap a governance command and every descendant."""
-
-    _signal_process_group(process, signal.SIGTERM)
-    with suppress(subprocess.TimeoutExpired):
-        process.wait(timeout=0.25)
-    group_proven = _signal_process_group(process, signal.SIGKILL)
-    try:
-        process.wait(timeout=1.0)
-    except subprocess.TimeoutExpired as exc:
-        raise RepositorySecurityError("bounded Git process could not be reaped") from exc
-    if not group_proven:
-        raise RepositorySecurityError("governance Git descendant termination could not be proven")
 
 
 def _decode(result: CommandResult) -> str:
@@ -423,21 +409,16 @@ def _stop_remote_process(process: Any) -> None:
     """Terminate and reap the isolated provider process and its descendants."""
 
     try:
-        os.killpg(process.pid, signal.SIGTERM)
-    except ProcessLookupError:
-        pass
-    except (PermissionError, OSError):
-        if process.is_alive():
-            process.terminate()
-    process.join(timeout=0.25)
-    try:
         os.killpg(process.pid, signal.SIGKILL)
         group_proven = True
     except ProcessLookupError:
-        group_proven = True
+        group_proven = _wait_for_exit_without_reaping(process, 0.0)
+        if not group_proven:
+            with suppress(ProcessLookupError, OSError):
+                process.kill()
     except (PermissionError, OSError):
         group_proven = False
-        if process.is_alive():
+        with suppress(ProcessLookupError, OSError):
             process.kill()
     process.join(timeout=1.0)
     if process.is_alive():
@@ -511,7 +492,8 @@ def _validate_remote_payload_types(value: dict[str, Any]) -> None:
     """Reject provider coercion before mutable evidence becomes authoritative."""
 
     if (
-        not isinstance(value.get("complete"), bool)
+        set(value) != _REMOTE_PAYLOAD_FIELDS
+        or not isinstance(value.get("complete"), bool)
         or not _is_str(value.get("repository"))
         or not _is_str(value.get("ref"))
         or not _is_str(value.get("observed_at"))
@@ -804,6 +786,10 @@ class GovernanceCollector:
                             "bounded remote provider isolation was not established"
                         )
                     if status == "RESULT":
+                        if len(payload) > self.max_output_bytes:
+                            raise RepositoryIntelligenceError(
+                                "bounded remote provider result exceeded its byte budget"
+                            )
                         try:
                             decoded = json.loads(payload)
                         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -814,6 +800,11 @@ class GovernanceCollector:
                             raise RepositoryIntelligenceError(
                                 "bounded remote provider result was malformed"
                             )
+                        _bounded_remote_shape(
+                            decoded,
+                            max_bytes=self.max_output_bytes,
+                            max_items=self.max_remote_items,
+                        )
                         return cast(dict[str, Any], decoded)
                     if status == "PERMISSION":
                         raise PermissionError("bounded remote provider denied access")
@@ -824,10 +815,6 @@ class GovernanceCollector:
                     )
                     raise RepositoryIntelligenceError(
                         f"bounded remote provider failed safely: {safe_type}"
-                    )
-                if not process.is_alive():
-                    raise RepositoryIntelligenceError(
-                        "bounded remote provider exited without complete evidence"
                     )
         finally:
             receiver.close()

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -47,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.7.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.8.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -57,7 +57,9 @@ GOVERNANCE_IMPLEMENTATION_MODULES = (
 )
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
 _GOVERNANCE_SCHEMA_VERSION = "pmpe.repository-governance/v1"
-_GOVERNANCE_FIELDS = frozenset({"schema_version", "branch_protection", "review_policy"})
+_GOVERNANCE_FIELDS = frozenset(
+    {"schema_version", "branch_protection", "review_policy", "security_settings"}
+)
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
 _REMOTE_PAYLOAD_FIELDS = frozenset(
     {
@@ -660,6 +662,7 @@ def _governance_content_is_complete(value: dict[str, Any]) -> bool:
         return False
     branch_protection = value["branch_protection"]
     review_policy = value["review_policy"]
+    security_settings = value["security_settings"]
     if (
         not isinstance(branch_protection, dict)
         or set(branch_protection) != {"observed", "required_checks"}
@@ -672,6 +675,11 @@ def _governance_content_is_complete(value: dict[str, Any]) -> bool:
         or set(review_policy) != {"required_approvals"}
         or not _is_int(review_policy.get("required_approvals"))
         or review_policy["required_approvals"] < 0
+        or not isinstance(security_settings, dict)
+        or set(security_settings) != {"observed", "leak_detection", "dependency_alerts"}
+        or security_settings.get("observed") is not True
+        or security_settings.get("leak_detection") not in {"ENABLED", "DISABLED"}
+        or security_settings.get("dependency_alerts") not in {"ENABLED", "DISABLED"}
     ):
         return False
     pending: list[Any] = [value]

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -47,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.9.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/3.0.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -56,7 +56,7 @@ GOVERNANCE_IMPLEMENTATION_MODULES = (
     "contracts.canonical",
 )
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
-_GOVERNANCE_SCHEMA_VERSION = "pmpe.repository-governance/v1"
+_GOVERNANCE_SCHEMA_VERSION = "pmpe.repository-governance/v2"
 _GOVERNANCE_FIELDS = frozenset(
     {"schema_version", "branch_protection", "review_policy", "security_settings"}
 )
@@ -665,16 +665,51 @@ def _governance_content_is_complete(value: dict[str, Any]) -> bool:
     security_settings = value["security_settings"]
     if (
         not isinstance(branch_protection, dict)
-        or set(branch_protection) != {"observed", "required_checks"}
+        or set(branch_protection)
+        != {
+            "observed",
+            "protected",
+            "required_checks",
+            "required_signed_commits",
+            "required_linear_history",
+            "push_restrictions",
+            "allow_force_pushes",
+            "allow_deletions",
+        }
         or branch_protection.get("observed") is not True
+        or not isinstance(branch_protection.get("protected"), bool)
         or not isinstance(branch_protection.get("required_checks"), list)
         or not all(_is_str(item) for item in branch_protection["required_checks"])
         or len(set(branch_protection["required_checks"]))
         != len(branch_protection["required_checks"])
+        or not all(
+            isinstance(branch_protection.get(field), bool)
+            for field in (
+                "required_signed_commits",
+                "required_linear_history",
+                "push_restrictions",
+                "allow_force_pushes",
+                "allow_deletions",
+            )
+        )
         or not isinstance(review_policy, dict)
-        or set(review_policy) != {"required_approvals"}
+        or set(review_policy)
+        != {
+            "required_approvals",
+            "dismiss_stale_reviews",
+            "require_code_owner_reviews",
+            "require_last_push_approval",
+        }
         or not _is_int(review_policy.get("required_approvals"))
         or review_policy["required_approvals"] < 0
+        or not all(
+            isinstance(review_policy.get(field), bool)
+            for field in (
+                "dismiss_stale_reviews",
+                "require_code_owner_reviews",
+                "require_last_push_approval",
+            )
+        )
         or not isinstance(security_settings, dict)
         or set(security_settings) != {"observed", "leak_detection", "dependency_alerts"}
         or security_settings.get("observed") is not True

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -51,7 +51,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.10.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.11.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -1093,12 +1093,12 @@ class GovernanceCollector:
             raise RepositorySecurityError(
                 "governance observations require the sealed cancellation signal"
             )
-        self.snapshot = snapshot
-        self.clock = clock
-        self.id_provider = id_provider
-        self.remote_provider = remote_provider
-        self.runner = command_runner or GovernanceCommandRunner(max_output_bytes=max_output_bytes)
-        self.redactor = EvidenceRedactor(environment={})
+        self._snapshot = snapshot
+        self._clock = clock
+        self._id_provider = id_provider
+        self._remote_provider = remote_provider
+        self._runner = command_runner or GovernanceCommandRunner(max_output_bytes=max_output_bytes)
+        self._redactor = EvidenceRedactor(environment={})
         self.timeout = command_timeout_seconds
         self.max_commands = max_commands
         self.max_branches = max_branches
@@ -1106,7 +1106,7 @@ class GovernanceCollector:
         self.max_remote_items = max_remote_items
         self.max_remote_age_seconds = max_remote_age_seconds
         self.stale_pull_request_after_seconds = stale_pull_request_after_seconds
-        self.cancellation = cancellation
+        self._cancellation = cancellation
         self._command_provenance: list[CommandProvenance] = []
         self._commands = 0
         self._local_unknowns: list[UnknownFact] = []
@@ -1121,8 +1121,116 @@ class GovernanceCollector:
         self._extension_implementation_evidence = tuple(
             _implementation_source_evidence(label, target) for label, target in extension_targets
         )
+        self._sealed_extension_evidence_digest = canonical_digest(
+            self._extension_implementation_evidence
+        )
+        self._sealed_execution_collaborators = (
+            self.snapshot,
+            self.clock,
+            self.id_provider,
+            self.remote_provider,
+            self.runner,
+            self.redactor,
+            self.cancellation,
+            self._extension_implementation_evidence,
+        )
+        self._sealed_execution_configuration = (
+            self.repository,
+            self.timeout,
+            self.max_commands,
+            self.max_branches,
+            self.max_output_bytes,
+            self.max_remote_items,
+            self.max_remote_age_seconds,
+            self.stale_pull_request_after_seconds,
+        )
+
+    @property
+    def snapshot(self) -> RepositorySnapshot | None:
+        return self._snapshot
+
+    @property
+    def clock(self) -> Clock:
+        return self._clock
+
+    @property
+    def id_provider(self) -> IdProvider:
+        return self._id_provider
+
+    @property
+    def remote_provider(self) -> RecordedRemoteProvider | None:
+        return self._remote_provider
+
+    @property
+    def runner(self) -> GovernanceCommandRunner:
+        return self._runner
+
+    @property
+    def redactor(self) -> EvidenceRedactor:
+        return self._redactor
+
+    @property
+    def cancellation(self) -> CancellationSignal | None:
+        return self._cancellation
+
+    def _assert_execution_collaborators_sealed(self) -> None:
+        current = (
+            self.snapshot,
+            self.clock,
+            self.id_provider,
+            self.remote_provider,
+            self.runner,
+            self.redactor,
+            self.cancellation,
+            self._extension_implementation_evidence,
+        )
+        if any(
+            observed is not expected
+            for observed, expected in zip(
+                current, self._sealed_execution_collaborators, strict=True
+            )
+        ):
+            raise RepositorySecurityError(
+                "governance execution collaborators changed after provenance binding"
+            )
+        try:
+            extension_evidence_digest = canonical_digest(self._extension_implementation_evidence)
+        except Exception as exc:
+            raise RepositorySecurityError(
+                "governance implementation provenance evidence is malformed"
+            ) from exc
+        if (
+            self._sealed_execution_configuration
+            != (
+                self.repository,
+                self.timeout,
+                self.max_commands,
+                self.max_branches,
+                self.max_output_bytes,
+                self.max_remote_items,
+                self.max_remote_age_seconds,
+                self.stale_pull_request_after_seconds,
+            )
+            or extension_evidence_digest != self._sealed_extension_evidence_digest
+            or self.redactor._environment_secrets != ()
+            or type(self.clock) not in {SystemUtcClock, RecordedUtcClock}
+            or type(self.id_provider) not in {UuidObservationIds, RecordedObservationIds}
+            or (
+                self.remote_provider is not None
+                and type(self.remote_provider) is not RecordedRemoteProvider
+            )
+            or type(self.runner) is not GovernanceCommandRunner
+            or type(self.redactor) is not EvidenceRedactor
+            or (self.cancellation is not None and type(self.cancellation) is not CancellationSignal)
+        ):
+            raise RepositorySecurityError("governance execution collaborators are no longer sealed")
+
+    def _assert_bound_snapshot_valid(self) -> None:
+        if self.snapshot is not None and not self.snapshot.digest_is_valid():
+            raise RepositorySecurityError("bound repository snapshot digest is invalid")
 
     def _is_cancelled(self) -> bool:
+        self._assert_execution_collaborators_sealed()
         if self.cancellation is None:
             return False
         try:
@@ -1131,29 +1239,33 @@ class GovernanceCollector:
             return True
 
     def _execute(self, root: Path, command: tuple[str, ...]) -> CommandResult:
+        self._assert_execution_collaborators_sealed()
+        runner = self.runner
+        cancellation = self.cancellation
         if self._is_cancelled():
             raise RepositoryIntelligenceError("governance observation was cancelled")
-        if self.runner.max_output_bytes != self.max_output_bytes:
+        if runner.max_output_bytes != self.max_output_bytes:
             raise RepositorySecurityError(
                 "governance command runner output budget changed after collector construction"
             )
         if self._commands >= self.max_commands:
             raise RepositoryIntelligenceError("governance command budget was exhausted")
         self._commands += 1
-        result = self.runner.run(
+        result = runner.run(
             command,
             root,
             self.timeout,
-            cancellation=self.cancellation,
+            cancellation=cancellation,
         )
         self._command_provenance.append(
             CommandProvenance(
                 args=command,
-                tool_identity=self.runner.identity,
+                tool_identity=runner.identity,
                 exit_status=result.returncode,
                 timed_out=result.timed_out,
             )
         )
+        self._assert_execution_collaborators_sealed()
         return result
 
     def _run(self, root: Path, *args: str) -> str:
@@ -1165,7 +1277,10 @@ class GovernanceCollector:
             raise RepositoryIntelligenceError("local Git observation is unavailable") from exc
 
     def _collect_remote_bounded(self, ref: str) -> dict[str, Any]:
-        if self.remote_provider is None:
+        self._assert_execution_collaborators_sealed()
+        remote_provider = self.remote_provider
+        cancellation = self.cancellation
+        if remote_provider is None:
             raise RepositoryIntelligenceError("no remote provider was configured")
         if not hasattr(os, "fork") or not hasattr(os, "setsid"):
             raise RepositoryIntelligenceError(
@@ -1178,7 +1293,7 @@ class GovernanceCollector:
             target=_remote_provider_worker,
             args=(
                 sender,
-                self.remote_provider,
+                remote_provider,
                 self.repository,
                 ref,
                 self.timeout,
@@ -1202,7 +1317,8 @@ class GovernanceCollector:
         ready = False
         try:
             while True:
-                if self._is_cancelled():
+                self._assert_execution_collaborators_sealed()
+                if _cancellation_requested(cancellation):
                     cancellation_event.set()
                     raise RepositoryIntelligenceError(
                         "bounded remote provider observation was cancelled"
@@ -1259,6 +1375,7 @@ class GovernanceCollector:
                             max_bytes=self.max_output_bytes,
                             max_items=self.max_remote_items,
                         )
+                        self._assert_execution_collaborators_sealed()
                         return cast(dict[str, Any], decoded)
                     if status == "PERMISSION":
                         raise PermissionError("bounded remote provider denied access")
@@ -1524,6 +1641,8 @@ class GovernanceCollector:
         return tuple(sorted(results, key=lambda item: item.path))
 
     def observe(self, repository_root: Path | str, *, ref: str) -> GovernanceObservation:
+        self._assert_execution_collaborators_sealed()
+        self._assert_bound_snapshot_valid()
         self._command_provenance = []
         self._commands = 0
         self._local_unknowns = []
@@ -1669,8 +1788,11 @@ class GovernanceCollector:
             for item in worktrees
         ):
             raise RepositoryIntelligenceError("local Git reference identity is malformed")
-        observed_at = self.clock.now()
-        observation_id = self.id_provider.new_id()
+        clock = self.clock
+        id_provider = self.id_provider
+        observed_at = clock.now()
+        observation_id = id_provider.new_id()
+        self._assert_execution_collaborators_sealed()
         observed_at_value = _parse_utc(observed_at, field="observation time")
 
         remote_branches: tuple[RemoteBranchObservation, ...] = ()
@@ -1702,6 +1824,7 @@ class GovernanceCollector:
             remote_collection_status = "STARTED"
             try:
                 raw_remote = self._collect_remote_bounded(ref)
+                self._assert_execution_collaborators_sealed()
             except (PermissionError, OSError):
                 remote_collection_status = "PERMISSION_OR_IO_BLOCKED"
                 disposition = "BLOCKED"
@@ -1729,11 +1852,13 @@ class GovernanceCollector:
                 )
             else:
                 try:
-                    sanitized_remote = cast(dict[str, Any], self.redactor.sanitize(raw_remote))
+                    redactor = self.redactor
+                    sanitized_remote = cast(dict[str, Any], redactor.sanitize(raw_remote))
                 except (RedactionError, Exception) as exc:
                     raise RepositorySecurityError(
                         "remote evidence redaction failed; observation was not created"
                     ) from exc
+                self._assert_execution_collaborators_sealed()
                 try:
                     _validate_remote_payload_types(raw_remote)
                     _validate_remote_payload_types(sanitized_remote)
@@ -2072,9 +2197,12 @@ class GovernanceCollector:
             "collector_implementation_digest": collector_digest,
         }
         try:
-            sanitized_inputs = self.redactor.sanitize(inputs)
+            redactor = self.redactor
+            sanitized_inputs = redactor.sanitize(inputs)
         except (RedactionError, Exception) as exc:
             raise RepositorySecurityError("observation redaction failed") from exc
+        self._assert_execution_collaborators_sealed()
+        self._assert_bound_snapshot_valid()
         input_digest = canonical_digest(sanitized_inputs)
         draft = GovernanceObservation(
             observation_id=observation_id,
@@ -2111,16 +2239,18 @@ class GovernanceCollector:
             observation_output_digest="",
             disposition=disposition,
             redaction={
-                "version": str(getattr(self.redactor, "version", "unknown")),
+                "version": str(getattr(redactor, "version", "unknown")),
                 "status": "SANITIZED_BEFORE_PERSISTENCE",
                 "marker": "[REDACTED]",
                 "mutable_truth": "TIME_BOUND_OBSERVATION_ONLY",
             },
         )
         try:
-            sanitized = cast(dict[str, Any], self.redactor.sanitize(draft.as_dict()))
+            sanitized = cast(dict[str, Any], redactor.sanitize(draft.as_dict()))
         except (RedactionError, Exception) as exc:
             raise RepositorySecurityError("observation redaction failed") from exc
+        self._assert_execution_collaborators_sealed()
+        self._assert_bound_snapshot_valid()
         if self._is_cancelled() and not any(
             item.get("fact") == "observation_cancellation"
             for item in cast(list[dict[str, Any]], sanitized["unknowns"])

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -51,7 +51,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.9.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.10.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -51,7 +51,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.7.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.8.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -1118,8 +1118,6 @@ class GovernanceCollector:
         ]
         if self.remote_provider is not None:
             extension_targets.append(("remote_provider", self.remote_provider))
-        if self.cancellation is not None:
-            extension_targets.append(("cancellation", self.cancellation))
         self._extension_implementation_evidence = tuple(
             _implementation_source_evidence(label, target) for label, target in extension_targets
         )

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -1,0 +1,415 @@
+"""Time-bound, separately reproducible mutable governance observations."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+from pmpe.contracts.canonical import canonical_digest
+from pmpe.repository.models import (
+    BranchObservation,
+    CommandProvenance,
+    CommandResult,
+    GovernanceObservation,
+    IssueObservation,
+    LocalState,
+    PullRequestObservation,
+    QueryProvenance,
+    RemoteBranchObservation,
+    UnknownFact,
+    WorktreeObservation,
+)
+from pmpe.repository.redaction import EvidenceRedactor, RedactionError
+from pmpe.repository.scanner import RepositoryIntelligenceError, RepositorySecurityError
+
+
+class Clock(Protocol):
+    def now(self) -> str: ...
+
+
+class IdProvider(Protocol):
+    def new_id(self) -> str: ...
+
+
+class RemoteProvider(Protocol):
+    tool_identity: str
+    api_version: str
+
+    def collect(self, repository: str, ref: str) -> dict[str, Any]: ...
+
+
+class SystemUtcClock:
+    def now(self) -> str:
+        return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+class UuidObservationIds:
+    def new_id(self) -> str:
+        return f"OBS-{uuid.uuid4()}"
+
+
+class GovernanceCommandRunner:
+    """Allowlisted local Git observation commands with mutation subcommands refused."""
+
+    identity = "git-governance-readonly/1.0.0"
+    _allowed = {"status", "rev-parse", "for-each-ref", "rev-list", "worktree"}
+
+    def run(self, args: tuple[str, ...], cwd: Path, timeout: int) -> CommandResult:
+        if len(args) < 2 or args[0] != "git" or args[1] not in self._allowed:
+            raise RepositorySecurityError("command is outside the governance read-only allowlist")
+        if args[1] == "worktree" and (len(args) < 3 or args[2] != "list"):
+            raise RepositorySecurityError("mutating Git worktree command was refused")
+        safe_environment = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "LC_ALL": "C",
+        }
+        try:
+            result = subprocess.run(
+                args,
+                cwd=cwd,
+                capture_output=True,
+                check=False,
+                timeout=timeout,
+                env=safe_environment,
+            )
+        except subprocess.TimeoutExpired:
+            return CommandResult(args=args, returncode=124, stdout=b"", stderr=b"", timed_out=True)
+        return CommandResult(
+            args=args,
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+
+def _decode(result: CommandResult) -> str:
+    if result.timed_out:
+        raise RepositoryIntelligenceError("governance observation command timed out")
+    if result.returncode != 0:
+        raise RepositoryIntelligenceError("governance observation command failed")
+    try:
+        return result.stdout.decode("utf-8") if isinstance(result.stdout, bytes) else result.stdout
+    except UnicodeDecodeError as exc:
+        raise RepositoryIntelligenceError("governance observation output is malformed") from exc
+
+
+def _observation_from_dict(value: dict[str, Any]) -> GovernanceObservation:
+    return GovernanceObservation(
+        observation_id=str(value["observation_id"]),
+        observed_at=str(value["observed_at"]),
+        repository=str(value["repository"]),
+        ref=str(value["ref"]),
+        local_state=LocalState(**value["local_state"]),
+        local_branches=tuple(BranchObservation(**item) for item in value["local_branches"]),
+        worktrees=tuple(WorktreeObservation(**item) for item in value["worktrees"]),
+        command_provenance=tuple(
+            CommandProvenance(
+                args=tuple(item["args"]),
+                tool_identity=str(item["tool_identity"]),
+                exit_status=int(item["exit_status"]),
+                timed_out=bool(item["timed_out"]),
+            )
+            for item in value["command_provenance"]
+        ),
+        remote_branches=tuple(RemoteBranchObservation(**item) for item in value["remote_branches"]),
+        pull_requests=tuple(PullRequestObservation(**item) for item in value["pull_requests"]),
+        issues=tuple(IssueObservation(**item) for item in value["issues"]),
+        governance=cast(dict[str, Any], value["governance"]),
+        query_provenance=tuple(QueryProvenance(**item) for item in value["query_provenance"]),
+        unknowns=tuple(UnknownFact(**item) for item in value["unknowns"]),
+        tool_identity=str(value["tool_identity"]),
+        api_query_version=str(value["api_query_version"]),
+        observation_input_digest=str(value["observation_input_digest"]),
+        observation_output_digest=str(value["observation_output_digest"]),
+        disposition=str(value["disposition"]),
+        redaction=cast(dict[str, Any], value["redaction"]),
+        artifact_kind=str(value["artifact_kind"]),
+    )
+
+
+class GovernanceCollector:
+    """Collect mutable local and injected remote observations without mutation."""
+
+    def __init__(
+        self,
+        *,
+        repository: str,
+        clock: Clock,
+        id_provider: IdProvider,
+        remote_provider: RemoteProvider | None = None,
+        command_runner: GovernanceCommandRunner | None = None,
+        redactor: Any | None = None,
+        command_timeout_seconds: int = 20,
+    ) -> None:
+        self.repository = repository
+        self.clock = clock
+        self.id_provider = id_provider
+        self.remote_provider = remote_provider
+        self.runner = command_runner or GovernanceCommandRunner()
+        self.redactor = redactor or EvidenceRedactor()
+        self.timeout = command_timeout_seconds
+        self._command_provenance: list[CommandProvenance] = []
+
+    def _run(self, root: Path, *args: str) -> str:
+        try:
+            command = ("git", *args)
+            result = self.runner.run(command, root, self.timeout)
+            self._command_provenance.append(
+                CommandProvenance(
+                    args=command,
+                    tool_identity=self.runner.identity,
+                    exit_status=result.returncode,
+                    timed_out=result.timed_out,
+                )
+            )
+            return _decode(result)
+        except (FileNotFoundError, OSError) as exc:
+            raise RepositoryIntelligenceError("local Git observation is unavailable") from exc
+
+    def _branches(self, root: Path, ref: str) -> tuple[BranchObservation, ...]:
+        raw = self._run(
+            root, "for-each-ref", "--format=%(refname:short) %(objectname)", "refs/heads"
+        )
+        branches: list[BranchObservation] = []
+        for line in raw.splitlines():
+            try:
+                name, sha = line.rsplit(" ", 1)
+            except ValueError as exc:
+                raise RepositoryIntelligenceError("local branch output is malformed") from exc
+            ahead = behind = 0
+            status = "OBSERVED"
+            comparison = self.runner.run(
+                ("git", "rev-list", "--left-right", "--count", f"{ref}...{name}"),
+                root,
+                self.timeout,
+            )
+            self._command_provenance.append(
+                CommandProvenance(
+                    args=("git", "rev-list", "--left-right", "--count", f"{ref}...{name}"),
+                    tool_identity=self.runner.identity,
+                    exit_status=comparison.returncode,
+                    timed_out=comparison.timed_out,
+                )
+            )
+            if comparison.returncode == 0 and not comparison.timed_out:
+                try:
+                    left, right = _decode(comparison).strip().split()
+                    behind, ahead = int(left), int(right)
+                except (ValueError, RepositoryIntelligenceError):
+                    status = "UNKNOWN"
+            else:
+                status = "UNKNOWN"
+            branches.append(
+                BranchObservation(
+                    name=name,
+                    sha=sha,
+                    ahead=ahead,
+                    behind=behind,
+                    status=status,
+                )
+            )
+        return tuple(sorted(branches, key=lambda item: item.name))
+
+    def _worktrees(self, root: Path) -> tuple[WorktreeObservation, ...]:
+        raw = self._run(root, "worktree", "list", "--porcelain")
+        results: list[WorktreeObservation] = []
+        current: dict[str, str] = {}
+        for line in (*raw.splitlines(), ""):
+            if not line:
+                if current:
+                    results.append(
+                        WorktreeObservation(
+                            path=current.get("worktree", "UNKNOWN"),
+                            head_sha=current.get("HEAD", "UNKNOWN"),
+                            branch=current.get("branch", "DETACHED").removeprefix("refs/heads/"),
+                        )
+                    )
+                    current = {}
+                continue
+            key, _, value = line.partition(" ")
+            current[key] = value
+        return tuple(sorted(results, key=lambda item: item.path))
+
+    def observe(self, repository_root: Path | str, *, ref: str) -> GovernanceObservation:
+        self._command_provenance = []
+        root = Path(repository_root).resolve()
+        status_raw = self._run(root, "status", "--porcelain=v1", "--untracked-files=all")
+        head_sha = self._run(root, "rev-parse", "HEAD").strip()
+        if len(head_sha) != 40:
+            raise RepositoryIntelligenceError("local Git HEAD is malformed")
+        index_dirty = False
+        worktree_dirty = False
+        untracked = False
+        for line in status_raw.splitlines():
+            if line.startswith("??"):
+                untracked = True
+                continue
+            if len(line) < 2:
+                raise RepositoryIntelligenceError("local Git status output is malformed")
+            index_dirty = index_dirty or line[0] not in {" ", "?"}
+            worktree_dirty = worktree_dirty or line[1] not in {" ", "?"}
+        local_state = LocalState(
+            index_dirty=index_dirty,
+            worktree_dirty=worktree_dirty,
+            untracked=untracked,
+            head_sha=head_sha,
+        )
+        branches = self._branches(root, ref)
+        worktrees = self._worktrees(root)
+        observed_at = self.clock.now()
+        observation_id = self.id_provider.new_id()
+        if not observed_at.endswith("Z"):
+            raise RepositoryIntelligenceError("observation clock must provide a UTC Z timestamp")
+
+        remote_branches: tuple[RemoteBranchObservation, ...] = ()
+        pull_requests: tuple[PullRequestObservation, ...] = ()
+        issues: tuple[IssueObservation, ...] = ()
+        governance: dict[str, Any] = {}
+        provenance: tuple[QueryProvenance, ...] = ()
+        unknowns: tuple[UnknownFact, ...] = (
+            UnknownFact(
+                fact="remote_governance",
+                status="UNSUPPORTED",
+                reason="No read-only remote provider was requested.",
+            ),
+        )
+        tool_identity = self.runner.identity
+        api_version = "local-git/1.0.0"
+        disposition = "COMPLETE"
+        sanitized_remote: dict[str, Any] = {}
+        if self.remote_provider is not None:
+            tool_identity = self.remote_provider.tool_identity
+            api_version = self.remote_provider.api_version
+            try:
+                raw_remote = self.remote_provider.collect(self.repository, ref)
+                sanitized_remote = cast(dict[str, Any], self.redactor.sanitize(raw_remote))
+                remote_branches = tuple(
+                    RemoteBranchObservation(name=str(item["name"]), sha=str(item["sha"]))
+                    for item in sanitized_remote.get("remote_branches", [])
+                )
+                pull_requests = tuple(
+                    PullRequestObservation(
+                        number=int(item["number"]),
+                        draft=bool(item["draft"]),
+                        head=str(item["head"]),
+                    )
+                    for item in sanitized_remote.get("pull_requests", [])
+                )
+                issues = tuple(
+                    IssueObservation(number=int(item["number"]), state=str(item["state"]))
+                    for item in sanitized_remote.get("issues", [])
+                )
+                governance = cast(dict[str, Any], sanitized_remote.get("governance", {}))
+                provenance = tuple(
+                    QueryProvenance(
+                        query=str(item["query"]),
+                        cursor=cast(str | None, item.get("cursor")),
+                        page=cast(int | None, item.get("page")),
+                    )
+                    for item in sanitized_remote.get("query_provenance", [])
+                )
+                unknowns = tuple(
+                    UnknownFact(
+                        fact=str(item["fact"]),
+                        status=str(item["status"]),
+                        reason=str(item["reason"]),
+                    )
+                    for item in sanitized_remote.get("unknowns", [])
+                )
+                if any(item.status == "BLOCKED" for item in unknowns):
+                    disposition = "BLOCKED"
+            except (PermissionError, OSError):
+                disposition = "BLOCKED"
+                unknowns = (
+                    UnknownFact(
+                        fact="remote_governance",
+                        status="BLOCKED",
+                        reason=(
+                            "The read-only remote provider denied access; no value was inferred."
+                        ),
+                    ),
+                )
+            except (RedactionError, Exception) as exc:
+                raise RepositorySecurityError(
+                    "remote evidence redaction failed; observation was not created"
+                ) from exc
+
+        inputs = {
+            "repository": self.repository,
+            "ref": ref,
+            "observation_id": observation_id,
+            "observed_at": observed_at,
+            "local_status": status_raw,
+            "local_state": asdict(local_state),
+            "local_branches": [asdict(item) for item in branches],
+            "worktrees": [asdict(item) for item in worktrees],
+            "command_provenance": [asdict(item) for item in self._command_provenance],
+            "remote_result": sanitized_remote,
+            "tool_identity": tool_identity,
+            "api_query_version": api_version,
+        }
+        try:
+            sanitized_inputs = self.redactor.sanitize(inputs)
+        except (RedactionError, Exception) as exc:
+            raise RepositorySecurityError("observation redaction failed") from exc
+        input_digest = canonical_digest(sanitized_inputs)
+        draft = GovernanceObservation(
+            observation_id=observation_id,
+            observed_at=observed_at,
+            repository=self.repository,
+            ref=ref,
+            local_state=local_state,
+            local_branches=branches,
+            worktrees=worktrees,
+            command_provenance=tuple(self._command_provenance),
+            remote_branches=remote_branches,
+            pull_requests=pull_requests,
+            issues=issues,
+            governance=governance,
+            query_provenance=provenance,
+            unknowns=unknowns,
+            tool_identity=tool_identity,
+            api_query_version=api_version,
+            observation_input_digest=input_digest,
+            observation_output_digest="",
+            disposition=disposition,
+            redaction={
+                "version": str(getattr(self.redactor, "version", "unknown")),
+                "status": "SANITIZED_BEFORE_PERSISTENCE",
+                "marker": "[REDACTED]",
+                "mutable_truth": "TIME_BOUND_OBSERVATION_ONLY",
+            },
+        )
+        try:
+            sanitized = cast(dict[str, Any], self.redactor.sanitize(asdict(draft)))
+        except (RedactionError, Exception) as exc:
+            raise RepositorySecurityError("observation redaction failed") from exc
+        sanitized["observation_output_digest"] = canonical_digest(
+            {key: value for key, value in sanitized.items() if key != "observation_output_digest"}
+        )
+        return _observation_from_dict(sanitized)
+
+
+def observe_governance(
+    repository_root: Path | str,
+    *,
+    repository: str,
+    ref: str,
+    clock: Clock | None = None,
+    id_provider: IdProvider | None = None,
+    remote_provider: RemoteProvider | None = None,
+) -> GovernanceObservation:
+    return GovernanceCollector(
+        repository=repository,
+        clock=clock or SystemUtcClock(),
+        id_provider=id_provider or UuidObservationIds(),
+        remote_provider=remote_provider,
+    ).observe(repository_root, ref=ref)

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -51,7 +51,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.8.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.9.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
+import re
+import selectors
 import subprocess
+import time
 import uuid
 from dataclasses import asdict
 from datetime import UTC, datetime
@@ -25,7 +29,23 @@ from pmpe.repository.models import (
     WorktreeObservation,
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
-from pmpe.repository.scanner import RepositoryIntelligenceError, RepositorySecurityError
+from pmpe.repository.scanner import (
+    Cancellation,
+    RepositoryIntelligenceError,
+    RepositorySecurityError,
+)
+
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.1.0"
+_REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
+_SAFE_REF = re.compile(r"^(?:HEAD|[A-Za-z0-9][A-Za-z0-9._/-]{0,255})$")
+
+
+def _valid_ref(value: str) -> bool:
+    return (
+        bool(_SAFE_REF.fullmatch(value))
+        and not any(marker in value for marker in ("..", "@{", "//", "\\"))
+        and not value.endswith(("/", ".", ".lock"))
+    )
 
 
 class Clock(Protocol):
@@ -40,7 +60,16 @@ class RemoteProvider(Protocol):
     tool_identity: str
     api_version: str
 
-    def collect(self, repository: str, ref: str) -> dict[str, Any]: ...
+    def collect(
+        self,
+        repository: str,
+        ref: str,
+        *,
+        timeout_seconds: int,
+        max_output_bytes: int,
+        max_items: int,
+        cancellation: Cancellation | None,
+    ) -> dict[str, Any]: ...
 
 
 class SystemUtcClock:
@@ -56,10 +85,20 @@ class UuidObservationIds:
 class GovernanceCommandRunner:
     """Allowlisted local Git observation commands with mutation subcommands refused."""
 
-    identity = "git-governance-readonly/1.0.0"
+    identity = "git-governance-readonly/1.1.0"
     _allowed = {"status", "rev-parse", "for-each-ref", "rev-list", "worktree"}
 
-    def run(self, args: tuple[str, ...], cwd: Path, timeout: int) -> CommandResult:
+    def __init__(self, *, max_output_bytes: int = 8_000_000) -> None:
+        self.max_output_bytes = max_output_bytes
+
+    def run(
+        self,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        cancellation: Cancellation | None = None,
+    ) -> CommandResult:
         if len(args) < 2 or args[0] != "git" or args[1] not in self._allowed:
             raise RepositorySecurityError("command is outside the governance read-only allowlist")
         if args[1] == "worktree" and (len(args) < 3 or args[2] != "list"):
@@ -70,24 +109,75 @@ class GovernanceCommandRunner:
             "GIT_CONFIG_SYSTEM": os.devnull,
             "GIT_TERMINAL_PROMPT": "0",
             "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_CONFIG_COUNT": "3",
+            "GIT_CONFIG_KEY_0": "core.fsmonitor",
+            "GIT_CONFIG_VALUE_0": "false",
+            "GIT_CONFIG_KEY_1": "core.untrackedCache",
+            "GIT_CONFIG_VALUE_1": "false",
+            "GIT_CONFIG_KEY_2": "core.preloadIndex",
+            "GIT_CONFIG_VALUE_2": "false",
             "LC_ALL": "C",
         }
         try:
-            result = subprocess.run(
+            process = subprocess.Popen(
                 args,
                 cwd=cwd,
-                capture_output=True,
-                check=False,
-                timeout=timeout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
                 env=safe_environment,
             )
+        except OSError:
+            raise
+        if process.stdout is None:
+            process.kill()
+            raise RepositoryIntelligenceError("governance command output is unavailable")
+        selector = selectors.DefaultSelector()
+        selector.register(process.stdout, selectors.EVENT_READ)
+        payload = bytearray()
+        deadline = time.monotonic() + timeout
+        timed_out = False
+        output_exceeded = False
+        cancelled = False
+        try:
+            while True:
+                if cancellation is not None and cancellation.cancelled():
+                    cancelled = True
+                    process.terminate()
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    timed_out = True
+                    process.kill()
+                    break
+                events = selector.select(remaining)
+                if not events:
+                    timed_out = True
+                    process.kill()
+                    break
+                chunk = os.read(process.stdout.fileno(), 65_536)
+                if not chunk:
+                    break
+                payload.extend(chunk)
+                if len(payload) > self.max_output_bytes:
+                    output_exceeded = True
+                    process.terminate()
+                    break
+        finally:
+            selector.close()
+            process.stdout.close()
+        try:
+            returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
         except subprocess.TimeoutExpired:
-            return CommandResult(args=args, returncode=124, stdout=b"", stderr=b"", timed_out=True)
+            process.kill()
+            returncode = process.wait()
+            timed_out = True
         return CommandResult(
             args=args,
-            returncode=result.returncode,
-            stdout=result.stdout,
-            stderr=result.stderr,
+            returncode=126 if cancelled else 125 if output_exceeded else returncode,
+            stdout=bytes(payload[: self.max_output_bytes]),
+            stderr=b"",
+            timed_out=timed_out,
         )
 
 
@@ -100,6 +190,65 @@ def _decode(result: CommandResult) -> str:
         return result.stdout.decode("utf-8") if isinstance(result.stdout, bytes) else result.stdout
     except UnicodeDecodeError as exc:
         raise RepositoryIntelligenceError("governance observation output is malformed") from exc
+
+
+def _parse_utc(value: str, *, field: str) -> datetime:
+    if not value.endswith("Z"):
+        raise RepositoryIntelligenceError(f"{field} must be an RFC 3339 UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.removesuffix("Z") + "+00:00")
+    except ValueError as exc:
+        raise RepositoryIntelligenceError(f"{field} must be an RFC 3339 UTC timestamp") from exc
+    if parsed.tzinfo != UTC:
+        raise RepositoryIntelligenceError(f"{field} must use UTC")
+    return parsed
+
+
+def _bounded_remote_shape(value: Any, *, max_bytes: int, max_items: int) -> None:
+    pending = [value]
+    items = 0
+    encoded_bytes = 0
+    while pending:
+        current = pending.pop()
+        items += 1
+        if items > max_items:
+            raise RepositoryIntelligenceError("remote observation item budget was exceeded")
+        if isinstance(current, str):
+            encoded_bytes += len(current.encode("utf-8", errors="replace"))
+        elif isinstance(current, bytes):
+            encoded_bytes += len(current)
+        elif isinstance(current, dict):
+            pending.extend(current.keys())
+            pending.extend(current.values())
+        elif isinstance(current, (list, tuple)):
+            pending.extend(current)
+        elif current is not None and not isinstance(current, (bool, int, float)):
+            raise RepositoryIntelligenceError("remote observation contains an unsupported value")
+        if encoded_bytes > max_bytes:
+            raise RepositoryIntelligenceError("remote observation byte budget was exceeded")
+
+
+def _governance_implementation_digest() -> str:
+    package_root = Path(__file__).resolve().parent
+    sources = (
+        ("repository.governance", package_root / "governance.py"),
+        ("repository.models", package_root / "models.py"),
+        ("repository.redaction", package_root / "redaction.py"),
+        ("contracts.canonical", package_root.parent / "contracts" / "canonical.py"),
+    )
+    try:
+        evidence = [
+            {
+                "module": name,
+                "source_digest": "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+            for name, path in sources
+        ]
+    except OSError as exc:
+        raise RepositoryIntelligenceError(
+            "governance implementation bytes are unavailable for provenance binding"
+        ) from exc
+    return canonical_digest(evidence)
 
 
 def _observation_from_dict(value: dict[str, Any]) -> GovernanceObservation:
@@ -125,7 +274,11 @@ def _observation_from_dict(value: dict[str, Any]) -> GovernanceObservation:
         issues=tuple(IssueObservation(**item) for item in value["issues"]),
         governance=cast(dict[str, Any], value["governance"]),
         query_provenance=tuple(QueryProvenance(**item) for item in value["query_provenance"]),
+        remote_observed_at=cast(str | None, value["remote_observed_at"]),
+        remote_query_coverage=tuple(value["remote_query_coverage"]),
         unknowns=tuple(UnknownFact(**item) for item in value["unknowns"]),
+        collector_version=str(value["collector_version"]),
+        collector_implementation_digest=str(value["collector_implementation_digest"]),
         tool_identity=str(value["tool_identity"]),
         api_query_version=str(value["api_query_version"]),
         observation_input_digest=str(value["observation_input_digest"]),
@@ -149,28 +302,56 @@ class GovernanceCollector:
         command_runner: GovernanceCommandRunner | None = None,
         redactor: Any | None = None,
         command_timeout_seconds: int = 20,
+        max_commands: int = 2_000,
+        max_branches: int = 1_000,
+        max_output_bytes: int = 8_000_000,
+        max_remote_items: int = 20_000,
+        max_remote_age_seconds: int = 300,
+        cancellation: Cancellation | None = None,
     ) -> None:
         self.repository = repository
         self.clock = clock
         self.id_provider = id_provider
         self.remote_provider = remote_provider
-        self.runner = command_runner or GovernanceCommandRunner()
+        self.runner = command_runner or GovernanceCommandRunner(max_output_bytes=max_output_bytes)
         self.redactor = redactor or EvidenceRedactor()
         self.timeout = command_timeout_seconds
+        self.max_commands = max_commands
+        self.max_branches = max_branches
+        self.max_output_bytes = max_output_bytes
+        self.max_remote_items = max_remote_items
+        self.max_remote_age_seconds = max_remote_age_seconds
+        self.cancellation = cancellation
         self._command_provenance: list[CommandProvenance] = []
+        self._commands = 0
+        self._local_unknowns: list[UnknownFact] = []
+
+    def _execute(self, root: Path, command: tuple[str, ...]) -> CommandResult:
+        if self.cancellation is not None and self.cancellation.cancelled():
+            raise RepositoryIntelligenceError("governance observation was cancelled")
+        if self._commands >= self.max_commands:
+            raise RepositoryIntelligenceError("governance command budget was exhausted")
+        self._commands += 1
+        result = self.runner.run(
+            command,
+            root,
+            self.timeout,
+            cancellation=self.cancellation,
+        )
+        self._command_provenance.append(
+            CommandProvenance(
+                args=command,
+                tool_identity=self.runner.identity,
+                exit_status=result.returncode,
+                timed_out=result.timed_out,
+            )
+        )
+        return result
 
     def _run(self, root: Path, *args: str) -> str:
         try:
             command = ("git", *args)
-            result = self.runner.run(command, root, self.timeout)
-            self._command_provenance.append(
-                CommandProvenance(
-                    args=command,
-                    tool_identity=self.runner.identity,
-                    exit_status=result.returncode,
-                    timed_out=result.timed_out,
-                )
-            )
+            result = self._execute(root, command)
             return _decode(result)
         except (FileNotFoundError, OSError) as exc:
             raise RepositoryIntelligenceError("local Git observation is unavailable") from exc
@@ -180,25 +361,26 @@ class GovernanceCollector:
             root, "for-each-ref", "--format=%(refname:short) %(objectname)", "refs/heads"
         )
         branches: list[BranchObservation] = []
-        for line in raw.splitlines():
+        lines = raw.splitlines()
+        if len(lines) > self.max_branches:
+            self._local_unknowns.append(
+                UnknownFact(
+                    fact="local_branch_inventory",
+                    status="BLOCKED",
+                    reason="The local branch-count budget was exceeded.",
+                )
+            )
+            lines = lines[: self.max_branches]
+        for line in lines:
             try:
                 name, sha = line.rsplit(" ", 1)
             except ValueError as exc:
                 raise RepositoryIntelligenceError("local branch output is malformed") from exc
             ahead = behind = 0
             status = "OBSERVED"
-            comparison = self.runner.run(
-                ("git", "rev-list", "--left-right", "--count", f"{ref}...{name}"),
+            comparison = self._execute(
                 root,
-                self.timeout,
-            )
-            self._command_provenance.append(
-                CommandProvenance(
-                    args=("git", "rev-list", "--left-right", "--count", f"{ref}...{name}"),
-                    tool_identity=self.runner.identity,
-                    exit_status=comparison.returncode,
-                    timed_out=comparison.timed_out,
-                )
+                ("git", "rev-list", "--left-right", "--count", f"{ref}...{name}"),
             )
             if comparison.returncode == 0 and not comparison.timed_out:
                 try:
@@ -208,6 +390,14 @@ class GovernanceCollector:
                     status = "UNKNOWN"
             else:
                 status = "UNKNOWN"
+            if status == "UNKNOWN":
+                self._local_unknowns.append(
+                    UnknownFact(
+                        fact=f"local_branch_divergence:{name}",
+                        status="BLOCKED",
+                        reason="The branch comparison could not be evaluated.",
+                    )
+                )
             branches.append(
                 BranchObservation(
                     name=name,
@@ -241,10 +431,26 @@ class GovernanceCollector:
 
     def observe(self, repository_root: Path | str, *, ref: str) -> GovernanceObservation:
         self._command_provenance = []
+        self._commands = 0
+        self._local_unknowns = []
+        if not _valid_ref(ref):
+            raise RepositorySecurityError("governance observation ref is invalid")
+        if any(
+            value <= 0
+            for value in (
+                self.timeout,
+                self.max_commands,
+                self.max_branches,
+                self.max_output_bytes,
+                self.max_remote_items,
+                self.max_remote_age_seconds,
+            )
+        ):
+            raise RepositoryIntelligenceError("governance observation budgets must be positive")
         root = Path(repository_root).resolve()
         status_raw = self._run(root, "status", "--porcelain=v1", "--untracked-files=all")
         head_sha = self._run(root, "rev-parse", "HEAD").strip()
-        if len(head_sha) != 40:
+        if not re.fullmatch(r"[0-9a-f]{40}", head_sha):
             raise RepositoryIntelligenceError("local Git HEAD is malformed")
         index_dirty = False
         worktree_dirty = False
@@ -267,15 +473,17 @@ class GovernanceCollector:
         worktrees = self._worktrees(root)
         observed_at = self.clock.now()
         observation_id = self.id_provider.new_id()
-        if not observed_at.endswith("Z"):
-            raise RepositoryIntelligenceError("observation clock must provide a UTC Z timestamp")
+        observed_at_value = _parse_utc(observed_at, field="observation time")
 
         remote_branches: tuple[RemoteBranchObservation, ...] = ()
         pull_requests: tuple[PullRequestObservation, ...] = ()
         issues: tuple[IssueObservation, ...] = ()
         governance: dict[str, Any] = {}
         provenance: tuple[QueryProvenance, ...] = ()
+        remote_observed_at: str | None = None
+        remote_query_coverage: tuple[str, ...] = ()
         unknowns: tuple[UnknownFact, ...] = (
+            *self._local_unknowns,
             UnknownFact(
                 fact="remote_governance",
                 status="UNSUPPORTED",
@@ -283,86 +491,158 @@ class GovernanceCollector:
             ),
         )
         tool_identity = self.runner.identity
-        api_version = "local-git/1.0.0"
-        disposition = "COMPLETE"
+        api_version = GOVERNANCE_COLLECTOR_VERSION
+        disposition = "BLOCKED" if self._local_unknowns else "PARTIAL"
         sanitized_remote: dict[str, Any] = {}
         if self.remote_provider is not None:
             tool_identity = self.remote_provider.tool_identity
             api_version = self.remote_provider.api_version
             try:
-                raw_remote = self.remote_provider.collect(self.repository, ref)
-                sanitized_remote = cast(dict[str, Any], self.redactor.sanitize(raw_remote))
-                remote_branches = tuple(
-                    RemoteBranchObservation(name=str(item["name"]), sha=str(item["sha"]))
-                    for item in sanitized_remote.get("remote_branches", [])
+                raw_remote = self.remote_provider.collect(
+                    self.repository,
+                    ref,
+                    timeout_seconds=self.timeout,
+                    max_output_bytes=self.max_output_bytes,
+                    max_items=self.max_remote_items,
+                    cancellation=self.cancellation,
                 )
-                pull_requests = tuple(
-                    PullRequestObservation(
-                        number=int(item["number"]),
-                        draft=bool(item["draft"]),
-                        head=str(item["head"]),
-                    )
-                    for item in sanitized_remote.get("pull_requests", [])
+                _bounded_remote_shape(
+                    raw_remote,
+                    max_bytes=self.max_output_bytes,
+                    max_items=self.max_remote_items,
                 )
-                issues = tuple(
-                    IssueObservation(number=int(item["number"]), state=str(item["state"]))
-                    for item in sanitized_remote.get("issues", [])
-                )
-                governance = cast(dict[str, Any], sanitized_remote.get("governance", {}))
-                provenance = tuple(
-                    QueryProvenance(
-                        query=str(item["query"]),
-                        cursor=cast(str | None, item.get("cursor")),
-                        page=cast(int | None, item.get("page")),
-                        has_next_page=bool(item.get("has_next_page", True)),
-                        result_count=cast(int | None, item.get("result_count")),
-                    )
-                    for item in sanitized_remote.get("query_provenance", [])
-                )
-                unknowns = tuple(
-                    UnknownFact(
-                        fact=str(item["fact"]),
-                        status=str(item["status"]),
-                        reason=str(item["reason"]),
-                    )
-                    for item in sanitized_remote.get("unknowns", [])
-                )
-                if any(item.status == "BLOCKED" for item in unknowns):
-                    disposition = "BLOCKED"
-                pagination_complete = (
-                    sanitized_remote.get("complete") is True
-                    and bool(provenance)
-                    and all(not item.has_next_page for item in provenance)
-                )
-                if not pagination_complete:
-                    disposition = "BLOCKED"
-                    unknowns = (
-                        *unknowns,
-                        UnknownFact(
-                            fact="remote_metadata_completeness",
-                            status="BLOCKED",
-                            reason=(
-                                "Remote query coverage or pagination completion was not proven; "
-                                "the returned subset is not represented as complete."
-                            ),
-                        ),
-                    )
             except (PermissionError, OSError):
                 disposition = "BLOCKED"
                 unknowns = (
+                    *self._local_unknowns,
                     UnknownFact(
                         fact="remote_governance",
                         status="BLOCKED",
                         reason=(
-                            "The read-only remote provider denied access; no value was inferred."
+                            "The bounded read-only remote provider denied access or failed; "
+                            "no value was inferred."
                         ),
                     ),
                 )
-            except (RedactionError, Exception) as exc:
-                raise RepositorySecurityError(
-                    "remote evidence redaction failed; observation was not created"
-                ) from exc
+            except Exception as exc:
+                disposition = "BLOCKED"
+                unknowns = (
+                    *self._local_unknowns,
+                    UnknownFact(
+                        fact="remote_governance",
+                        status="BLOCKED",
+                        reason=f"The bounded remote provider failed safely: {type(exc).__name__}.",
+                    ),
+                )
+            else:
+                try:
+                    sanitized_remote = cast(dict[str, Any], self.redactor.sanitize(raw_remote))
+                except (RedactionError, Exception) as exc:
+                    raise RepositorySecurityError(
+                        "remote evidence redaction failed; observation was not created"
+                    ) from exc
+                try:
+                    remote_observed_at = str(sanitized_remote["observed_at"])
+                    remote_observed_value = _parse_utc(
+                        remote_observed_at, field="remote observation time"
+                    )
+                    remote_age = (observed_at_value - remote_observed_value).total_seconds()
+                    remote_query_coverage = tuple(
+                        sorted(str(item) for item in sanitized_remote.get("coverage", []))
+                    )
+                    coverage_complete = _REQUIRED_REMOTE_COVERAGE.issubset(remote_query_coverage)
+                    freshness_proven = -30 <= remote_age <= self.max_remote_age_seconds
+                    remote_branches = tuple(
+                        RemoteBranchObservation(name=str(item["name"]), sha=str(item["sha"]))
+                        for item in sanitized_remote.get("remote_branches", [])
+                    )
+                    pull_requests = tuple(
+                        PullRequestObservation(
+                            number=int(item["number"]),
+                            draft=bool(item["draft"]),
+                            head=str(item["head"]),
+                        )
+                        for item in sanitized_remote.get("pull_requests", [])
+                    )
+                    issues = tuple(
+                        IssueObservation(number=int(item["number"]), state=str(item["state"]))
+                        for item in sanitized_remote.get("issues", [])
+                    )
+                    governance = cast(dict[str, Any], sanitized_remote.get("governance", {}))
+                    provenance = tuple(
+                        QueryProvenance(
+                            query=str(item["query"]),
+                            cursor=cast(str | None, item.get("cursor")),
+                            page=cast(int | None, item.get("page")),
+                            has_next_page=bool(item.get("has_next_page", True)),
+                            result_count=cast(int | None, item.get("result_count")),
+                        )
+                        for item in sanitized_remote.get("query_provenance", [])
+                    )
+                    remote_unknowns = tuple(
+                        UnknownFact(
+                            fact=str(item["fact"]),
+                            status=str(item["status"]),
+                            reason=str(item["reason"]),
+                        )
+                        for item in sanitized_remote.get("unknowns", [])
+                    )
+                    if any(
+                        not re.fullmatch(r"[0-9a-f]{40}", item.sha) for item in remote_branches
+                    ) or any(
+                        not re.fullmatch(r"[0-9a-f]{40}", item.head) for item in pull_requests
+                    ):
+                        raise ValueError("remote commit identity is malformed")
+                    if any(
+                        item.status not in {"UNKNOWN", "UNSUPPORTED", "BLOCKED"}
+                        for item in remote_unknowns
+                    ):
+                        raise ValueError("remote unknown status is malformed")
+                    if any(
+                        (item.page is not None and item.page < 1)
+                        or (item.result_count is not None and item.result_count < 0)
+                        for item in provenance
+                    ):
+                        raise ValueError("remote pagination evidence is malformed")
+                except (KeyError, TypeError, ValueError, RepositoryIntelligenceError):
+                    disposition = "BLOCKED"
+                    unknowns = (
+                        *self._local_unknowns,
+                        UnknownFact(
+                            fact="remote_metadata_shape",
+                            status="BLOCKED",
+                            reason="Remote metadata shape or observation time is invalid.",
+                        ),
+                    )
+                else:
+                    unknowns = (*self._local_unknowns, *remote_unknowns)
+                    disposition = (
+                        "BLOCKED"
+                        if any(item.status == "BLOCKED" for item in unknowns)
+                        else "PARTIAL"
+                        if any(item.status in {"UNKNOWN", "UNSUPPORTED"} for item in unknowns)
+                        else "COMPLETE"
+                    )
+                    pagination_complete = (
+                        sanitized_remote.get("complete") is True
+                        and bool(provenance)
+                        and all(not item.has_next_page for item in provenance)
+                    )
+                    if not pagination_complete or not coverage_complete or not freshness_proven:
+                        disposition = "BLOCKED"
+                        unknowns = (
+                            *unknowns,
+                            UnknownFact(
+                                fact="remote_metadata_completeness",
+                                status="BLOCKED",
+                                reason=(
+                                    "Remote query coverage, pagination, or freshness was not "
+                                    "proven; the result is not represented as complete."
+                                ),
+                            ),
+                        )
 
+        collector_digest = _governance_implementation_digest()
         inputs = {
             "repository": self.repository,
             "ref": ref,
@@ -374,8 +654,12 @@ class GovernanceCollector:
             "worktrees": [asdict(item) for item in worktrees],
             "command_provenance": [asdict(item) for item in self._command_provenance],
             "remote_result": sanitized_remote,
+            "remote_observed_at": remote_observed_at,
+            "remote_query_coverage": remote_query_coverage,
             "tool_identity": tool_identity,
             "api_query_version": api_version,
+            "collector_version": GOVERNANCE_COLLECTOR_VERSION,
+            "collector_implementation_digest": collector_digest,
         }
         try:
             sanitized_inputs = self.redactor.sanitize(inputs)
@@ -396,7 +680,11 @@ class GovernanceCollector:
             issues=issues,
             governance=governance,
             query_provenance=provenance,
+            remote_observed_at=remote_observed_at,
+            remote_query_coverage=remote_query_coverage,
             unknowns=unknowns,
+            collector_version=GOVERNANCE_COLLECTOR_VERSION,
+            collector_implementation_digest=collector_digest,
             tool_identity=tool_identity,
             api_query_version=api_version,
             observation_input_digest=input_digest,
@@ -410,7 +698,7 @@ class GovernanceCollector:
             },
         )
         try:
-            sanitized = cast(dict[str, Any], self.redactor.sanitize(asdict(draft)))
+            sanitized = cast(dict[str, Any], self.redactor.sanitize(draft.as_dict()))
         except (RedactionError, Exception) as exc:
             raise RepositorySecurityError("observation redaction failed") from exc
         sanitized["observation_output_digest"] = canonical_digest(

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -13,6 +13,7 @@ import signal
 import subprocess
 import time
 import uuid
+from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import asdict
 from datetime import UTC, datetime
@@ -49,7 +50,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.2.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.3.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -209,10 +210,17 @@ class RecordedRemoteProvider:
         "_delay_seconds",
         "_payload",
         "_permission_denied",
+        "_sealed",
         "api_version",
     )
 
     tool_identity = "recorded-remote-payload/2.0.0"
+    _collection_provenance: Mapping[str, Any]
+    _delay_seconds: float
+    _payload: bytes
+    _permission_denied: bool
+    _sealed: bool
+    api_version: str
 
     def __init__(
         self,
@@ -227,7 +235,7 @@ class RecordedRemoteProvider:
         if not math.isfinite(delay_seconds) or not 0 <= delay_seconds <= 300:
             raise ValueError("recorded remote delay must be bounded")
         try:
-            self._payload = json.dumps(
+            canonical_payload = json.dumps(
                 payload,
                 allow_nan=False,
                 ensure_ascii=False,
@@ -236,19 +244,39 @@ class RecordedRemoteProvider:
             ).encode("utf-8")
         except (TypeError, ValueError) as exc:
             raise ValueError("recorded remote payload is not canonical JSON") from exc
-        self.api_version = api_version
-        self._collection_provenance = {
+        provenance = {
             "source_kind": "RECORDED_UNATTESTED",
             "replay_provider": self.tool_identity,
             "api_version": api_version,
+            "recorded_payload_digest": "sha256:" + hashlib.sha256(canonical_payload).hexdigest(),
+            "attestation": "ABSENT",
+        }
+        object.__setattr__(self, "_payload", canonical_payload)
+        object.__setattr__(self, "api_version", api_version)
+        object.__setattr__(self, "_collection_provenance", MappingProxyType(provenance))
+        object.__setattr__(self, "_delay_seconds", delay_seconds)
+        object.__setattr__(self, "_permission_denied", permission_denied)
+        object.__setattr__(self, "_sealed", True)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if getattr(self, "_sealed", False):
+            raise AttributeError("recorded remote input is immutable")
+        object.__setattr__(self, name, value)
+
+    def _assert_integrity(self) -> None:
+        expected = {
+            "source_kind": "RECORDED_UNATTESTED",
+            "replay_provider": self.tool_identity,
+            "api_version": self.api_version,
             "recorded_payload_digest": "sha256:" + hashlib.sha256(self._payload).hexdigest(),
             "attestation": "ABSENT",
         }
-        self._delay_seconds = delay_seconds
-        self._permission_denied = permission_denied
+        if dict(self._collection_provenance) != expected:
+            raise RepositorySecurityError("recorded remote provenance integrity check failed")
 
     @property
     def collection_provenance(self) -> dict[str, Any]:
+        self._assert_integrity()
         return dict(self._collection_provenance)
 
     def collect(
@@ -262,6 +290,7 @@ class RecordedRemoteProvider:
         cancellation: Cancellation | None,
     ) -> dict[str, Any]:
         del repository, ref
+        self._assert_integrity()
         if (
             timeout_seconds > _MAX_GOVERNANCE_BUDGETS["command_timeout_seconds"]
             or max_output_bytes > _MAX_GOVERNANCE_BUDGETS["max_output_bytes"]

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -51,7 +51,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.5.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.6.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -36,7 +36,7 @@ from pmpe.repository.scanner import (
     RepositorySecurityError,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.2.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.3.0"
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
 _SAFE_REF = re.compile(r"^(?:HEAD|[A-Za-z0-9][A-Za-z0-9._/-]{0,255})$")
 
@@ -86,8 +86,16 @@ class UuidObservationIds:
 class GovernanceCommandRunner:
     """Allowlisted local Git observation commands with mutation subcommands refused."""
 
-    identity = "git-governance-readonly/1.2.0"
-    _allowed = {"config", "status", "rev-parse", "for-each-ref", "rev-list", "worktree"}
+    identity = "git-governance-readonly/1.3.0"
+    _allowed = {
+        "config",
+        "status",
+        "rev-parse",
+        "for-each-ref",
+        "rev-list",
+        "worktree",
+        "ls-files",
+    }
     _filter_probe = (
         "--name-only",
         "--get-regexp",
@@ -109,6 +117,8 @@ class GovernanceCommandRunner:
             raise RepositorySecurityError("command is outside the governance read-only allowlist")
         if args[1] == "config" and args[2:] != self._filter_probe:
             raise RepositorySecurityError("Git configuration reads are outside the safe probe")
+        if args[1] == "ls-files" and args[2:] != ("--stage", "-z"):
+            raise RepositorySecurityError("Git index reads are outside the safe probe")
         if args[1] == "worktree" and (len(args) < 3 or args[2] != "list"):
             raise RepositorySecurityError("mutating Git worktree command was refused")
         safe_environment = {
@@ -118,6 +128,7 @@ class GovernanceCommandRunner:
             "GIT_TERMINAL_PROMPT": "0",
             "GIT_OPTIONAL_LOCKS": "0",
             "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
             "GIT_CONFIG_COUNT": "6",
             "GIT_CONFIG_KEY_0": "core.fsmonitor",
             "GIT_CONFIG_VALUE_0": "false",
@@ -255,6 +266,29 @@ def _bounded_remote_shape(value: Any, *, max_bytes: int, max_items: int) -> None
             raise RepositoryIntelligenceError("remote observation contains an unsupported value")
         if encoded_bytes > max_bytes:
             raise RepositoryIntelligenceError("remote observation byte budget was exceeded")
+
+
+def _pagination_is_complete(
+    provenance: tuple[QueryProvenance, ...], expected_counts: dict[str, int]
+) -> bool:
+    if {item.surface for item in provenance} != set(expected_counts):
+        return False
+    for surface, expected_count in expected_counts.items():
+        pages = sorted(
+            (item for item in provenance if item.surface == surface),
+            key=lambda item: item.page if item.page is not None else 0,
+        )
+        if not pages or any(item.page is None or item.result_count is None for item in pages):
+            return False
+        if [item.page for item in pages] != list(range(1, len(pages) + 1)):
+            return False
+        if any(item.has_next_page != (index < len(pages) - 1) for index, item in enumerate(pages)):
+            return False
+        if sum(item.result_count or 0 for item in pages) != expected_count:
+            return False
+        if any(not item.query.strip() for item in pages):
+            return False
+    return True
 
 
 def _governance_implementation_digest() -> str:
@@ -491,6 +525,39 @@ class GovernanceCollector:
             )
         if filter_probe.returncode != 1:
             raise RepositoryIntelligenceError("Git content-filter safety could not be proven")
+        index_listing = self._run(root, "ls-files", "--stage", "-z")
+        gitlinks = 0
+        for record in index_listing.split("\0"):
+            if not record:
+                continue
+            metadata, separator, _path = record.partition("\t")
+            fields = metadata.split()
+            if separator != "\t" or len(fields) != 3:
+                raise RepositoryIntelligenceError("Git index metadata is malformed")
+            mode, object_id, stage = fields
+            if not re.fullmatch(r"[0-7]{6}", mode) or not re.fullmatch(r"[0-9a-f]{40}", object_id):
+                raise RepositoryIntelligenceError("Git index metadata is malformed")
+            if stage != "0":
+                self._local_unknowns.append(
+                    UnknownFact(
+                        fact="unmerged_index_state",
+                        status="BLOCKED",
+                        reason="The index contains an unmerged entry.",
+                    )
+                )
+            if mode == "160000":
+                gitlinks += 1
+        if gitlinks:
+            self._local_unknowns.append(
+                UnknownFact(
+                    fact="submodule_worktree_state",
+                    status="UNSUPPORTED",
+                    reason=(
+                        "Gitlink entries are present; nested submodule worktree dirtiness is "
+                        "not executed or inferred and remains a separate mutable unknown."
+                    ),
+                )
+            )
         status_raw = self._run(
             root,
             "status",
@@ -620,6 +687,7 @@ class GovernanceCollector:
                     governance = cast(dict[str, Any], sanitized_remote.get("governance", {}))
                     provenance = tuple(
                         QueryProvenance(
+                            surface=str(item["surface"]),
                             query=str(item["query"]),
                             cursor=cast(str | None, item.get("cursor")),
                             page=cast(int | None, item.get("page")),
@@ -672,10 +740,16 @@ class GovernanceCollector:
                         if any(item.status in {"UNKNOWN", "UNSUPPORTED"} for item in unknowns)
                         else "COMPLETE"
                     )
-                    pagination_complete = (
-                        sanitized_remote.get("complete") is True
-                        and bool(provenance)
-                        and all(not item.has_next_page for item in provenance)
+                    pagination_complete = sanitized_remote.get(
+                        "complete"
+                    ) is True and _pagination_is_complete(
+                        provenance,
+                        {
+                            "remote_branches": len(remote_branches),
+                            "pull_requests": len(pull_requests),
+                            "issues": len(issues),
+                            "governance": 1 if governance else 0,
+                        },
                     )
                     if not pagination_complete or not coverage_complete or not freshness_proven:
                         disposition = "BLOCKED"

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import math
 import multiprocessing
 import os
 import re
@@ -41,7 +43,14 @@ from pmpe.repository.scanner import (
     _implementation_source_evidence,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.6.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.7.0"
+GOVERNANCE_IMPLEMENTATION_MODULES = (
+    "repository.governance",
+    "repository.models",
+    "repository.redaction",
+    "repository.scanner",
+    "contracts.canonical",
+)
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
 _REQUIRED_GOVERNANCE_FACTS = frozenset({"branch_protection", "review_policy"})
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
@@ -130,7 +139,7 @@ def _remote_provider_worker(
                 "GIT_TERMINAL_PROMPT": "0",
             }
         )
-        connection.send(("READY", None))
+        connection.send_bytes(b"READY\0")
         result = provider.collect(
             repository,
             ref,
@@ -142,14 +151,23 @@ def _remote_provider_worker(
         if not isinstance(result, dict):
             raise TypeError("remote provider result must be an object")
         _bounded_remote_shape(result, max_bytes=max_output_bytes, max_items=max_items)
-        connection.send(("RESULT", result))
+        encoded = json.dumps(
+            result,
+            allow_nan=False,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        if len(encoded) > max_output_bytes:
+            raise RepositoryIntelligenceError("remote observation byte budget was exceeded")
+        connection.send_bytes(b"RESULT\0" + encoded)
     except PermissionError:
-        connection.send(("PERMISSION", None))
+        connection.send_bytes(b"PERMISSION\0")
     except BaseException as exc:
         # Exception text can contain credentials. Only the safe type identity crosses
         # the process boundary and is later sanitized before persistence.
         with suppress(BrokenPipeError, EOFError, OSError):
-            connection.send(("ERROR", type(exc).__name__))
+            connection.send_bytes(b"ERROR\0" + type(exc).__name__.encode("ascii", errors="replace"))
     finally:
         connection.close()
 
@@ -366,15 +384,36 @@ def _bounded_remote_shape(value: Any, *, max_bytes: int, max_items: int) -> None
         if items > max_items:
             raise RepositoryIntelligenceError("remote observation item budget was exceeded")
         if isinstance(current, str):
-            encoded_bytes += len(current.encode("utf-8", errors="replace"))
-        elif isinstance(current, bytes):
-            encoded_bytes += len(current)
+            encoded_bytes += len(
+                json.dumps(current, ensure_ascii=False).encode("utf-8", errors="strict")
+            )
+        elif isinstance(current, bool):
+            encoded_bytes += 4 if current else 5
+        elif isinstance(current, int):
+            try:
+                encoded_bytes += len(str(current))
+            except ValueError as exc:
+                raise RepositoryIntelligenceError(
+                    "remote observation numeric value exceeds the byte budget"
+                ) from exc
+        elif isinstance(current, float):
+            if not math.isfinite(current):
+                raise RepositoryIntelligenceError(
+                    "remote observation contains a non-finite numeric value"
+                )
+            encoded_bytes += len(repr(current))
         elif isinstance(current, dict):
+            if not all(isinstance(key, str) for key in current):
+                raise RepositoryIntelligenceError("remote observation object keys must be strings")
+            encoded_bytes += 2 + max(0, len(current) - 1)
             pending.extend(current.keys())
             pending.extend(current.values())
         elif isinstance(current, (list, tuple)):
+            encoded_bytes += 2 + max(0, len(current) - 1)
             pending.extend(current)
-        elif current is not None and not isinstance(current, (bool, int, float)):
+        elif current is None:
+            encoded_bytes += 4
+        else:
             raise RepositoryIntelligenceError("remote observation contains an unsupported value")
         if encoded_bytes > max_bytes:
             raise RepositoryIntelligenceError("remote observation byte budget was exceeded")
@@ -530,19 +569,20 @@ def _governance_implementation_digest(
     extension_evidence: tuple[dict[str, str], ...] = (),
 ) -> str:
     package_root = Path(__file__).resolve().parent
-    sources = (
-        ("repository.governance", package_root / "governance.py"),
-        ("repository.models", package_root / "models.py"),
-        ("repository.redaction", package_root / "redaction.py"),
-        ("contracts.canonical", package_root.parent / "contracts" / "canonical.py"),
-    )
+    sources = {
+        "repository.governance": package_root / "governance.py",
+        "repository.models": package_root / "models.py",
+        "repository.redaction": package_root / "redaction.py",
+        "repository.scanner": package_root / "scanner.py",
+        "contracts.canonical": package_root.parent / "contracts" / "canonical.py",
+    }
     try:
         evidence: list[dict[str, str]] = [
             {
                 "module": name,
-                "source_digest": "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest(),
+                "source_digest": "sha256:" + hashlib.sha256(sources[name].read_bytes()).hexdigest(),
             }
-            for name, path in sources
+            for name in GOVERNANCE_IMPLEMENTATION_MODULES
         ]
     except OSError as exc:
         raise RepositoryIntelligenceError(
@@ -736,23 +776,52 @@ class GovernanceCollector:
                     raise RepositoryIntelligenceError("bounded remote provider timed out")
                 if receiver.poll(min(remaining, 0.05)):
                     try:
-                        status, payload = receiver.recv()
-                    except EOFError as exc:
+                        frame = receiver.recv_bytes(maxlength=self.max_output_bytes + 256)
+                    except (EOFError, OSError) as exc:
                         raise RepositoryIntelligenceError(
-                            "bounded remote provider exited without evidence"
+                            "bounded remote provider output was absent or exceeded its byte budget"
+                        ) from exc
+                    raw_status, separator, payload = frame.partition(b"\0")
+                    if not separator:
+                        raise RepositoryIntelligenceError(
+                            "bounded remote provider protocol was malformed"
+                        )
+                    try:
+                        status = raw_status.decode("ascii")
+                    except UnicodeDecodeError as exc:
+                        raise RepositoryIntelligenceError(
+                            "bounded remote provider protocol was malformed"
                         ) from exc
                     if status == "READY":
+                        if payload:
+                            raise RepositoryIntelligenceError(
+                                "bounded remote provider protocol was malformed"
+                            )
                         ready = True
                         continue
                     if not ready:
                         raise RepositoryIntelligenceError(
                             "bounded remote provider isolation was not established"
                         )
-                    if status == "RESULT" and isinstance(payload, dict):
-                        return cast(dict[str, Any], payload)
+                    if status == "RESULT":
+                        try:
+                            decoded = json.loads(payload)
+                        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                            raise RepositoryIntelligenceError(
+                                "bounded remote provider result was malformed"
+                            ) from exc
+                        if not isinstance(decoded, dict):
+                            raise RepositoryIntelligenceError(
+                                "bounded remote provider result was malformed"
+                            )
+                        return cast(dict[str, Any], decoded)
                     if status == "PERMISSION":
                         raise PermissionError("bounded remote provider denied access")
-                    safe_type = payload if isinstance(payload, str) else "UnknownError"
+                    safe_type = (
+                        payload.decode("ascii", errors="replace")
+                        if status == "ERROR"
+                        else "UnknownError"
+                    )
                     raise RepositoryIntelligenceError(
                         f"bounded remote provider failed safely: {safe_type}"
                     )
@@ -984,13 +1053,16 @@ class GovernanceCollector:
         tool_identity = self.runner.identity
         api_version = GOVERNANCE_COLLECTOR_VERSION
         disposition = "BLOCKED" if self._local_unknowns else "PARTIAL"
+        remote_collection_status = "NOT_REQUESTED"
         sanitized_remote: dict[str, Any] = {}
         if self.remote_provider is not None:
             tool_identity = self.remote_provider.tool_identity
             api_version = self.remote_provider.api_version
+            remote_collection_status = "STARTED"
             try:
                 raw_remote = self._collect_remote_bounded(ref)
             except (PermissionError, OSError):
+                remote_collection_status = "PERMISSION_OR_IO_BLOCKED"
                 disposition = "BLOCKED"
                 unknowns = (
                     *self._local_unknowns,
@@ -1004,6 +1076,7 @@ class GovernanceCollector:
                     ),
                 )
             except Exception as exc:
+                remote_collection_status = "ERROR_BLOCKED"
                 disposition = "BLOCKED"
                 unknowns = (
                     *self._local_unknowns,
@@ -1098,6 +1171,7 @@ class GovernanceCollector:
                     ):
                         raise ValueError("remote pagination evidence is malformed")
                 except (KeyError, TypeError, ValueError, RepositoryIntelligenceError):
+                    remote_collection_status = "INVALID_BLOCKED"
                     disposition = "BLOCKED"
                     unknowns = (
                         *self._local_unknowns,
@@ -1108,6 +1182,7 @@ class GovernanceCollector:
                         ),
                     )
                 else:
+                    remote_collection_status = "EVALUATED"
                     unknowns = (*self._local_unknowns, *remote_unknowns)
                     disposition = (
                         "BLOCKED"
@@ -1157,6 +1232,7 @@ class GovernanceCollector:
         if self._is_cancelled() and not any(
             item.fact == "observation_cancellation" for item in unknowns
         ):
+            remote_collection_status = "CANCELLED"
             disposition = "BLOCKED"
             unknowns = (
                 *unknowns,
@@ -1186,9 +1262,27 @@ class GovernanceCollector:
             "local_branches": [asdict(item) for item in branches],
             "worktrees": [asdict(item) for item in worktrees],
             "command_provenance": [asdict(item) for item in self._command_provenance],
+            "collector_configuration": {
+                "command_timeout_seconds": self.timeout,
+                "max_commands": self.max_commands,
+                "max_branches": self.max_branches,
+                "max_output_bytes": self.max_output_bytes,
+                "max_remote_items": self.max_remote_items,
+                "max_remote_age_seconds": self.max_remote_age_seconds,
+            },
             "remote_result": sanitized_remote,
+            "remote_collection_status": remote_collection_status,
             "remote_observed_at": remote_observed_at,
             "remote_query_coverage": remote_query_coverage,
+            "normalized_remote_evidence": {
+                "remote_branches": [asdict(item) for item in remote_branches],
+                "pull_requests": [asdict(item) for item in pull_requests],
+                "issues": [asdict(item) for item in issues],
+                "governance": governance,
+                "query_provenance": [asdict(item) for item in provenance],
+            },
+            "evaluation_disposition": disposition,
+            "evaluation_unknowns": [asdict(item) for item in unknowns],
             "tool_identity": tool_identity,
             "api_query_version": api_version,
             "collector_version": GOVERNANCE_COLLECTOR_VERSION,

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -17,7 +17,7 @@ from contextlib import suppress
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Any, Protocol, cast, final
 
 from pmpe.contracts.canonical import canonical_digest
 from pmpe.repository.models import (
@@ -46,7 +46,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.8.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.9.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -114,6 +114,64 @@ class RemoteProvider(Protocol):
         max_items: int,
         cancellation: Cancellation | None,
     ) -> dict[str, Any]: ...
+
+
+@final
+class RecordedRemoteProvider:
+    """Sealed, data-only remote input that cannot execute caller-supplied collection code."""
+
+    __slots__ = ("_delay_seconds", "_payload", "_permission_denied", "api_version")
+
+    tool_identity = "recorded-remote-payload/1.0.0"
+
+    def __init__(
+        self,
+        payload: dict[str, Any],
+        *,
+        api_version: str,
+        delay_seconds: float = 0.0,
+        permission_denied: bool = False,
+    ) -> None:
+        if not api_version.strip():
+            raise ValueError("recorded remote API version is required")
+        if not math.isfinite(delay_seconds) or not 0 <= delay_seconds <= 300:
+            raise ValueError("recorded remote delay must be bounded")
+        try:
+            self._payload = json.dumps(
+                payload,
+                allow_nan=False,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise ValueError("recorded remote payload is not canonical JSON") from exc
+        self.api_version = api_version
+        self._delay_seconds = delay_seconds
+        self._permission_denied = permission_denied
+
+    def collect(
+        self,
+        repository: str,
+        ref: str,
+        *,
+        timeout_seconds: int,
+        max_output_bytes: int,
+        max_items: int,
+        cancellation: Cancellation | None,
+    ) -> dict[str, Any]:
+        del repository, ref, timeout_seconds, max_output_bytes, max_items
+        deadline = time.monotonic() + self._delay_seconds
+        while time.monotonic() < deadline:
+            if _cancellation_requested(cancellation):
+                raise RepositoryIntelligenceError("recorded remote replay was cancelled")
+            time.sleep(min(0.01, max(0.0, deadline - time.monotonic())))
+        if self._permission_denied:
+            raise PermissionError("recorded remote input reports permission denial")
+        decoded = json.loads(self._payload)
+        if not isinstance(decoded, dict):
+            raise RepositoryIntelligenceError("recorded remote payload is malformed")
+        return cast(dict[str, Any], decoded)
 
 
 class SystemUtcClock:
@@ -534,9 +592,16 @@ def _validate_remote_payload_types(value: dict[str, Any]) -> None:
         collection = value.get(key)
         if not isinstance(collection, list):
             raise ValueError(f"remote {key} inventory is malformed")
+        allowed_fields = {field for field, _predicate in required}
+        if key == "query_provenance":
+            allowed_fields.add("cursor")
         for item in collection:
-            if not isinstance(item, dict) or any(
-                field not in item or not predicate(item[field]) for field, predicate in required
+            if (
+                not isinstance(item, dict)
+                or set(item) != allowed_fields
+                or any(
+                    field not in item or not predicate(item[field]) for field, predicate in required
+                )
             ):
                 raise ValueError(f"remote {key} record is malformed")
             if key == "query_provenance" and not (
@@ -638,9 +703,16 @@ class GovernanceCollector:
         cancellation: Cancellation | None = None,
     ) -> None:
         self.repository = repository
-        if snapshot is not None and snapshot.repository != repository:
-            raise RepositoryIntelligenceError(
-                "governance repository label does not match the bound snapshot"
+        if snapshot is not None:
+            if snapshot.repository != repository:
+                raise RepositoryIntelligenceError(
+                    "governance repository label does not match the bound snapshot"
+                )
+            if not snapshot.digest_is_valid():
+                raise RepositorySecurityError("bound repository snapshot digest is invalid")
+        if remote_provider is not None and type(remote_provider) is not RecordedRemoteProvider:
+            raise RepositorySecurityError(
+                "remote observations require the sealed data-only provider"
             )
         self.snapshot = snapshot
         self.clock = clock

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -47,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.6.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.7.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -56,8 +56,8 @@ GOVERNANCE_IMPLEMENTATION_MODULES = (
     "contracts.canonical",
 )
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
-_REQUIRED_GOVERNANCE_FACTS = frozenset({"branch_protection", "review_policy"})
 _GOVERNANCE_SCHEMA_VERSION = "pmpe.repository-governance/v1"
+_GOVERNANCE_FIELDS = frozenset({"schema_version", "branch_protection", "review_policy"})
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
 _REMOTE_PAYLOAD_FIELDS = frozenset(
     {
@@ -653,20 +653,23 @@ def _stop_remote_process(process: Any) -> None:
 
 
 def _governance_content_is_complete(value: dict[str, Any]) -> bool:
-    if value.get(
-        "schema_version"
-    ) != _GOVERNANCE_SCHEMA_VERSION or not _REQUIRED_GOVERNANCE_FACTS.issubset(value):
+    if (
+        value.get("schema_version") != _GOVERNANCE_SCHEMA_VERSION
+        or set(value) != _GOVERNANCE_FIELDS
+    ):
         return False
     branch_protection = value["branch_protection"]
     review_policy = value["review_policy"]
     if (
         not isinstance(branch_protection, dict)
+        or set(branch_protection) != {"observed", "required_checks"}
         or not isinstance(branch_protection.get("observed"), bool)
         or not isinstance(branch_protection.get("required_checks"), list)
         or not all(_is_str(item) for item in branch_protection["required_checks"])
         or len(set(branch_protection["required_checks"]))
         != len(branch_protection["required_checks"])
         or not isinstance(review_policy, dict)
+        or set(review_policy) != {"required_approvals"}
         or not _is_int(review_policy.get("required_approvals"))
         or review_policy["required_approvals"] < 0
     ):
@@ -753,7 +756,10 @@ def _validate_remote_payload_types(value: dict[str, Any]) -> None:
                 ("mergeability", _is_str),
             ),
         ),
-        ("issues", (("number", _is_int), ("state", _is_str))),
+        (
+            "issues",
+            (("number", _is_int), ("state", lambda item: item in {"OPEN", "CLOSED"})),
+        ),
         (
             "query_provenance",
             (
@@ -904,8 +910,10 @@ class GovernanceCollector:
             )
         if command_runner is not None and type(command_runner) is not GovernanceCommandRunner:
             raise RepositorySecurityError("governance observations require the sealed Git reader")
-        if redactor is not None and type(redactor) is not EvidenceRedactor:
-            raise RepositorySecurityError("governance observations require the sealed redactor")
+        if redactor is not None:
+            raise RepositorySecurityError(
+                "governance observations use only the sealed fixed state-free redaction policy"
+            )
         if cancellation is not None and type(cancellation) is not CancellationSignal:
             raise RepositorySecurityError(
                 "governance observations require the sealed cancellation signal"
@@ -915,7 +923,7 @@ class GovernanceCollector:
         self.id_provider = id_provider
         self.remote_provider = remote_provider
         self.runner = command_runner or GovernanceCommandRunner(max_output_bytes=max_output_bytes)
-        self.redactor = redactor or EvidenceRedactor()
+        self.redactor = EvidenceRedactor(environment={})
         self.timeout = command_timeout_seconds
         self.max_commands = max_commands
         self.max_branches = max_branches
@@ -1483,7 +1491,7 @@ class GovernanceCollector:
                     remote_query_coverage = tuple(
                         sorted(cast(list[str], sanitized_remote["coverage"]))
                     )
-                    coverage_complete = _REQUIRED_REMOTE_COVERAGE.issubset(remote_query_coverage)
+                    coverage_complete = set(remote_query_coverage) == _REQUIRED_REMOTE_COVERAGE
                     freshness_proven = -30 <= remote_age <= self.max_remote_age_seconds
                     remote_branches = tuple(
                         RemoteBranchObservation(name=item["name"], sha=item["sha"])

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -1088,8 +1088,8 @@ class GovernanceCollector:
                         record_invalid = False
                         continue
                     missing = {"worktree", "HEAD"} - set(current)
-                    detached = "detached" in current or "bare" in current
-                    if missing or ("branch" not in current and not detached):
+                    lifecycle_states = sum(key in current for key in ("branch", "detached", "bare"))
+                    if missing or lifecycle_states != 1:
                         self._local_unknowns.append(
                             UnknownFact(
                                 fact=f"worktree_record:{record_number}",
@@ -1106,7 +1106,9 @@ class GovernanceCollector:
                         WorktreeObservation(
                             path=current["worktree"],
                             head_sha=current["HEAD"],
-                            branch=current.get("branch", "DETACHED").removeprefix("refs/heads/"),
+                            branch=current.get(
+                                "branch", "BARE" if "bare" in current else "DETACHED"
+                            ).removeprefix("refs/heads/"),
                             bare="bare" in current,
                             detached="detached" in current,
                             locked="locked" in current,
@@ -1151,6 +1153,28 @@ class GovernanceCollector:
                         fact=f"worktree_record:{record_number + 1}",
                         status="BLOCKED",
                         reason="A required Git worktree field is malformed.",
+                    )
+                )
+                current = {}
+                record_invalid = True
+                continue
+            if key in {"bare", "detached"} and (separator or value):
+                self._local_unknowns.append(
+                    UnknownFact(
+                        fact=f"worktree_record:{record_number + 1}",
+                        status="BLOCKED",
+                        reason="A marker-only Git worktree field contains an unexpected value.",
+                    )
+                )
+                current = {}
+                record_invalid = True
+                continue
+            if key in {"locked", "prunable"} and separator and not value:
+                self._local_unknowns.append(
+                    UnknownFact(
+                        fact=f"worktree_record:{record_number + 1}",
+                        status="BLOCKED",
+                        reason="A Git worktree lifecycle reason is malformed.",
                     )
                 )
                 current = {}

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -47,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.2.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.3.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -1107,8 +1107,25 @@ class GovernanceCollector:
                             path=current["worktree"],
                             head_sha=current["HEAD"],
                             branch=current.get("branch", "DETACHED").removeprefix("refs/heads/"),
+                            bare="bare" in current,
+                            detached="detached" in current,
+                            locked="locked" in current,
+                            locked_reason=current.get("locked") or None,
+                            prunable="prunable" in current,
+                            prunable_reason=current.get("prunable") or None,
                         )
                     )
+                    if "prunable" in current:
+                        self._local_unknowns.append(
+                            UnknownFact(
+                                fact=f"worktree_prunable:{record_number}",
+                                status="BLOCKED",
+                                reason=(
+                                    "Git reports a prunable worktree; its lifecycle state is "
+                                    "preserved but cannot be represented as healthy active work."
+                                ),
+                            )
+                        )
                     current = {}
                 continue
             key, separator, value = field.partition(" ")

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import json
 import math
@@ -49,14 +50,14 @@ from pmpe.repository.scanner import (
     _cancellation_requested,
     _implementation_module_evidence,
     _implementation_source_evidence,
+    _module_attribute_value_evidence,
     _runtime_dependency_evidence,
-    _runtime_dependency_module_digest,
     _spawn_guarded_git,
     _stop_guarded_process_group,
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.14.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.15.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -965,32 +966,93 @@ def _validate_remote_payload_types(value: dict[str, Any]) -> None:
         raise ValueError("remote default branch is malformed")
 
 
-def _governance_import_binding_state_digest(names: tuple[str, ...]) -> str:
-    evidence: list[dict[str, str]] = []
-    for name in names:
-        target = globals().get(name)
-        if type(target) is not ModuleType:
-            evidence.append({"binding": name, "module": "INVALID", "runtime_digest": "INVALID"})
-            continue
-        evidence.append(
-            {
-                "binding": name,
-                "module": target.__name__,
-                "runtime_digest": _runtime_dependency_module_digest(target),
-            }
-        )
-    return canonical_digest(evidence)
-
-
 _SEALED_GOVERNANCE_IMPORT_NAMES = tuple(
     sorted(name for name, target in globals().items() if type(target) is ModuleType)
 )
-_SEALED_GOVERNANCE_IMPORT_STATE_NAMES = ("json", "math", "os", "re", "time", "uuid")
-_SEALED_GOVERNANCE_IMPORT_STATE_DIGEST = _governance_import_binding_state_digest(
-    _SEALED_GOVERNANCE_IMPORT_STATE_NAMES
-)
 _SEALED_GOVERNANCE_IMPORT_PROCESS_IDENTITIES = tuple(
     (name, id(globals()[name])) for name in _SEALED_GOVERNANCE_IMPORT_NAMES
+)
+
+
+def _governance_direct_module_attribute_names() -> tuple[tuple[str, tuple[str, ...]], ...]:
+    try:
+        tree = ast.parse(_GOVERNANCE_IMPLEMENTATION_PATHS["repository.governance"].read_text())
+    except (OSError, SyntaxError, UnicodeError) as exc:
+        raise RepositoryIntelligenceError(
+            "governance module attributes are unavailable for provenance binding"
+        ) from exc
+    attributes: dict[str, set[str]] = {name: set() for name in _SEALED_GOVERNANCE_IMPORT_NAMES}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in attributes
+        ):
+            attributes[node.value.id].add(node.attr)
+    return tuple(
+        (name, tuple(sorted(names))) for name, names in sorted(attributes.items()) if names
+    )
+
+
+def _governance_module_attribute_identities(
+    attribute_names: tuple[tuple[str, tuple[str, ...]], ...],
+) -> tuple[tuple[str, str, int], ...]:
+    identities: list[tuple[str, str, int]] = []
+    for module_name, names in attribute_names:
+        module = globals().get(module_name)
+        namespace = vars(module) if type(module) is ModuleType else {}
+        for name in names:
+            target = namespace.get(name)
+            identities.append((module_name, name, id(target) if target is not None else -1))
+    return tuple(identities)
+
+
+def _governance_module_attribute_state_digest(
+    attribute_names: tuple[tuple[str, tuple[str, ...]], ...],
+) -> str:
+    evidence: list[dict[str, Any]] = []
+    for module_name, names in attribute_names:
+        module = globals().get(module_name)
+        if type(module) is not ModuleType:
+            raise RepositorySecurityError("governance imported-module binding changed")
+        namespace = vars(module)
+        for name in names:
+            if name not in namespace:
+                raise RepositorySecurityError("governance imported-module attribute is unavailable")
+            evidence.append(
+                {
+                    "module": module_name,
+                    "attribute": name,
+                    "state": _module_attribute_value_evidence(module_name, name, namespace[name]),
+                }
+            )
+    return canonical_digest(evidence)
+
+
+def _governance_external_global_names() -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            name
+            for name, target in globals().items()
+            if (
+                type(target) is ModuleType
+                or callable(target)
+                and str(getattr(target, "__module__", "")) != __name__
+            )
+        )
+    )
+
+
+_SEALED_GOVERNANCE_MODULE_ATTRIBUTE_NAMES = _governance_direct_module_attribute_names()
+_SEALED_GOVERNANCE_MODULE_ATTRIBUTE_STATE_DIGEST = _governance_module_attribute_state_digest(
+    _SEALED_GOVERNANCE_MODULE_ATTRIBUTE_NAMES
+)
+_SEALED_GOVERNANCE_MODULE_ATTRIBUTE_PROCESS_IDENTITIES = _governance_module_attribute_identities(
+    _SEALED_GOVERNANCE_MODULE_ATTRIBUTE_NAMES
+)
+_SEALED_GOVERNANCE_EXTERNAL_GLOBAL_NAMES = _governance_external_global_names()
+_SEALED_GOVERNANCE_EXTERNAL_GLOBAL_PROCESS_IDENTITIES = tuple(
+    (name, id(globals()[name])) for name in _SEALED_GOVERNANCE_EXTERNAL_GLOBAL_NAMES
 )
 
 
@@ -1005,11 +1067,21 @@ def _assert_governance_import_bindings_sealed(*, verify_state: bool = False) -> 
     )
     if current_identities != _SEALED_GOVERNANCE_IMPORT_PROCESS_IDENTITIES:
         raise RepositorySecurityError("governance imported-module bindings changed")
-    if verify_state and (
-        _governance_import_binding_state_digest(_SEALED_GOVERNANCE_IMPORT_STATE_NAMES)
-        != _SEALED_GOVERNANCE_IMPORT_STATE_DIGEST
+    if (
+        _governance_module_attribute_identities(_SEALED_GOVERNANCE_MODULE_ATTRIBUTE_NAMES)
+        != _SEALED_GOVERNANCE_MODULE_ATTRIBUTE_PROCESS_IDENTITIES
     ):
-        raise RepositorySecurityError("governance imported-module state changed")
+        raise RepositorySecurityError("governance imported-module attributes changed")
+    if (
+        tuple((name, id(globals().get(name))) for name in _SEALED_GOVERNANCE_EXTERNAL_GLOBAL_NAMES)
+        != _SEALED_GOVERNANCE_EXTERNAL_GLOBAL_PROCESS_IDENTITIES
+    ):
+        raise RepositorySecurityError("governance imported global bindings changed")
+    if verify_state and (
+        _governance_module_attribute_state_digest(_SEALED_GOVERNANCE_MODULE_ATTRIBUTE_NAMES)
+        != _SEALED_GOVERNANCE_MODULE_ATTRIBUTE_STATE_DIGEST
+    ):
+        raise RepositorySecurityError("governance imported-module attribute state changed")
 
 
 def _governance_implementation_digest(
@@ -1787,6 +1859,7 @@ class GovernanceCollector:
 
     def observe(self, repository_root: Path | str, *, ref: str) -> GovernanceObservation:
         self._assert_execution_collaborators_sealed()
+        _assert_governance_import_bindings_sealed(verify_state=True)
         self._assert_bound_snapshot_valid()
         self._command_provenance = []
         self._commands = 0

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -47,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/3.0.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.0.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -66,6 +66,7 @@ _REMOTE_PAYLOAD_FIELDS = frozenset(
         "complete",
         "repository",
         "ref",
+        "default_branch",
         "observed_at",
         "coverage",
         "remote_branches",
@@ -77,6 +78,16 @@ _REMOTE_PAYLOAD_FIELDS = frozenset(
     }
 )
 _SAFE_REF = re.compile(r"^(?:HEAD|[A-Za-z0-9][A-Za-z0-9._/-]{0,255})$")
+_SAFE_REMOTE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$")
+_MAX_GOVERNANCE_BUDGETS = {
+    "command_timeout_seconds": 120,
+    "max_commands": 20_000,
+    "max_branches": 10_000,
+    "max_output_bytes": 64_000_000,
+    "max_remote_items": 100_000,
+    "max_remote_age_seconds": 86_400,
+    "stale_pull_request_after_seconds": 31_536_000,
+}
 
 
 def _valid_ref(value: str) -> bool:
@@ -155,6 +166,9 @@ class RemoteProvider(Protocol):
     tool_identity: str
     api_version: str
 
+    @property
+    def collection_provenance(self) -> dict[str, Any]: ...
+
     def collect(
         self,
         repository: str,
@@ -171,9 +185,15 @@ class RemoteProvider(Protocol):
 class RecordedRemoteProvider:
     """Sealed, data-only remote input that cannot execute caller-supplied collection code."""
 
-    __slots__ = ("_delay_seconds", "_payload", "_permission_denied", "api_version")
+    __slots__ = (
+        "_collection_provenance",
+        "_delay_seconds",
+        "_payload",
+        "_permission_denied",
+        "api_version",
+    )
 
-    tool_identity = "recorded-remote-payload/1.1.0"
+    tool_identity = "recorded-remote-payload/2.0.0"
 
     def __init__(
         self,
@@ -198,8 +218,19 @@ class RecordedRemoteProvider:
         except (TypeError, ValueError) as exc:
             raise ValueError("recorded remote payload is not canonical JSON") from exc
         self.api_version = api_version
+        self._collection_provenance = {
+            "source_kind": "RECORDED_UNATTESTED",
+            "replay_provider": self.tool_identity,
+            "api_version": api_version,
+            "recorded_payload_digest": "sha256:" + hashlib.sha256(self._payload).hexdigest(),
+            "attestation": "ABSENT",
+        }
         self._delay_seconds = delay_seconds
         self._permission_denied = permission_denied
+
+    @property
+    def collection_provenance(self) -> dict[str, Any]:
+        return dict(self._collection_provenance)
 
     def collect(
         self,
@@ -211,7 +242,13 @@ class RecordedRemoteProvider:
         max_items: int,
         cancellation: Cancellation | None,
     ) -> dict[str, Any]:
-        del repository, ref, timeout_seconds
+        del repository, ref
+        if (
+            timeout_seconds > _MAX_GOVERNANCE_BUDGETS["command_timeout_seconds"]
+            or max_output_bytes > _MAX_GOVERNANCE_BUDGETS["max_output_bytes"]
+            or max_items > _MAX_GOVERNANCE_BUDGETS["max_remote_items"]
+        ):
+            raise RepositoryIntelligenceError("recorded remote replay budget exceeds hard ceiling")
         if _cancellation_requested(cancellation):
             raise RepositoryIntelligenceError("recorded remote replay was cancelled")
         _preflight_json_limits(
@@ -362,6 +399,8 @@ class GovernanceCommandRunner:
         "rev-list",
         "worktree",
         "ls-files",
+        "remote",
+        "symbolic-ref",
     }
     _filter_probe = (
         "--name-only",
@@ -376,6 +415,10 @@ class GovernanceCommandRunner:
     )
 
     def __init__(self, *, max_output_bytes: int = 8_000_000) -> None:
+        if not 0 < max_output_bytes <= _MAX_GOVERNANCE_BUDGETS["max_output_bytes"]:
+            raise RepositoryIntelligenceError(
+                "governance command output budget exceeds hard ceiling"
+            )
         self.max_output_bytes = max_output_bytes
 
     def run(
@@ -398,6 +441,10 @@ class GovernanceCommandRunner:
             raise RepositorySecurityError("Git status reads are outside the safe probe")
         if args[1] == "worktree" and (len(args) < 3 or args[2] != "list"):
             raise RepositorySecurityError("mutating Git worktree command was refused")
+        if args[1] == "remote" and args[2:]:
+            raise RepositorySecurityError("Git remote reads are outside the safe inventory")
+        if args[1] == "symbolic-ref" and args[2:] != ("--quiet", "--short", "HEAD"):
+            raise RepositorySecurityError("Git symbolic-ref reads are outside the safe probe")
         safe_environment = {
             "PATH": "/usr/bin:/bin",
             "GIT_CONFIG_GLOBAL": os.devnull,
@@ -779,6 +826,7 @@ def _validate_remote_payload_types(value: dict[str, Any]) -> None:
         or not isinstance(value.get("complete"), bool)
         or not _is_str(value.get("repository"))
         or not _is_str(value.get("ref"))
+        or not _is_str(value.get("default_branch"))
         or not _is_str(value.get("observed_at"))
         or not isinstance(value.get("coverage"), list)
         or not all(_is_str(item) for item in value["coverage"])
@@ -788,7 +836,17 @@ def _validate_remote_payload_types(value: dict[str, Any]) -> None:
         raise ValueError("remote payload envelope is malformed")
 
     records: tuple[tuple[str, tuple[tuple[str, Any], ...]], ...] = (
-        ("remote_branches", (("name", _is_str), ("sha", _is_str))),
+        (
+            "remote_branches",
+            (
+                ("name", _is_str),
+                ("sha", _is_str),
+                ("comparison_ref", _is_str),
+                ("ahead", _is_int),
+                ("behind", _is_int),
+                ("status", lambda item: item in {"OBSERVED", "UNKNOWN", "BLOCKED"}),
+            ),
+        ),
         (
             "pull_requests",
             (
@@ -840,6 +898,13 @@ def _validate_remote_payload_types(value: dict[str, Any]) -> None:
                 raise ValueError("remote query cursor is malformed")
     if any(item["number"] < 1 for key in ("pull_requests", "issues") for item in value[key]):
         raise ValueError("remote record number is malformed")
+    if any(
+        item["ahead"] < 0 or item["behind"] < 0 or item["comparison_ref"] != value["ref"]
+        for item in value["remote_branches"]
+    ):
+        raise ValueError("remote branch divergence is malformed")
+    if not _valid_ref(value["default_branch"]):
+        raise ValueError("remote default branch is malformed")
 
 
 def _governance_implementation_digest(
@@ -880,6 +945,8 @@ def _observation_from_dict(value: dict[str, Any]) -> GovernanceObservation:
         repository_snapshot_digest=cast(str | None, value["repository_snapshot_digest"]),
         repository_snapshot_commit=cast(str | None, value["repository_snapshot_commit"]),
         local_state=LocalState(**value["local_state"]),
+        current_branch=str(value["current_branch"]),
+        configured_remotes=tuple(value["configured_remotes"]),
         local_branches=tuple(BranchObservation(**item) for item in value["local_branches"]),
         worktrees=tuple(WorktreeObservation(**item) for item in value["worktrees"]),
         command_provenance=tuple(
@@ -892,12 +959,14 @@ def _observation_from_dict(value: dict[str, Any]) -> GovernanceObservation:
             for item in value["command_provenance"]
         ),
         remote_branches=tuple(RemoteBranchObservation(**item) for item in value["remote_branches"]),
+        remote_default_branch=cast(str | None, value["remote_default_branch"]),
         pull_requests=tuple(PullRequestObservation(**item) for item in value["pull_requests"]),
         issues=tuple(IssueObservation(**item) for item in value["issues"]),
         governance=cast(dict[str, Any], value["governance"]),
         query_provenance=tuple(QueryProvenance(**item) for item in value["query_provenance"]),
         remote_observed_at=cast(str | None, value["remote_observed_at"]),
         remote_query_coverage=tuple(value["remote_query_coverage"]),
+        remote_collection_provenance=cast(dict[str, Any], value["remote_collection_provenance"]),
         unknowns=tuple(UnknownFact(**item) for item in value["unknowns"]),
         collector_version=str(value["collector_version"]),
         collector_implementation_digest=str(value["collector_implementation_digest"]),
@@ -1140,7 +1209,51 @@ class GovernanceCollector:
             receiver.close()
             _stop_remote_process(process)
 
-    def _branches(self, root: Path, ref: str) -> tuple[BranchObservation, ...]:
+    def _current_branch(self, root: Path) -> str:
+        result = self._execute(
+            root,
+            ("git", "symbolic-ref", "--quiet", "--short", "HEAD"),
+        )
+        if result.returncode == 1 and not result.timed_out:
+            return "DETACHED"
+        if result.returncode != 0 or result.timed_out:
+            self._local_unknowns.append(
+                UnknownFact(
+                    fact="current_branch",
+                    status="BLOCKED",
+                    reason="The current branch could not be observed safely.",
+                )
+            )
+            return "UNKNOWN"
+        value = _decode(result).strip()
+        if not _valid_ref(value):
+            self._local_unknowns.append(
+                UnknownFact(
+                    fact="current_branch",
+                    status="BLOCKED",
+                    reason="The current branch identity is malformed.",
+                )
+            )
+            return "UNKNOWN"
+        return value
+
+    def _configured_remotes(self, root: Path) -> tuple[str, ...]:
+        raw = self._run(root, "remote")
+        names = tuple(sorted(raw.splitlines()))
+        if len(names) != len(set(names)) or any(
+            _SAFE_REMOTE_NAME.fullmatch(name) is None for name in names
+        ):
+            self._local_unknowns.append(
+                UnknownFact(
+                    fact="configured_remotes",
+                    status="BLOCKED",
+                    reason="Configured Git remote names are malformed or duplicated.",
+                )
+            )
+            return ()
+        return names
+
+    def _branches(self, root: Path, reference_commit: str) -> tuple[BranchObservation, ...]:
         raw = self._run(
             root, "for-each-ref", "--format=%(refname:short) %(objectname)", "refs/heads"
         )
@@ -1164,7 +1277,13 @@ class GovernanceCollector:
             status = "OBSERVED"
             comparison = self._execute(
                 root,
-                ("git", "rev-list", "--left-right", "--count", f"{ref}...{name}"),
+                (
+                    "git",
+                    "rev-list",
+                    "--left-right",
+                    "--count",
+                    f"{reference_commit}...{name}",
+                ),
             )
             if comparison.returncode == 0 and not comparison.timed_out:
                 try:
@@ -1358,6 +1477,19 @@ class GovernanceCollector:
             )
         ):
             raise RepositoryIntelligenceError("governance observation budgets must be positive")
+        configured_budgets = {
+            "command_timeout_seconds": self.timeout,
+            "max_commands": self.max_commands,
+            "max_branches": self.max_branches,
+            "max_output_bytes": self.max_output_bytes,
+            "max_remote_items": self.max_remote_items,
+            "max_remote_age_seconds": self.max_remote_age_seconds,
+            "stale_pull_request_after_seconds": self.stale_pull_request_after_seconds,
+        }
+        if any(value > _MAX_GOVERNANCE_BUDGETS[name] for name, value in configured_budgets.items()):
+            raise RepositoryIntelligenceError(
+                "governance observation budget exceeds a hard safety ceiling"
+            )
         root = Path(repository_root).resolve()
         filter_probe = self._execute(
             root,
@@ -1449,7 +1581,22 @@ class GovernanceCollector:
             head_sha=head_sha,
             git_object_format=object_format,
         )
-        branches = self._branches(root, ref)
+        for is_dirty, fact, explanation in (
+            (index_dirty, "dirty_index", "The Git index contains uncommitted changes."),
+            (
+                worktree_dirty,
+                "dirty_worktree",
+                "The working tree contains unstaged tracked changes.",
+            ),
+            (untracked, "untracked_files", "The working tree contains untracked files."),
+        ):
+            if is_dirty:
+                self._local_unknowns.append(
+                    UnknownFact(fact=fact, status="BLOCKED", reason=explanation)
+                )
+        current_branch = self._current_branch(root)
+        configured_remotes = self._configured_remotes(root)
+        branches = self._branches(root, ref_commit)
         worktrees = self._worktrees(root)
         if any(not _valid_object_id(item.sha, object_format) for item in branches) or any(
             (item.bare and item.head_sha != "")
@@ -1467,7 +1614,9 @@ class GovernanceCollector:
         governance: dict[str, Any] = {}
         provenance: tuple[QueryProvenance, ...] = ()
         remote_observed_at: str | None = None
+        remote_default_branch: str | None = None
         remote_query_coverage: tuple[str, ...] = ()
+        remote_collection_provenance: dict[str, Any] = {}
         unknowns: tuple[UnknownFact, ...] = (
             *self._local_unknowns,
             UnknownFact(
@@ -1484,6 +1633,7 @@ class GovernanceCollector:
         if self.remote_provider is not None:
             tool_identity = self.remote_provider.tool_identity
             api_version = self.remote_provider.api_version
+            remote_collection_provenance = self.remote_provider.collection_provenance
             remote_collection_status = "STARTED"
             try:
                 raw_remote = self._collect_remote_bounded(ref)
@@ -1527,6 +1677,7 @@ class GovernanceCollector:
                     if sanitized_remote.get("ref") != ref:
                         raise ValueError("remote ref identity does not match the request")
                     remote_observed_at = cast(str, sanitized_remote["observed_at"])
+                    remote_default_branch = cast(str, sanitized_remote["default_branch"])
                     remote_observed_value = _parse_utc(
                         remote_observed_at, field="remote observation time"
                     )
@@ -1537,7 +1688,14 @@ class GovernanceCollector:
                     coverage_complete = set(remote_query_coverage) == _REQUIRED_REMOTE_COVERAGE
                     freshness_proven = -30 <= remote_age <= self.max_remote_age_seconds
                     remote_branches = tuple(
-                        RemoteBranchObservation(name=item["name"], sha=item["sha"])
+                        RemoteBranchObservation(
+                            name=item["name"],
+                            sha=item["sha"],
+                            comparison_ref=item["comparison_ref"],
+                            ahead=item["ahead"],
+                            behind=item["behind"],
+                            status=item["status"],
+                        )
                         for item in sanitized_remote["remote_branches"]
                     )
                     parsed_pull_requests: list[PullRequestObservation] = []
@@ -1615,6 +1773,23 @@ class GovernanceCollector:
                                 for number in unknown_mergeability
                             ),
                         )
+                    unresolved_remote_divergence = tuple(
+                        item.name for item in remote_branches if item.status != "OBSERVED"
+                    )
+                    if unresolved_remote_divergence:
+                        remote_unknowns = (
+                            *remote_unknowns,
+                            *(
+                                UnknownFact(
+                                    fact=f"remote_branch_divergence:{name}",
+                                    status="BLOCKED",
+                                    reason=(
+                                        "Remote branch divergence was not observed completely."
+                                    ),
+                                )
+                                for name in unresolved_remote_divergence
+                            ),
+                        )
                     if any(
                         not _valid_object_id(item.sha, object_format) for item in remote_branches
                     ) or any(
@@ -1645,7 +1820,19 @@ class GovernanceCollector:
                     )
                 else:
                     remote_collection_status = "EVALUATED"
-                    unknowns = (*self._local_unknowns, *remote_unknowns)
+                    unknowns = (
+                        *self._local_unknowns,
+                        *remote_unknowns,
+                        UnknownFact(
+                            fact="remote_collection_attestation",
+                            status="BLOCKED",
+                            reason=(
+                                "Remote facts were supplied as reproducible recorded input, "
+                                "but no independently verifiable collector attestation was "
+                                "available; they cannot make this observation complete."
+                            ),
+                        ),
+                    )
                     disposition = (
                         "BLOCKED"
                         if any(item.status == "BLOCKED" for item in unknowns)
@@ -1691,6 +1878,68 @@ class GovernanceCollector:
                             ),
                         )
 
+        revalidation_unknown_start = len(self._local_unknowns)
+        try:
+            final_ref_commit = self._run(
+                root,
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                f"{ref}^{{commit}}",
+            ).strip()
+            final_head_sha = self._run(root, "rev-parse", "HEAD").strip()
+            final_index_listing = self._run(root, "ls-files", "--stage", "-z")
+            final_status_raw = self._run(
+                root,
+                "status",
+                "--porcelain=v1",
+                "-z",
+                "--untracked-files=all",
+                "--ignore-submodules=all",
+            )
+            final_current_branch = self._current_branch(root)
+            final_configured_remotes = self._configured_remotes(root)
+            final_branches = self._branches(root, ref_commit)
+            final_worktrees = self._worktrees(root)
+        except RepositoryIntelligenceError:
+            disposition = "BLOCKED"
+            unknowns = (
+                *unknowns,
+                UnknownFact(
+                    fact="local_state_revalidation",
+                    status="BLOCKED",
+                    reason=("Mutable local state could not be revalidated before finalization."),
+                ),
+            )
+        else:
+            revalidation_unknowns = tuple(self._local_unknowns[revalidation_unknown_start:])
+            if revalidation_unknowns:
+                disposition = "BLOCKED"
+                unknowns = (*unknowns, *revalidation_unknowns)
+            if (
+                final_ref_commit != ref_commit
+                or final_head_sha != head_sha
+                or final_index_listing != index_listing
+                or final_status_raw != status_raw
+                or final_current_branch != current_branch
+                or final_configured_remotes != configured_remotes
+                or final_branches != branches
+                or final_worktrees != worktrees
+            ):
+                disposition = "BLOCKED"
+                unknowns = (
+                    *unknowns,
+                    UnknownFact(
+                        fact="concurrent_local_mutation",
+                        status="BLOCKED",
+                        reason=(
+                            "The ref, HEAD, index, worktree, branch, remote, or worktree "
+                            "inventory changed during collection; mixed-time facts were not "
+                            "represented as complete."
+                        ),
+                    ),
+                )
+
         if self._is_cancelled() and not any(
             item.fact == "observation_cancellation" for item in unknowns
         ):
@@ -1721,6 +1970,8 @@ class GovernanceCollector:
             "observed_at": observed_at,
             "local_status": status_raw,
             "local_state": asdict(local_state),
+            "current_branch": current_branch,
+            "configured_remotes": configured_remotes,
             "local_branches": [asdict(item) for item in branches],
             "worktrees": [asdict(item) for item in worktrees],
             "command_provenance": [asdict(item) for item in self._command_provenance],
@@ -1736,7 +1987,9 @@ class GovernanceCollector:
             "remote_result": sanitized_remote,
             "remote_collection_status": remote_collection_status,
             "remote_observed_at": remote_observed_at,
+            "remote_default_branch": remote_default_branch,
             "remote_query_coverage": remote_query_coverage,
+            "remote_collection_provenance": remote_collection_provenance,
             "normalized_remote_evidence": {
                 "remote_branches": [asdict(item) for item in remote_branches],
                 "pull_requests": [asdict(item) for item in pull_requests],
@@ -1768,16 +2021,20 @@ class GovernanceCollector:
                 self.snapshot.commit_sha if self.snapshot is not None else None
             ),
             local_state=local_state,
+            current_branch=current_branch,
+            configured_remotes=configured_remotes,
             local_branches=branches,
             worktrees=worktrees,
             command_provenance=tuple(self._command_provenance),
             remote_branches=remote_branches,
+            remote_default_branch=remote_default_branch,
             pull_requests=pull_requests,
             issues=issues,
             governance=governance,
             query_provenance=provenance,
             remote_observed_at=remote_observed_at,
             remote_query_coverage=remote_query_coverage,
+            remote_collection_provenance=remote_collection_provenance,
             unknowns=unknowns,
             collector_version=GOVERNANCE_COLLECTOR_VERSION,
             collector_implementation_digest=collector_digest,

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -37,6 +37,7 @@ from pmpe.repository.models import (
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 from pmpe.repository.scanner import (
     Cancellation,
+    CancellationSignal,
     RepositoryIntelligenceError,
     RepositorySecurityError,
     _cancellation_requested,
@@ -46,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.9.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.0.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -174,14 +175,49 @@ class RecordedRemoteProvider:
         return cast(dict[str, Any], decoded)
 
 
+@final
 class SystemUtcClock:
+    __slots__ = ()
+
     def now(self) -> str:
         return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
 
 
+@final
+class RecordedUtcClock:
+    """Data-only deterministic clock for reproducible observations."""
+
+    __slots__ = ("_value",)
+
+    def __init__(self, value: str) -> None:
+        _parse_utc(value, field="recorded observation time")
+        self._value = value
+
+    def now(self) -> str:
+        return self._value
+
+
+@final
 class UuidObservationIds:
+    __slots__ = ()
+
     def new_id(self) -> str:
         return f"OBS-{uuid.uuid4()}"
+
+
+@final
+class RecordedObservationIds:
+    """Data-only deterministic observation identifier provider."""
+
+    __slots__ = ("_value",)
+
+    def __init__(self, value: str) -> None:
+        if not re.fullmatch(r"OBS-[A-Za-z0-9._:-]{1,200}", value):
+            raise ValueError("recorded observation ID must be a safe opaque identifier")
+        self._value = value
+
+    def new_id(self) -> str:
+        return self._value
 
 
 class _SharedCancellation:
@@ -257,6 +293,7 @@ class GovernanceCommandRunner:
     """Allowlisted local Git observation commands with mutation subcommands refused."""
 
     identity = "git-governance-readonly/1.7.0"
+    __slots__ = ("max_output_bytes",)
     _allowed = {
         "config",
         "status",
@@ -283,6 +320,8 @@ class GovernanceCommandRunner:
         *,
         cancellation: Cancellation | None = None,
     ) -> CommandResult:
+        if cancellation is not None and type(cancellation) is not CancellationSignal:
+            raise RepositorySecurityError("governance cancellation requires the sealed signal")
         if len(args) < 2 or args[0] != "git" or args[1] not in self._allowed:
             raise RepositorySecurityError("command is outside the governance read-only allowlist")
         if args[1] == "config" and args[2:] != self._filter_probe:
@@ -713,6 +752,20 @@ class GovernanceCollector:
         if remote_provider is not None and type(remote_provider) is not RecordedRemoteProvider:
             raise RepositorySecurityError(
                 "remote observations require the sealed data-only provider"
+            )
+        if type(clock) not in {SystemUtcClock, RecordedUtcClock}:
+            raise RepositorySecurityError("governance observations require a sealed clock")
+        if type(id_provider) not in {UuidObservationIds, RecordedObservationIds}:
+            raise RepositorySecurityError(
+                "governance observations require a sealed observation ID provider"
+            )
+        if command_runner is not None and type(command_runner) is not GovernanceCommandRunner:
+            raise RepositorySecurityError("governance observations require the sealed Git reader")
+        if redactor is not None and type(redactor) is not EvidenceRedactor:
+            raise RepositorySecurityError("governance observations require the sealed redactor")
+        if cancellation is not None and type(cancellation) is not CancellationSignal:
+            raise RepositorySecurityError(
+                "governance observations require the sealed cancellation signal"
             )
         self.snapshot = snapshot
         self.clock = clock

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -37,10 +37,11 @@ from pmpe.repository.scanner import (
     Cancellation,
     RepositoryIntelligenceError,
     RepositorySecurityError,
+    _cancellation_requested,
     _implementation_source_evidence,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.5.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.6.0"
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
 _REQUIRED_GOVERNANCE_FACTS = frozenset({"branch_protection", "review_policy"})
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
@@ -156,7 +157,7 @@ def _remote_provider_worker(
 class GovernanceCommandRunner:
     """Allowlisted local Git observation commands with mutation subcommands refused."""
 
-    identity = "git-governance-readonly/1.5.0"
+    identity = "git-governance-readonly/1.6.0"
     _allowed = {
         "config",
         "status",
@@ -237,14 +238,12 @@ class GovernanceCommandRunner:
         cancelled = False
         try:
             while True:
-                if cancellation is not None and cancellation.cancelled():
+                if _cancellation_requested(cancellation):
                     cancelled = True
-                    _signal_process_group(process, signal.SIGTERM)
                     break
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     timed_out = True
-                    _signal_process_group(process, signal.SIGKILL)
                     break
                 events = selector.select(min(remaining, 0.1))
                 if not events:
@@ -255,24 +254,28 @@ class GovernanceCommandRunner:
                 payload.extend(chunk)
                 if len(payload) > self.max_output_bytes:
                     output_exceeded = True
-                    _signal_process_group(process, signal.SIGTERM)
                     break
+        except BaseException:
+            _stop_governance_process_group(process)
+            raise
         finally:
             selector.close()
             process.stdout.close()
-        try:
-            returncode = process.wait(
-                timeout=(
-                    0.25 if cancelled or output_exceeded else max(0.1, deadline - time.monotonic())
-                )
-            )
-        except subprocess.TimeoutExpired:
-            _signal_process_group(process, signal.SIGKILL)
+        if cancelled or output_exceeded or timed_out:
+            _stop_governance_process_group(process)
+            returncode = process.returncode
+        else:
             try:
-                returncode = process.wait(timeout=1.0)
-            except subprocess.TimeoutExpired as exc:
-                raise RepositorySecurityError("bounded Git process could not be reaped") from exc
-            timed_out = True
+                returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                _stop_governance_process_group(process)
+                returncode = process.returncode
+            else:
+                if not _signal_process_group(process, signal.SIGKILL):
+                    raise RepositorySecurityError(
+                        "governance Git descendant termination could not be proven"
+                    )
         return CommandResult(
             args=args,
             returncode=126 if cancelled else 125 if output_exceeded else returncode,
@@ -282,29 +285,52 @@ class GovernanceCommandRunner:
         )
 
 
-def _signal_process_group(process: subprocess.Popen[bytes], action: signal.Signals) -> None:
+def _signal_process_group(process: subprocess.Popen[bytes], action: signal.Signals) -> bool:
     """Stop the isolated Git process group, including any unexpected descendant."""
 
     try:
         os.killpg(process.pid, action)
+        return True
     except ProcessLookupError:
-        return
+        return True
     except OSError:
+        try:
+            os.killpg(process.pid, 0)
+        except ProcessLookupError:
+            return True
+        except OSError:
+            pass
         # Content filters are refused and submodule recursion is disabled. Always
         # fall back to the parent and let the caller prove it was reaped.
         try:
             process.send_signal(action)
         except ProcessLookupError:
-            return
+            return False
         except OSError:
             try:
                 process.kill()
             except ProcessLookupError:
-                return
+                return False
             except OSError as exc:
                 raise RepositorySecurityError(
                     "bounded Git process group and parent could not be terminated"
                 ) from exc
+        return False
+
+
+def _stop_governance_process_group(process: subprocess.Popen[bytes]) -> None:
+    """Terminate, fence, and reap a governance command and every descendant."""
+
+    _signal_process_group(process, signal.SIGTERM)
+    with suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=0.25)
+    group_proven = _signal_process_group(process, signal.SIGKILL)
+    try:
+        process.wait(timeout=1.0)
+    except subprocess.TimeoutExpired as exc:
+        raise RepositorySecurityError("bounded Git process could not be reaped") from exc
+    if not group_proven:
+        raise RepositorySecurityError("governance Git descendant termination could not be proven")
 
 
 def _decode(result: CommandResult) -> str:
@@ -359,18 +385,28 @@ def _stop_remote_process(process: Any) -> None:
 
     try:
         os.killpg(process.pid, signal.SIGTERM)
-    except (ProcessLookupError, PermissionError, OSError):
+    except ProcessLookupError:
+        pass
+    except (PermissionError, OSError):
         if process.is_alive():
             process.terminate()
     process.join(timeout=0.25)
     try:
         os.killpg(process.pid, signal.SIGKILL)
-    except (ProcessLookupError, PermissionError, OSError):
+        group_proven = True
+    except ProcessLookupError:
+        group_proven = True
+    except (PermissionError, OSError):
+        group_proven = False
         if process.is_alive():
             process.kill()
     process.join(timeout=1.0)
     if process.is_alive():
         raise RepositorySecurityError("bounded remote provider process could not be reaped")
+    if not group_proven:
+        raise RepositorySecurityError(
+            "bounded remote-provider descendant termination could not be proven"
+        )
 
 
 def _governance_content_is_complete(value: dict[str, Any]) -> bool:
@@ -422,6 +458,72 @@ def _pagination_is_complete(
         if any(not item.query.strip() for item in pages):
             return False
     return True
+
+
+def _is_str(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _is_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _validate_remote_payload_types(value: dict[str, Any]) -> None:
+    """Reject provider coercion before mutable evidence becomes authoritative."""
+
+    if (
+        not isinstance(value.get("complete"), bool)
+        or not _is_str(value.get("repository"))
+        or not _is_str(value.get("ref"))
+        or not _is_str(value.get("observed_at"))
+        or not isinstance(value.get("coverage"), list)
+        or not all(_is_str(item) for item in value["coverage"])
+        or len(set(value["coverage"])) != len(value["coverage"])
+        or not isinstance(value.get("governance"), dict)
+    ):
+        raise ValueError("remote payload envelope is malformed")
+
+    records: tuple[tuple[str, tuple[tuple[str, Any], ...]], ...] = (
+        ("remote_branches", (("name", _is_str), ("sha", _is_str))),
+        (
+            "pull_requests",
+            (
+                ("number", _is_int),
+                ("draft", lambda item: isinstance(item, bool)),
+                ("head", _is_str),
+            ),
+        ),
+        ("issues", (("number", _is_int), ("state", _is_str))),
+        (
+            "query_provenance",
+            (
+                ("surface", _is_str),
+                ("query", _is_str),
+                ("page", _is_int),
+                ("has_next_page", lambda item: isinstance(item, bool)),
+                ("result_count", _is_int),
+            ),
+        ),
+        (
+            "unknowns",
+            (("fact", _is_str), ("status", _is_str), ("reason", _is_str)),
+        ),
+    )
+    for key, required in records:
+        collection = value.get(key)
+        if not isinstance(collection, list):
+            raise ValueError(f"remote {key} inventory is malformed")
+        for item in collection:
+            if not isinstance(item, dict) or any(
+                field not in item or not predicate(item[field]) for field, predicate in required
+            ):
+                raise ValueError(f"remote {key} record is malformed")
+            if key == "query_provenance" and not (
+                item.get("cursor") is None or isinstance(item.get("cursor"), str)
+            ):
+                raise ValueError("remote query cursor is malformed")
+    if any(item["number"] < 1 for key in ("pull_requests", "issues") for item in value[key]):
+        raise ValueError("remote record number is malformed")
 
 
 def _governance_implementation_digest(
@@ -919,35 +1021,37 @@ class GovernanceCollector:
                         "remote evidence redaction failed; observation was not created"
                     ) from exc
                 try:
+                    _validate_remote_payload_types(raw_remote)
+                    _validate_remote_payload_types(sanitized_remote)
                     if sanitized_remote.get("repository") != self.repository:
                         raise ValueError("remote repository identity does not match the request")
                     if sanitized_remote.get("ref") != ref:
                         raise ValueError("remote ref identity does not match the request")
-                    remote_observed_at = str(sanitized_remote["observed_at"])
+                    remote_observed_at = cast(str, sanitized_remote["observed_at"])
                     remote_observed_value = _parse_utc(
                         remote_observed_at, field="remote observation time"
                     )
                     remote_age = (observed_at_value - remote_observed_value).total_seconds()
                     remote_query_coverage = tuple(
-                        sorted(str(item) for item in sanitized_remote.get("coverage", []))
+                        sorted(cast(list[str], sanitized_remote["coverage"]))
                     )
                     coverage_complete = _REQUIRED_REMOTE_COVERAGE.issubset(remote_query_coverage)
                     freshness_proven = -30 <= remote_age <= self.max_remote_age_seconds
                     remote_branches = tuple(
-                        RemoteBranchObservation(name=str(item["name"]), sha=str(item["sha"]))
-                        for item in sanitized_remote.get("remote_branches", [])
+                        RemoteBranchObservation(name=item["name"], sha=item["sha"])
+                        for item in sanitized_remote["remote_branches"]
                     )
                     pull_requests = tuple(
                         PullRequestObservation(
-                            number=int(item["number"]),
-                            draft=bool(item["draft"]),
-                            head=str(item["head"]),
+                            number=item["number"],
+                            draft=item["draft"],
+                            head=item["head"],
                         )
-                        for item in sanitized_remote.get("pull_requests", [])
+                        for item in sanitized_remote["pull_requests"]
                     )
                     issues = tuple(
-                        IssueObservation(number=int(item["number"]), state=str(item["state"]))
-                        for item in sanitized_remote.get("issues", [])
+                        IssueObservation(number=item["number"], state=item["state"])
+                        for item in sanitized_remote["issues"]
                     )
                     if len({item.name for item in remote_branches}) != len(remote_branches):
                         raise ValueError("remote branch inventory contains duplicate names")
@@ -955,26 +1059,26 @@ class GovernanceCollector:
                         raise ValueError("pull request inventory contains duplicate numbers")
                     if len({item.number for item in issues}) != len(issues):
                         raise ValueError("issue inventory contains duplicate numbers")
-                    governance = cast(dict[str, Any], sanitized_remote.get("governance", {}))
+                    governance = cast(dict[str, Any], sanitized_remote["governance"])
                     governance_complete = _governance_content_is_complete(governance)
                     provenance = tuple(
                         QueryProvenance(
-                            surface=str(item["surface"]),
-                            query=str(item["query"]),
+                            surface=item["surface"],
+                            query=item["query"],
                             cursor=cast(str | None, item.get("cursor")),
                             page=cast(int | None, item.get("page")),
-                            has_next_page=bool(item.get("has_next_page", True)),
+                            has_next_page=item["has_next_page"],
                             result_count=cast(int | None, item.get("result_count")),
                         )
-                        for item in sanitized_remote.get("query_provenance", [])
+                        for item in sanitized_remote["query_provenance"]
                     )
                     remote_unknowns = tuple(
                         UnknownFact(
-                            fact=str(item["fact"]),
-                            status=str(item["status"]),
-                            reason=str(item["reason"]),
+                            fact=item["fact"],
+                            status=item["status"],
+                            reason=item["reason"],
                         )
-                        for item in sanitized_remote.get("unknowns", [])
+                        for item in sanitized_remote["unknowns"]
                     )
                     if any(
                         not _valid_object_id(item.sha, object_format) for item in remote_branches

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -47,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.1.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.2.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -123,7 +123,7 @@ class RecordedRemoteProvider:
 
     __slots__ = ("_delay_seconds", "_payload", "_permission_denied", "api_version")
 
-    tool_identity = "recorded-remote-payload/1.0.0"
+    tool_identity = "recorded-remote-payload/1.1.0"
 
     def __init__(
         self,
@@ -161,7 +161,14 @@ class RecordedRemoteProvider:
         max_items: int,
         cancellation: Cancellation | None,
     ) -> dict[str, Any]:
-        del repository, ref, timeout_seconds, max_output_bytes, max_items
+        del repository, ref, timeout_seconds
+        if _cancellation_requested(cancellation):
+            raise RepositoryIntelligenceError("recorded remote replay was cancelled")
+        _preflight_json_limits(
+            self._payload,
+            max_bytes=max_output_bytes,
+            max_items=max_items,
+        )
         deadline = time.monotonic() + self._delay_seconds
         while time.monotonic() < deadline:
             if _cancellation_requested(cancellation):
@@ -169,9 +176,12 @@ class RecordedRemoteProvider:
             time.sleep(min(0.01, max(0.0, deadline - time.monotonic())))
         if self._permission_denied:
             raise PermissionError("recorded remote input reports permission denial")
+        if _cancellation_requested(cancellation):
+            raise RepositoryIntelligenceError("recorded remote replay was cancelled")
         decoded = json.loads(self._payload)
         if not isinstance(decoded, dict):
             raise RepositoryIntelligenceError("recorded remote payload is malformed")
+        _bounded_remote_shape(decoded, max_bytes=max_output_bytes, max_items=max_items)
         return cast(dict[str, Any], decoded)
 
 
@@ -502,6 +512,66 @@ def _bounded_remote_shape(value: Any, *, max_bytes: int, max_items: int) -> None
             raise RepositoryIntelligenceError("remote observation byte budget was exceeded")
 
 
+def _preflight_json_limits(payload: bytes, *, max_bytes: int, max_items: int) -> None:
+    """Bound encoded JSON bytes and value/key tokens before object materialization."""
+
+    if max_bytes <= 0 or max_items <= 0:
+        raise RepositoryIntelligenceError("remote observation budgets must be positive")
+    if len(payload) > max_bytes:
+        raise RepositoryIntelligenceError("recorded remote payload exceeds the byte budget")
+    index = 0
+    items = 0
+    length = len(payload)
+    whitespace_or_delimiter = b" \t\r\n,:]}"
+    while index < length:
+        current = payload[index]
+        if current in whitespace_or_delimiter:
+            index += 1
+            continue
+        if current in b"[{":
+            items += 1
+            index += 1
+        elif current == ord('"'):
+            items += 1
+            index += 1
+            while index < length:
+                current = payload[index]
+                index += 1
+                if current == ord('"'):
+                    break
+                if current == ord("\\"):
+                    if index >= length:
+                        raise RepositoryIntelligenceError("recorded remote payload is malformed")
+                    escape = payload[index]
+                    index += 1
+                    if escape == ord("u"):
+                        index += 4
+                        if index > length:
+                            raise RepositoryIntelligenceError(
+                                "recorded remote payload is malformed"
+                            )
+            else:
+                raise RepositoryIntelligenceError("recorded remote payload is malformed")
+        elif current in b"-0123456789":
+            items += 1
+            index += 1
+            while index < length and payload[index] in b"0123456789+-.eE":
+                index += 1
+        elif payload.startswith(b"true", index):
+            items += 1
+            index += 4
+        elif payload.startswith(b"false", index):
+            items += 1
+            index += 5
+        elif payload.startswith(b"null", index):
+            items += 1
+            index += 4
+        else:
+            raise RepositoryIntelligenceError("recorded remote payload is malformed")
+        if items > max_items:
+            raise RepositoryIntelligenceError("remote observation item budget was exceeded")
+
+
 def _stop_remote_process(process: Any) -> None:
     """Terminate and reap the isolated provider process and its descendants."""
 
@@ -609,6 +679,8 @@ def _validate_remote_payload_types(value: dict[str, Any]) -> None:
                 ("number", _is_int),
                 ("draft", lambda item: isinstance(item, bool)),
                 ("head", _is_str),
+                ("updated_at", _is_str),
+                ("mergeability", _is_str),
             ),
         ),
         ("issues", (("number", _is_int), ("state", _is_str))),
@@ -739,6 +811,7 @@ class GovernanceCollector:
         max_output_bytes: int = 8_000_000,
         max_remote_items: int = 20_000,
         max_remote_age_seconds: int = 300,
+        stale_pull_request_after_seconds: int = 2_592_000,
         cancellation: Cancellation | None = None,
     ) -> None:
         self.repository = repository
@@ -779,6 +852,7 @@ class GovernanceCollector:
         self.max_output_bytes = max_output_bytes
         self.max_remote_items = max_remote_items
         self.max_remote_age_seconds = max_remote_age_seconds
+        self.stale_pull_request_after_seconds = stale_pull_request_after_seconds
         self.cancellation = cancellation
         self._command_provenance: list[CommandProvenance] = []
         self._commands = 0
@@ -999,22 +1073,72 @@ class GovernanceCollector:
         return tuple(sorted(branches, key=lambda item: item.name))
 
     def _worktrees(self, root: Path) -> tuple[WorktreeObservation, ...]:
-        raw = self._run(root, "worktree", "list", "--porcelain")
+        raw = self._run(root, "worktree", "list", "--porcelain", "-z")
         results: list[WorktreeObservation] = []
         current: dict[str, str] = {}
-        for line in (*raw.splitlines(), ""):
-            if not line:
-                if current:
+        record_invalid = False
+        record_number = 0
+        allowed_fields = {"worktree", "HEAD", "branch", "bare", "detached", "locked", "prunable"}
+        for field in (*raw.split("\0"), ""):
+            if not field:
+                if current or record_invalid:
+                    record_number += 1
+                    if record_invalid:
+                        current = {}
+                        record_invalid = False
+                        continue
+                    missing = {"worktree", "HEAD"} - set(current)
+                    detached = "detached" in current or "bare" in current
+                    if missing or ("branch" not in current and not detached):
+                        self._local_unknowns.append(
+                            UnknownFact(
+                                fact=f"worktree_record:{record_number}",
+                                status="BLOCKED",
+                                reason=(
+                                    "A Git worktree record is incomplete; mutable worktree state "
+                                    "was not inferred."
+                                ),
+                            )
+                        )
+                        current = {}
+                        continue
                     results.append(
                         WorktreeObservation(
-                            path=current.get("worktree", "UNKNOWN"),
-                            head_sha=current.get("HEAD", "UNKNOWN"),
+                            path=current["worktree"],
+                            head_sha=current["HEAD"],
                             branch=current.get("branch", "DETACHED").removeprefix("refs/heads/"),
                         )
                     )
                     current = {}
                 continue
-            key, _, value = line.partition(" ")
+            key, separator, value = field.partition(" ")
+            if record_invalid:
+                continue
+            if key not in allowed_fields or key in current:
+                self._local_unknowns.append(
+                    UnknownFact(
+                        fact=f"worktree_record:{record_number + 1}",
+                        status="BLOCKED",
+                        reason=(
+                            "A Git worktree record contains an unknown or duplicate field; "
+                            "mutable worktree state was not inferred."
+                        ),
+                    )
+                )
+                current = {}
+                record_invalid = True
+                continue
+            if key in {"worktree", "HEAD", "branch"} and (not separator or not value):
+                self._local_unknowns.append(
+                    UnknownFact(
+                        fact=f"worktree_record:{record_number + 1}",
+                        status="BLOCKED",
+                        reason="A required Git worktree field is malformed.",
+                    )
+                )
+                current = {}
+                record_invalid = True
+                continue
             current[key] = value
         return tuple(sorted(results, key=lambda item: item.path))
 
@@ -1033,6 +1157,7 @@ class GovernanceCollector:
                 self.max_output_bytes,
                 self.max_remote_items,
                 self.max_remote_age_seconds,
+                self.stale_pull_request_after_seconds,
             )
         ):
             raise RepositoryIntelligenceError("governance observation budgets must be positive")
@@ -1139,8 +1264,7 @@ class GovernanceCollector:
         branches = self._branches(root, ref)
         worktrees = self._worktrees(root)
         if any(not _valid_object_id(item.sha, object_format) for item in branches) or any(
-            item.head_sha != "UNKNOWN" and not _valid_object_id(item.head_sha, object_format)
-            for item in worktrees
+            not _valid_object_id(item.head_sha, object_format) for item in worktrees
         ):
             raise RepositoryIntelligenceError("local Git reference identity is malformed")
         observed_at = self.clock.now()
@@ -1226,14 +1350,30 @@ class GovernanceCollector:
                         RemoteBranchObservation(name=item["name"], sha=item["sha"])
                         for item in sanitized_remote["remote_branches"]
                     )
-                    pull_requests = tuple(
-                        PullRequestObservation(
-                            number=item["number"],
-                            draft=item["draft"],
-                            head=item["head"],
+                    parsed_pull_requests: list[PullRequestObservation] = []
+                    for item in sanitized_remote["pull_requests"]:
+                        update_age = (
+                            remote_observed_value
+                            - _parse_utc(
+                                item["updated_at"],
+                                field="pull request update time",
+                            )
+                        ).total_seconds()
+                        if update_age < -30:
+                            raise ValueError(
+                                "pull request update time is later than the remote observation"
+                            )
+                        parsed_pull_requests.append(
+                            PullRequestObservation(
+                                number=item["number"],
+                                draft=item["draft"],
+                                head=item["head"],
+                                updated_at=item["updated_at"],
+                                mergeability=item["mergeability"],
+                                stale=update_age > self.stale_pull_request_after_seconds,
+                            )
                         )
-                        for item in sanitized_remote["pull_requests"]
-                    )
+                    pull_requests = tuple(parsed_pull_requests)
                     issues = tuple(
                         IssueObservation(number=item["number"], state=item["state"])
                         for item in sanitized_remote["issues"]
@@ -1265,6 +1405,26 @@ class GovernanceCollector:
                         )
                         for item in sanitized_remote["unknowns"]
                     )
+                    unknown_mergeability = tuple(
+                        item.number
+                        for item in pull_requests
+                        if item.mergeability not in {"MERGEABLE", "CONFLICTING"}
+                    )
+                    if unknown_mergeability:
+                        remote_unknowns = (
+                            *remote_unknowns,
+                            *(
+                                UnknownFact(
+                                    fact=f"pull_request_mergeability:{number}",
+                                    status="BLOCKED",
+                                    reason=(
+                                        "Pull request conflict/mergeability evidence is missing "
+                                        "or unsupported."
+                                    ),
+                                )
+                                for number in unknown_mergeability
+                            ),
+                        )
                     if any(
                         not _valid_object_id(item.sha, object_format) for item in remote_branches
                     ) or any(
@@ -1381,6 +1541,7 @@ class GovernanceCollector:
                 "max_output_bytes": self.max_output_bytes,
                 "max_remote_items": self.max_remote_items,
                 "max_remote_age_seconds": self.max_remote_age_seconds,
+                "stale_pull_request_after_seconds": self.stale_pull_request_after_seconds,
             },
             "remote_result": sanitized_remote,
             "remote_collection_status": remote_collection_status,

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -49,7 +49,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.1.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.2.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -1984,6 +1984,8 @@ class GovernanceCollector:
             "observation_id": observation_id,
             "observed_at": observed_at,
             "local_status": status_raw,
+            "git_index_listing_digest": "sha256:"
+            + hashlib.sha256(index_listing.encode("utf-8")).hexdigest(),
             "local_state": asdict(local_state),
             "current_branch": current_branch,
             "configured_remotes": configured_remotes,

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -47,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.0.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.1.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -292,7 +292,7 @@ def _remote_provider_worker(
 class GovernanceCommandRunner:
     """Allowlisted local Git observation commands with mutation subcommands refused."""
 
-    identity = "git-governance-readonly/1.7.0"
+    identity = "git-governance-readonly/1.8.0"
     __slots__ = ("max_output_bytes",)
     _allowed = {
         "config",
@@ -331,7 +331,7 @@ class GovernanceCommandRunner:
         if args[1] == "worktree" and (len(args) < 3 or args[2] != "list"):
             raise RepositorySecurityError("mutating Git worktree command was refused")
         safe_environment = {
-            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "PATH": "/usr/bin:/bin",
             "GIT_CONFIG_GLOBAL": os.devnull,
             "GIT_CONFIG_SYSTEM": os.devnull,
             "GIT_TERMINAL_PROMPT": "0",

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -49,7 +49,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.0.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.1.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -408,8 +408,8 @@ def _remote_provider_worker(
 class GovernanceCommandRunner:
     """Allowlisted local Git observation commands with mutation subcommands refused."""
 
-    identity = "git-governance-readonly/1.9.0"
-    __slots__ = ("max_output_bytes",)
+    identity = "git-governance-readonly/1.10.0"
+    __slots__ = ("_max_output_bytes",)
     _allowed = {
         "config",
         "status",
@@ -438,7 +438,11 @@ class GovernanceCommandRunner:
             raise RepositoryIntelligenceError(
                 "governance command output budget exceeds hard ceiling"
             )
-        self.max_output_bytes = max_output_bytes
+        self._max_output_bytes = max_output_bytes
+
+    @property
+    def max_output_bytes(self) -> int:
+        return self._max_output_bytes
 
     def run(
         self,
@@ -1079,6 +1083,10 @@ class GovernanceCollector:
     def _execute(self, root: Path, command: tuple[str, ...]) -> CommandResult:
         if self._is_cancelled():
             raise RepositoryIntelligenceError("governance observation was cancelled")
+        if self.runner.max_output_bytes != self.max_output_bytes:
+            raise RepositorySecurityError(
+                "governance command runner output budget changed after collector construction"
+            )
         if self._commands >= self.max_commands:
             raise RepositoryIntelligenceError("governance command budget was exhausted")
         self._commands += 1

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -35,6 +35,7 @@ from pmpe.repository.models import (
     RepositorySnapshot,
     UnknownFact,
     WorktreeObservation,
+    _assert_repository_model_bindings_sealed,
 )
 from pmpe.repository.redaction import (
     EvidenceRedactor,
@@ -52,13 +53,15 @@ from pmpe.repository.scanner import (
     _implementation_source_evidence,
     _module_attribute_value_evidence,
     _runtime_dependency_evidence,
-    _sealed_multiprocessing_context,
+    _sealed_fork_event,
+    _sealed_fork_pipe,
+    _sealed_fork_process,
     _spawn_guarded_git,
     _stop_guarded_process_group,
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.16.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.17.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -1108,7 +1111,10 @@ def _governance_implementation_digest(
     extension_evidence: tuple[dict[str, str], ...] = (),
 ) -> str:
     _assert_governance_import_bindings_sealed(verify_state=True)
-    _sealed_multiprocessing_context()
+    try:
+        _assert_repository_model_bindings_sealed()
+    except ValueError as exc:
+        raise RepositorySecurityError("repository model digest bindings changed") from exc
     evidence = _implementation_module_evidence(
         _GOVERNANCE_IMPLEMENTATION_PATHS,
         _GOVERNANCE_IMPORTED_SOURCE_DIGESTS,
@@ -1524,10 +1530,9 @@ class GovernanceCollector:
             raise RepositoryIntelligenceError(
                 "bounded remote provider execution is unsupported on this platform"
             )
-        context = _sealed_multiprocessing_context()
-        receiver, sender = context.Pipe(duplex=False)
-        cancellation_event = context.Event()
-        process = context.Process(
+        receiver, sender = _sealed_fork_pipe(duplex=False)
+        cancellation_event = _sealed_fork_event()
+        process = _sealed_fork_process(
             target=_remote_provider_worker,
             args=(
                 sender,

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -47,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.4.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.5.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -57,6 +57,7 @@ GOVERNANCE_IMPLEMENTATION_MODULES = (
 )
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
 _REQUIRED_GOVERNANCE_FACTS = frozenset({"branch_protection", "review_policy"})
+_GOVERNANCE_SCHEMA_VERSION = "pmpe.repository-governance/v1"
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
 _REMOTE_PAYLOAD_FIELDS = frozenset(
     {
@@ -597,9 +598,23 @@ def _stop_remote_process(process: Any) -> None:
 
 
 def _governance_content_is_complete(value: dict[str, Any]) -> bool:
-    if not _REQUIRED_GOVERNANCE_FACTS.issubset(value):
+    if value.get(
+        "schema_version"
+    ) != _GOVERNANCE_SCHEMA_VERSION or not _REQUIRED_GOVERNANCE_FACTS.issubset(value):
         return False
-    if any(value[fact] in ({}, [], "") for fact in _REQUIRED_GOVERNANCE_FACTS):
+    branch_protection = value["branch_protection"]
+    review_policy = value["review_policy"]
+    if (
+        not isinstance(branch_protection, dict)
+        or not isinstance(branch_protection.get("observed"), bool)
+        or not isinstance(branch_protection.get("required_checks"), list)
+        or not all(_is_str(item) for item in branch_protection["required_checks"])
+        or len(set(branch_protection["required_checks"]))
+        != len(branch_protection["required_checks"])
+        or not isinstance(review_policy, dict)
+        or not _is_int(review_policy.get("required_approvals"))
+        or review_policy["required_approvals"] < 0
+    ):
         return False
     pending: list[Any] = [value]
     visited = 0

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -47,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.5.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.6.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -83,6 +83,53 @@ def _valid_ref(value: str) -> bool:
         and not any(marker in value for marker in ("..", "@{", "//", "\\"))
         and not value.endswith(("/", ".", ".lock"))
     )
+
+
+def _valid_branch_ref(value: str) -> bool:
+    prefix = "refs/heads/"
+    if not value.startswith(prefix):
+        return False
+    name = value.removeprefix(prefix)
+    return (
+        name != "HEAD"
+        and _valid_ref(name)
+        and all(
+            part and not part.startswith(".") and not part.endswith((".", ".lock"))
+            for part in name.split("/")
+        )
+    )
+
+
+def _parse_porcelain_status(value: str) -> tuple[bool, bool, bool]:
+    """Parse the bounded NUL porcelain-v1 grammar or fail closed."""
+
+    records = value.split("\0")
+    if not records or records[-1] != "":
+        raise RepositoryIntelligenceError("local Git status output is malformed")
+    records.pop()
+    index_dirty = False
+    worktree_dirty = False
+    untracked = False
+    position = 0
+    allowed_codes = frozenset(" MTADRCU")
+    while position < len(records):
+        record = records[position]
+        if len(record) < 4 or record[2] != " " or not record[3:]:
+            raise RepositoryIntelligenceError("local Git status output is malformed")
+        status = record[:2]
+        if status == "??":
+            untracked = True
+        elif status == "!!" or status == "  " or any(code not in allowed_codes for code in status):
+            raise RepositoryIntelligenceError("local Git status output is malformed")
+        else:
+            index_dirty = index_dirty or status[0] != " "
+            worktree_dirty = worktree_dirty or status[1] != " "
+            if any(code in {"R", "C"} for code in status):
+                position += 1
+                if position >= len(records) or not records[position]:
+                    raise RepositoryIntelligenceError("local Git status output is malformed")
+        position += 1
+    return index_dirty, worktree_dirty, untracked
 
 
 def _valid_object_id(value: str, object_format: str) -> bool:
@@ -303,7 +350,7 @@ def _remote_provider_worker(
 class GovernanceCommandRunner:
     """Allowlisted local Git observation commands with mutation subcommands refused."""
 
-    identity = "git-governance-readonly/1.8.0"
+    identity = "git-governance-readonly/1.9.0"
     __slots__ = ("max_output_bytes",)
     _allowed = {
         "config",
@@ -318,6 +365,12 @@ class GovernanceCommandRunner:
         "--name-only",
         "--get-regexp",
         r"^filter\..*\.(clean|smudge|process)$",
+    )
+    _status_probe = (
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--ignore-submodules=all",
     )
 
     def __init__(self, *, max_output_bytes: int = 8_000_000) -> None:
@@ -339,6 +392,8 @@ class GovernanceCommandRunner:
             raise RepositorySecurityError("Git configuration reads are outside the safe probe")
         if args[1] == "ls-files" and args[2:] != ("--stage", "-z"):
             raise RepositorySecurityError("Git index reads are outside the safe probe")
+        if args[1] == "status" and args[2:] != self._status_probe:
+            raise RepositorySecurityError("Git status reads are outside the safe probe")
         if args[1] == "worktree" and (len(args) < 3 or args[2] != "list"):
             raise RepositorySecurityError("mutating Git worktree command was refused")
         safe_environment = {
@@ -1134,6 +1189,21 @@ class GovernanceCollector:
                         )
                         current = {}
                         continue
+                    if not Path(current["worktree"]).is_absolute() or (
+                        "branch" in current and not _valid_branch_ref(current["branch"])
+                    ):
+                        self._local_unknowns.append(
+                            UnknownFact(
+                                fact=f"worktree_record:{record_number}",
+                                status="BLOCKED",
+                                reason=(
+                                    "A Git worktree path or branch reference is malformed; "
+                                    "mutable worktree state was not inferred."
+                                ),
+                            )
+                        )
+                        current = {}
+                        continue
                     results.append(
                         WorktreeObservation(
                             path=current["worktree"],
@@ -1313,23 +1383,14 @@ class GovernanceCollector:
             root,
             "status",
             "--porcelain=v1",
+            "-z",
             "--untracked-files=all",
             "--ignore-submodules=all",
         )
         head_sha = self._run(root, "rev-parse", "HEAD").strip()
         if not _valid_object_id(head_sha, object_format):
             raise RepositoryIntelligenceError("local Git HEAD is malformed")
-        index_dirty = False
-        worktree_dirty = False
-        untracked = False
-        for line in status_raw.splitlines():
-            if line.startswith("??"):
-                untracked = True
-                continue
-            if len(line) < 2:
-                raise RepositoryIntelligenceError("local Git status output is malformed")
-            index_dirty = index_dirty or line[0] not in {" ", "?"}
-            worktree_dirty = worktree_dirty or line[1] not in {" ", "?"}
+        index_dirty, worktree_dirty, untracked = _parse_porcelain_status(status_raw)
         local_state = LocalState(
             index_dirty=index_dirty,
             worktree_dirty=worktree_dirty,

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -47,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.3.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.4.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -1087,8 +1087,12 @@ class GovernanceCollector:
                         current = {}
                         record_invalid = False
                         continue
-                    missing = {"worktree", "HEAD"} - set(current)
                     lifecycle_states = sum(key in current for key in ("branch", "detached", "bare"))
+                    required_fields = {"worktree"}
+                    if "bare" not in current:
+                        required_fields.add("HEAD")
+                    missing = required_fields - set(current)
+                    invalid_identity_shape = "bare" in current and "HEAD" in current
                     if missing or lifecycle_states != 1:
                         self._local_unknowns.append(
                             UnknownFact(
@@ -1102,10 +1106,26 @@ class GovernanceCollector:
                         )
                         current = {}
                         continue
+                    if invalid_identity_shape:
+                        self._local_unknowns.append(
+                            UnknownFact(
+                                fact=f"worktree_record:{record_number}",
+                                status="BLOCKED",
+                                reason=(
+                                    "A bare Git worktree record contains an unexpected HEAD; "
+                                    "mutable worktree state was not inferred."
+                                ),
+                            )
+                        )
+                        current = {}
+                        continue
                     results.append(
                         WorktreeObservation(
                             path=current["worktree"],
-                            head_sha=current["HEAD"],
+                            # Git's documented bare-worktree porcelain form does not
+                            # contain HEAD.  Preserve that absence instead of inventing
+                            # an immutable revision for a mutable bare repository.
+                            head_sha=current.get("HEAD", ""),
                             branch=current.get(
                                 "branch", "BARE" if "bare" in current else "DETACHED"
                             ).removeprefix("refs/heads/"),
@@ -1305,7 +1325,9 @@ class GovernanceCollector:
         branches = self._branches(root, ref)
         worktrees = self._worktrees(root)
         if any(not _valid_object_id(item.sha, object_format) for item in branches) or any(
-            not _valid_object_id(item.head_sha, object_format) for item in worktrees
+            (item.bare and item.head_sha != "")
+            or (not item.bare and not _valid_object_id(item.head_sha, object_format))
+            for item in worktrees
         ):
             raise RepositoryIntelligenceError("local Git reference identity is malformed")
         observed_at = self.clock.now()

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -51,7 +51,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.6.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.7.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -45,12 +45,13 @@ from pmpe.repository.scanner import (
     _cancellation_requested,
     _implementation_module_evidence,
     _implementation_source_evidence,
+    _runtime_dependency_evidence,
     _spawn_guarded_git,
     _stop_guarded_process_group,
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.3.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.4.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -966,6 +967,7 @@ def _governance_implementation_digest(
         _GOVERNANCE_IMPLEMENTATION_PATHS,
         _GOVERNANCE_IMPORTED_SOURCE_DIGESTS,
     )
+    evidence.extend(_runtime_dependency_evidence())
     evidence.extend(extension_evidence)
     return canonical_digest(
         sorted(evidence, key=lambda item: (item.get("label", ""), item["module"]))

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -36,7 +36,11 @@ from pmpe.repository.models import (
     UnknownFact,
     WorktreeObservation,
 )
-from pmpe.repository.redaction import EvidenceRedactor, RedactionError
+from pmpe.repository.redaction import (
+    EvidenceRedactor,
+    RedactionError,
+    assert_distinct_identities_preserved,
+)
 from pmpe.repository.scanner import (
     Cancellation,
     CancellationSignal,
@@ -51,7 +55,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.11.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.12.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -1037,6 +1041,47 @@ def _observation_from_dict(value: dict[str, Any]) -> GovernanceObservation:
         redaction=cast(dict[str, Any], value["redaction"]),
         artifact_kind=str(value["artifact_kind"]),
     )
+
+
+def _observation_identity_groups(
+    original: Mapping[str, Any], sanitized: Mapping[str, Any]
+) -> dict[str, list[tuple[str, str]]]:
+    """Pair mutable-observation identities before and after redaction."""
+
+    groups: dict[str, list[tuple[str, str]]] = {
+        "configured remotes": [],
+        "branch references": [],
+        "worktree paths": [],
+        "query cursors": [],
+        "unknown facts": [],
+    }
+    try:
+        for raw_remote, safe_remote in zip(
+            cast(list[str], original["configured_remotes"]),
+            cast(list[str], sanitized["configured_remotes"]),
+            strict=True,
+        ):
+            groups["configured remotes"].append((raw_remote, safe_remote))
+        for collection, field, namespace in (
+            ("local_branches", "name", "branch references"),
+            ("remote_branches", "name", "branch references"),
+            ("worktrees", "branch", "branch references"),
+            ("worktrees", "path", "worktree paths"),
+            ("query_provenance", "cursor", "query cursors"),
+            ("unknowns", "fact", "unknown facts"),
+        ):
+            for raw_item, safe_item in zip(
+                cast(list[dict[str, Any]], original[collection]),
+                cast(list[dict[str, Any]], sanitized[collection]),
+                strict=True,
+            ):
+                raw_value = raw_item[field]
+                safe_value = safe_item[field]
+                if raw_value is not None and safe_value is not None:
+                    groups[namespace].append((str(raw_value), str(safe_value)))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RedactionError("redaction changed observation identity structure") from exc
+    return groups
 
 
 class GovernanceCollector:
@@ -2245,8 +2290,11 @@ class GovernanceCollector:
                 "mutable_truth": "TIME_BOUND_OBSERVATION_ONLY",
             },
         )
+        original = draft.as_dict()
         try:
-            sanitized = cast(dict[str, Any], redactor.sanitize(draft.as_dict()))
+            sanitized = cast(dict[str, Any], redactor.sanitize(original))
+            for namespace, identities in _observation_identity_groups(original, sanitized).items():
+                assert_distinct_identities_preserved(namespace, identities)
         except (RedactionError, Exception) as exc:
             raise RepositorySecurityError("observation redaction failed") from exc
         self._assert_execution_collaborators_sealed()

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -51,7 +51,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.4.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.5.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -972,6 +972,27 @@ def _governance_implementation_digest(
     return canonical_digest(
         sorted(evidence, key=lambda item: (item.get("label", ""), item["module"]))
     )
+
+
+def _late_cancellation_input_digest(sanitized_inputs: dict[str, Any]) -> str:
+    """Bind a cancellation first observed after the initial input digest fence."""
+
+    rebound = dict(sanitized_inputs)
+    unknowns = [dict(item) for item in cast(list[dict[str, Any]], rebound["evaluation_unknowns"])]
+    if not any(item.get("fact") == "observation_cancellation" for item in unknowns):
+        unknowns.append(
+            {
+                "fact": "observation_cancellation",
+                "status": "BLOCKED",
+                "reason": "Mutable governance observation was cancelled before finalization.",
+            }
+        )
+    rebound["evaluation_unknowns"] = sorted(
+        unknowns,
+        key=lambda item: (item["fact"], item["status"], item["reason"]),
+    )
+    rebound["evaluation_disposition"] = "BLOCKED"
+    return canonical_digest(rebound)
 
 
 def _observation_from_dict(value: dict[str, Any]) -> GovernanceObservation:
@@ -2118,6 +2139,9 @@ class GovernanceCollector:
                 key=lambda item: (item["fact"], item["status"], item["reason"]),
             )
             sanitized["disposition"] = "BLOCKED"
+            sanitized["observation_input_digest"] = _late_cancellation_input_digest(
+                sanitized_inputs
+            )
         sanitized["observation_output_digest"] = canonical_digest(
             {key: value for key, value in sanitized.items() if key != "observation_output_digest"}
         )

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -18,7 +18,7 @@ from contextlib import suppress
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
-from types import MappingProxyType
+from types import MappingProxyType, ModuleType
 from typing import Any, Protocol, cast, final
 
 from pmpe.contracts.canonical import canonical_digest
@@ -50,12 +50,13 @@ from pmpe.repository.scanner import (
     _implementation_module_evidence,
     _implementation_source_evidence,
     _runtime_dependency_evidence,
+    _runtime_dependency_module_digest,
     _spawn_guarded_git,
     _stop_guarded_process_group,
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.13.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.14.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -964,9 +965,57 @@ def _validate_remote_payload_types(value: dict[str, Any]) -> None:
         raise ValueError("remote default branch is malformed")
 
 
+def _governance_import_binding_state_digest(names: tuple[str, ...]) -> str:
+    evidence: list[dict[str, str]] = []
+    for name in names:
+        target = globals().get(name)
+        if type(target) is not ModuleType:
+            evidence.append({"binding": name, "module": "INVALID", "runtime_digest": "INVALID"})
+            continue
+        evidence.append(
+            {
+                "binding": name,
+                "module": target.__name__,
+                "runtime_digest": _runtime_dependency_module_digest(target),
+            }
+        )
+    return canonical_digest(evidence)
+
+
+_SEALED_GOVERNANCE_IMPORT_NAMES = tuple(
+    sorted(name for name, target in globals().items() if type(target) is ModuleType)
+)
+_SEALED_GOVERNANCE_IMPORT_STATE_NAMES = ("json", "math", "os", "re", "time", "uuid")
+_SEALED_GOVERNANCE_IMPORT_STATE_DIGEST = _governance_import_binding_state_digest(
+    _SEALED_GOVERNANCE_IMPORT_STATE_NAMES
+)
+_SEALED_GOVERNANCE_IMPORT_PROCESS_IDENTITIES = tuple(
+    (name, id(globals()[name])) for name in _SEALED_GOVERNANCE_IMPORT_NAMES
+)
+
+
+def _assert_governance_import_bindings_sealed(*, verify_state: bool = False) -> None:
+    current_identities = tuple(
+        (
+            name,
+            id(target) if type(target) is ModuleType else -1,
+        )
+        for name in _SEALED_GOVERNANCE_IMPORT_NAMES
+        for target in (globals().get(name),)
+    )
+    if current_identities != _SEALED_GOVERNANCE_IMPORT_PROCESS_IDENTITIES:
+        raise RepositorySecurityError("governance imported-module bindings changed")
+    if verify_state and (
+        _governance_import_binding_state_digest(_SEALED_GOVERNANCE_IMPORT_STATE_NAMES)
+        != _SEALED_GOVERNANCE_IMPORT_STATE_DIGEST
+    ):
+        raise RepositorySecurityError("governance imported-module state changed")
+
+
 def _governance_implementation_digest(
     extension_evidence: tuple[dict[str, str], ...] = (),
 ) -> str:
+    _assert_governance_import_bindings_sealed(verify_state=True)
     evidence = _implementation_module_evidence(
         _GOVERNANCE_IMPLEMENTATION_PATHS,
         _GOVERNANCE_IMPORTED_SOURCE_DIGESTS,
@@ -1141,6 +1190,7 @@ class GovernanceCollector:
         stale_pull_request_after_seconds: int = 2_592_000,
         cancellation: Cancellation | None = None,
     ) -> None:
+        _assert_governance_import_bindings_sealed()
         self.repository = repository
         if snapshot is not None:
             if snapshot.repository != repository:
@@ -1187,6 +1237,9 @@ class GovernanceCollector:
         self.max_remote_age_seconds = max_remote_age_seconds
         self.stale_pull_request_after_seconds = stale_pull_request_after_seconds
         self._cancellation = cancellation
+        self._sealed_cancellation_lock = (
+            cancellation._lock if type(cancellation) is CancellationSignal else None
+        )
         self._command_provenance: list[CommandProvenance] = []
         self._commands = 0
         self._local_unknowns: list[UnknownFact] = []
@@ -1212,6 +1265,7 @@ class GovernanceCollector:
             self.runner,
             self.redactor,
             self.cancellation,
+            self._sealed_cancellation_lock,
             self._extension_implementation_evidence,
         )
         self._sealed_execution_configuration = (
@@ -1254,6 +1308,7 @@ class GovernanceCollector:
         return self._cancellation
 
     def _assert_execution_collaborators_sealed(self) -> None:
+        _assert_governance_import_bindings_sealed()
         current = (
             self.snapshot,
             self.clock,
@@ -1262,6 +1317,7 @@ class GovernanceCollector:
             self.runner,
             self.redactor,
             self.cancellation,
+            (self.cancellation._lock if type(self.cancellation) is CancellationSignal else None),
             self._extension_implementation_evidence,
         )
         if any(
@@ -1317,6 +1373,15 @@ class GovernanceCollector:
             return self.cancellation.cancelled()
         except Exception:
             return True
+
+    def _claim_completion(self) -> bool:
+        self._assert_execution_collaborators_sealed()
+        if self.cancellation is None:
+            return True
+        try:
+            return self.cancellation.claim_completion()
+        except Exception:
+            return False
 
     def _execute(self, root: Path, command: tuple[str, ...]) -> CommandResult:
         self._assert_execution_collaborators_sealed()
@@ -2360,6 +2425,35 @@ class GovernanceCollector:
         sanitized["observation_output_digest"] = canonical_digest(
             {key: value for key, value in sanitized.items() if key != "observation_output_digest"}
         )
+        if (
+            not any(
+                item.get("fact") == "observation_cancellation"
+                for item in cast(list[dict[str, Any]], sanitized["unknowns"])
+            )
+            and not self._claim_completion()
+        ):
+            cast(list[dict[str, Any]], sanitized["unknowns"]).append(
+                {
+                    "fact": "observation_cancellation",
+                    "status": "BLOCKED",
+                    "reason": "Mutable governance observation was cancelled before finalization.",
+                }
+            )
+            sanitized["unknowns"] = sorted(
+                cast(list[dict[str, Any]], sanitized["unknowns"]),
+                key=lambda item: (item["fact"], item["status"], item["reason"]),
+            )
+            sanitized["disposition"] = "BLOCKED"
+            sanitized["observation_input_digest"] = _late_cancellation_input_digest(
+                sanitized_inputs
+            )
+            sanitized["observation_output_digest"] = canonical_digest(
+                {
+                    key: value
+                    for key, value in sanitized.items()
+                    if key != "observation_output_digest"
+                }
+            )
         return _observation_from_dict(sanitized)
 
 

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -55,7 +55,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.12.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.13.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -1084,6 +1084,41 @@ def _observation_identity_groups(
     return groups
 
 
+def _remote_identity_groups(
+    original: Mapping[str, Any], sanitized: Mapping[str, Any]
+) -> dict[str, list[tuple[str, str]]]:
+    """Pair remote identities at their first redaction boundary."""
+
+    groups: dict[str, list[tuple[str, str]]] = {
+        "remote branch references": [],
+        "remote query surfaces": [],
+        "remote query expressions": [],
+        "remote query cursors": [],
+        "remote unknown facts": [],
+    }
+    try:
+        for collection, field, namespace in (
+            ("remote_branches", "name", "remote branch references"),
+            ("remote_branches", "comparison_ref", "remote branch references"),
+            ("query_provenance", "surface", "remote query surfaces"),
+            ("query_provenance", "query", "remote query expressions"),
+            ("query_provenance", "cursor", "remote query cursors"),
+            ("unknowns", "fact", "remote unknown facts"),
+        ):
+            for raw_item, safe_item in zip(
+                cast(list[dict[str, Any]], original[collection]),
+                cast(list[dict[str, Any]], sanitized[collection]),
+                strict=True,
+            ):
+                raw_value = raw_item.get(field)
+                safe_value = safe_item.get(field)
+                if raw_value is not None and safe_value is not None:
+                    groups[namespace].append((str(raw_value), str(safe_value)))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RedactionError("redaction changed remote identity structure") from exc
+    return groups
+
+
 class GovernanceCollector:
     """Collect mutable local and injected remote observations without mutation."""
 
@@ -1899,6 +1934,10 @@ class GovernanceCollector:
                 try:
                     redactor = self.redactor
                     sanitized_remote = cast(dict[str, Any], redactor.sanitize(raw_remote))
+                    for namespace, identities in _remote_identity_groups(
+                        raw_remote, sanitized_remote
+                    ).items():
+                        assert_distinct_identities_preserved(namespace, identities)
                 except (RedactionError, Exception) as exc:
                     raise RepositorySecurityError(
                         "remote evidence redaction failed; observation was not created"

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -69,6 +69,7 @@ class GovernanceCommandRunner:
             "GIT_CONFIG_GLOBAL": os.devnull,
             "GIT_CONFIG_SYSTEM": os.devnull,
             "GIT_TERMINAL_PROMPT": "0",
+            "GIT_OPTIONAL_LOCKS": "0",
             "LC_ALL": "C",
         }
         try:
@@ -313,6 +314,8 @@ class GovernanceCollector:
                         query=str(item["query"]),
                         cursor=cast(str | None, item.get("cursor")),
                         page=cast(int | None, item.get("page")),
+                        has_next_page=bool(item.get("has_next_page", True)),
+                        result_count=cast(int | None, item.get("result_count")),
                     )
                     for item in sanitized_remote.get("query_provenance", [])
                 )
@@ -326,6 +329,24 @@ class GovernanceCollector:
                 )
                 if any(item.status == "BLOCKED" for item in unknowns):
                     disposition = "BLOCKED"
+                pagination_complete = (
+                    sanitized_remote.get("complete") is True
+                    and bool(provenance)
+                    and all(not item.has_next_page for item in provenance)
+                )
+                if not pagination_complete:
+                    disposition = "BLOCKED"
+                    unknowns = (
+                        *unknowns,
+                        UnknownFact(
+                            fact="remote_metadata_completeness",
+                            status="BLOCKED",
+                            reason=(
+                                "Remote query coverage or pagination completion was not proven; "
+                                "the returned subset is not represented as complete."
+                            ),
+                        ),
+                    )
             except (PermissionError, OSError):
                 disposition = "BLOCKED"
                 unknowns = (

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -28,6 +28,7 @@ from pmpe.repository.models import (
     PullRequestObservation,
     QueryProvenance,
     RemoteBranchObservation,
+    RepositorySnapshot,
     UnknownFact,
     WorktreeObservation,
 )
@@ -36,9 +37,10 @@ from pmpe.repository.scanner import (
     Cancellation,
     RepositoryIntelligenceError,
     RepositorySecurityError,
+    _implementation_source_evidence,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.4.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/1.5.0"
 _REQUIRED_REMOTE_COVERAGE = frozenset({"remote_branches", "pull_requests", "issues", "governance"})
 _REQUIRED_GOVERNANCE_FACTS = frozenset({"branch_protection", "review_policy"})
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
@@ -154,7 +156,7 @@ def _remote_provider_worker(
 class GovernanceCommandRunner:
     """Allowlisted local Git observation commands with mutation subcommands refused."""
 
-    identity = "git-governance-readonly/1.4.0"
+    identity = "git-governance-readonly/1.5.0"
     _allowed = {
         "config",
         "status",
@@ -355,20 +357,18 @@ def _bounded_remote_shape(value: Any, *, max_bytes: int, max_items: int) -> None
 def _stop_remote_process(process: Any) -> None:
     """Terminate and reap the isolated provider process and its descendants."""
 
-    if not process.is_alive():
-        process.join(timeout=0.1)
-        return
     try:
         os.killpg(process.pid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError, OSError):
-        process.terminate()
+        if process.is_alive():
+            process.terminate()
     process.join(timeout=0.25)
-    if process.is_alive():
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError, OSError):
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        if process.is_alive():
             process.kill()
-        process.join(timeout=1.0)
+    process.join(timeout=1.0)
     if process.is_alive():
         raise RepositorySecurityError("bounded remote provider process could not be reaped")
 
@@ -424,7 +424,9 @@ def _pagination_is_complete(
     return True
 
 
-def _governance_implementation_digest() -> str:
+def _governance_implementation_digest(
+    extension_evidence: tuple[dict[str, str], ...] = (),
+) -> str:
     package_root = Path(__file__).resolve().parent
     sources = (
         ("repository.governance", package_root / "governance.py"),
@@ -433,7 +435,7 @@ def _governance_implementation_digest() -> str:
         ("contracts.canonical", package_root.parent / "contracts" / "canonical.py"),
     )
     try:
-        evidence = [
+        evidence: list[dict[str, str]] = [
             {
                 "module": name,
                 "source_digest": "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest(),
@@ -444,7 +446,10 @@ def _governance_implementation_digest() -> str:
         raise RepositoryIntelligenceError(
             "governance implementation bytes are unavailable for provenance binding"
         ) from exc
-    return canonical_digest(evidence)
+    evidence.extend(extension_evidence)
+    return canonical_digest(
+        sorted(evidence, key=lambda item: (item.get("label", ""), item["module"]))
+    )
 
 
 def _observation_from_dict(value: dict[str, Any]) -> GovernanceObservation:
@@ -453,6 +458,8 @@ def _observation_from_dict(value: dict[str, Any]) -> GovernanceObservation:
         observed_at=str(value["observed_at"]),
         repository=str(value["repository"]),
         ref=str(value["ref"]),
+        repository_snapshot_digest=cast(str | None, value["repository_snapshot_digest"]),
+        repository_snapshot_commit=cast(str | None, value["repository_snapshot_commit"]),
         local_state=LocalState(**value["local_state"]),
         local_branches=tuple(BranchObservation(**item) for item in value["local_branches"]),
         worktrees=tuple(WorktreeObservation(**item) for item in value["worktrees"]),
@@ -492,6 +499,7 @@ class GovernanceCollector:
         self,
         *,
         repository: str,
+        snapshot: RepositorySnapshot | None = None,
         clock: Clock,
         id_provider: IdProvider,
         remote_provider: RemoteProvider | None = None,
@@ -506,6 +514,11 @@ class GovernanceCollector:
         cancellation: Cancellation | None = None,
     ) -> None:
         self.repository = repository
+        if snapshot is not None and snapshot.repository != repository:
+            raise RepositoryIntelligenceError(
+                "governance repository label does not match the bound snapshot"
+            )
+        self.snapshot = snapshot
         self.clock = clock
         self.id_provider = id_provider
         self.remote_provider = remote_provider
@@ -521,6 +534,19 @@ class GovernanceCollector:
         self._command_provenance: list[CommandProvenance] = []
         self._commands = 0
         self._local_unknowns: list[UnknownFact] = []
+        extension_targets: list[tuple[str, Any]] = [
+            ("clock", self.clock),
+            ("id_provider", self.id_provider),
+            ("command_runner", self.runner),
+            ("redactor", self.redactor),
+        ]
+        if self.remote_provider is not None:
+            extension_targets.append(("remote_provider", self.remote_provider))
+        if self.cancellation is not None:
+            extension_targets.append(("cancellation", self.cancellation))
+        self._extension_implementation_evidence = tuple(
+            _implementation_source_evidence(label, target) for label, target in extension_targets
+        )
 
     def _is_cancelled(self) -> bool:
         if self.cancellation is None:
@@ -748,6 +774,22 @@ class GovernanceCollector:
             raise RepositoryIntelligenceError(
                 f"Git object format {object_format!r} is explicitly unsupported"
             )
+        ref_commit = self._run(
+            root,
+            "rev-parse",
+            "--verify",
+            "--end-of-options",
+            f"{ref}^{{commit}}",
+        ).strip()
+        if not _valid_object_id(ref_commit, object_format):
+            raise RepositoryIntelligenceError("governance observation ref identity is malformed")
+        if self.snapshot is not None and (
+            self.snapshot.commit_sha != ref_commit
+            or self.snapshot.git_object_format != object_format
+        ):
+            raise RepositoryIntelligenceError(
+                "governance ref does not resolve to the bound repository snapshot"
+            )
         index_listing = self._run(root, "ls-files", "--stage", "-z")
         gitlinks = 0
         for record in index_listing.split("\0"):
@@ -877,6 +919,10 @@ class GovernanceCollector:
                         "remote evidence redaction failed; observation was not created"
                     ) from exc
                 try:
+                    if sanitized_remote.get("repository") != self.repository:
+                        raise ValueError("remote repository identity does not match the request")
+                    if sanitized_remote.get("ref") != ref:
+                        raise ValueError("remote ref identity does not match the request")
                     remote_observed_at = str(sanitized_remote["observed_at"])
                     remote_observed_value = _parse_utc(
                         remote_observed_at, field="remote observation time"
@@ -903,6 +949,12 @@ class GovernanceCollector:
                         IssueObservation(number=int(item["number"]), state=str(item["state"]))
                         for item in sanitized_remote.get("issues", [])
                     )
+                    if len({item.name for item in remote_branches}) != len(remote_branches):
+                        raise ValueError("remote branch inventory contains duplicate names")
+                    if len({item.number for item in pull_requests}) != len(pull_requests):
+                        raise ValueError("pull request inventory contains duplicate numbers")
+                    if len({item.number for item in issues}) != len(issues):
+                        raise ValueError("issue inventory contains duplicate numbers")
                     governance = cast(dict[str, Any], sanitized_remote.get("governance", {}))
                     governance_complete = _governance_content_is_complete(governance)
                     provenance = tuple(
@@ -1010,10 +1062,19 @@ class GovernanceCollector:
                     reason="Mutable governance observation was cancelled before finalization.",
                 ),
             )
-        collector_digest = _governance_implementation_digest()
+        collector_digest = _governance_implementation_digest(
+            self._extension_implementation_evidence
+        )
         inputs = {
             "repository": self.repository,
             "ref": ref,
+            "resolved_ref_commit": ref_commit,
+            "repository_snapshot_digest": (
+                self.snapshot.snapshot_digest if self.snapshot is not None else None
+            ),
+            "repository_snapshot_commit": (
+                self.snapshot.commit_sha if self.snapshot is not None else None
+            ),
             "observation_id": observation_id,
             "observed_at": observed_at,
             "local_status": status_raw,
@@ -1039,6 +1100,12 @@ class GovernanceCollector:
             observed_at=observed_at,
             repository=self.repository,
             ref=ref,
+            repository_snapshot_digest=(
+                self.snapshot.snapshot_digest if self.snapshot is not None else None
+            ),
+            repository_snapshot_commit=(
+                self.snapshot.commit_sha if self.snapshot is not None else None
+            ),
             local_state=local_state,
             local_branches=branches,
             worktrees=worktrees,
@@ -1096,12 +1163,14 @@ def observe_governance(
     *,
     repository: str,
     ref: str,
+    snapshot: RepositorySnapshot | None = None,
     clock: Clock | None = None,
     id_provider: IdProvider | None = None,
     remote_provider: RemoteProvider | None = None,
 ) -> GovernanceObservation:
     return GovernanceCollector(
         repository=repository,
+        snapshot=snapshot,
         clock=clock or SystemUtcClock(),
         id_provider=id_provider or UuidObservationIds(),
         remote_provider=remote_provider,

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -6,7 +6,6 @@ import ast
 import hashlib
 import json
 import math
-import multiprocessing
 import os
 import re
 import selectors
@@ -48,16 +47,18 @@ from pmpe.repository.scanner import (
     RepositoryIntelligenceError,
     RepositorySecurityError,
     _cancellation_requested,
+    _direct_imported_global_names,
     _implementation_module_evidence,
     _implementation_source_evidence,
     _module_attribute_value_evidence,
     _runtime_dependency_evidence,
+    _sealed_multiprocessing_context,
     _spawn_guarded_git,
     _stop_guarded_process_group,
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.15.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.16.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -1030,17 +1031,28 @@ def _governance_module_attribute_state_digest(
 
 
 def _governance_external_global_names() -> tuple[str, ...]:
-    return tuple(
-        sorted(
-            name
-            for name, target in globals().items()
-            if (
-                type(target) is ModuleType
-                or callable(target)
-                and str(getattr(target, "__module__", "")) != __name__
-            )
+    return _direct_imported_global_names(_GOVERNANCE_IMPLEMENTATION_PATHS["repository.governance"])
+
+
+def _governance_external_global_state_digest(names: tuple[str, ...]) -> str:
+    evidence: list[dict[str, Any]] = []
+    for name in names:
+        if name not in globals():
+            raise RepositorySecurityError("governance imported global binding is unavailable")
+        target = globals()[name]
+        evidence.append(
+            {
+                "binding": name,
+                "state": (
+                    {"guard": "identity"}
+                    if type(target) is ModuleType or callable(target)
+                    else _module_attribute_value_evidence(
+                        "governance-imported-global", name, target
+                    )
+                ),
+            }
         )
-    )
+    return canonical_digest(evidence)
 
 
 _SEALED_GOVERNANCE_MODULE_ATTRIBUTE_NAMES = _governance_direct_module_attribute_names()
@@ -1053,6 +1065,9 @@ _SEALED_GOVERNANCE_MODULE_ATTRIBUTE_PROCESS_IDENTITIES = _governance_module_attr
 _SEALED_GOVERNANCE_EXTERNAL_GLOBAL_NAMES = _governance_external_global_names()
 _SEALED_GOVERNANCE_EXTERNAL_GLOBAL_PROCESS_IDENTITIES = tuple(
     (name, id(globals()[name])) for name in _SEALED_GOVERNANCE_EXTERNAL_GLOBAL_NAMES
+)
+_SEALED_GOVERNANCE_EXTERNAL_GLOBAL_STATE_DIGEST = _governance_external_global_state_digest(
+    _SEALED_GOVERNANCE_EXTERNAL_GLOBAL_NAMES
 )
 
 
@@ -1082,12 +1097,18 @@ def _assert_governance_import_bindings_sealed(*, verify_state: bool = False) -> 
         != _SEALED_GOVERNANCE_MODULE_ATTRIBUTE_STATE_DIGEST
     ):
         raise RepositorySecurityError("governance imported-module attribute state changed")
+    if verify_state and (
+        _governance_external_global_state_digest(_SEALED_GOVERNANCE_EXTERNAL_GLOBAL_NAMES)
+        != _SEALED_GOVERNANCE_EXTERNAL_GLOBAL_STATE_DIGEST
+    ):
+        raise RepositorySecurityError("governance imported global binding state changed")
 
 
 def _governance_implementation_digest(
     extension_evidence: tuple[dict[str, str], ...] = (),
 ) -> str:
     _assert_governance_import_bindings_sealed(verify_state=True)
+    _sealed_multiprocessing_context()
     evidence = _implementation_module_evidence(
         _GOVERNANCE_IMPLEMENTATION_PATHS,
         _GOVERNANCE_IMPORTED_SOURCE_DIGESTS,
@@ -1503,7 +1524,7 @@ class GovernanceCollector:
             raise RepositoryIntelligenceError(
                 "bounded remote provider execution is unsupported on this platform"
             )
-        context = multiprocessing.get_context("fork")
+        context = _sealed_multiprocessing_context()
         receiver, sender = context.Pipe(duplex=False)
         cancellation_event = context.Event()
         process = context.Process(

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -47,7 +47,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.8.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/2.9.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -666,7 +666,7 @@ def _governance_content_is_complete(value: dict[str, Any]) -> bool:
     if (
         not isinstance(branch_protection, dict)
         or set(branch_protection) != {"observed", "required_checks"}
-        or not isinstance(branch_protection.get("observed"), bool)
+        or branch_protection.get("observed") is not True
         or not isinstance(branch_protection.get("required_checks"), list)
         or not all(_is_str(item) for item in branch_protection["required_checks"])
         or len(set(branch_protection["required_checks"]))

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -182,7 +182,7 @@ class RepositorySnapshot:
         claimed = str(payload.pop("snapshot_digest", ""))
         return bool(claimed) and claimed == canonical_digest(payload)
 
-    def assessment_reference(self, observation: GovernanceObservation) -> dict[str, str]:
+    def assessment_reference(self, observation: GovernanceObservation) -> dict[str, Any]:
         """Return the narrow evidence seam consumed by later lifecycle work."""
 
         if not self.digest_is_valid():
@@ -198,11 +198,26 @@ class RepositorySnapshot:
             raise ValueError(
                 "governance observation is not bound to this exact repository snapshot"
             )
+        if (
+            self.disposition != "COMPLETE"
+            or self.unsupported_categories
+            or any(item.blocking for item in self.findings)
+        ):
+            raise ValueError("repository snapshot is not complete and cannot enter engineering")
+        if observation.disposition != "COMPLETE" or observation.unknowns:
+            raise ValueError("governance observation is not complete and cannot enter engineering")
         return {
             "repository_snapshot_digest": self.snapshot_digest,
+            "repository_snapshot_disposition": self.disposition,
             "repository_commit": self.commit_sha,
             "governance_observation_id": observation.observation_id,
             "governance_observation_digest": observation.observation_output_digest,
+            "governance_observation_disposition": observation.disposition,
+            "governance_observed_at": observation.observed_at,
+            "remote_observed_at": observation.remote_observed_at,
+            "governance_query_provenance_digest": canonical_digest(
+                [_plain(item) for item in observation.query_provenance]
+            ),
         }
 
 
@@ -241,6 +256,10 @@ class WorktreeObservation:
 class RemoteBranchObservation:
     name: str
     sha: str
+    comparison_ref: str
+    ahead: int
+    behind: int
+    status: str
 
 
 @dataclass(frozen=True)
@@ -285,16 +304,20 @@ class GovernanceObservation:
     repository_snapshot_digest: str | None
     repository_snapshot_commit: str | None
     local_state: LocalState
+    current_branch: str
+    configured_remotes: tuple[str, ...]
     local_branches: tuple[BranchObservation, ...]
     worktrees: tuple[WorktreeObservation, ...]
     command_provenance: tuple[CommandProvenance, ...]
     remote_branches: tuple[RemoteBranchObservation, ...]
+    remote_default_branch: str | None
     pull_requests: tuple[PullRequestObservation, ...]
     issues: tuple[IssueObservation, ...]
     governance: Mapping[str, Any]
     query_provenance: tuple[QueryProvenance, ...]
     remote_observed_at: str | None
     remote_query_coverage: tuple[str, ...]
+    remote_collection_provenance: Mapping[str, Any]
     unknowns: tuple[UnknownFact, ...]
     collector_version: str
     collector_implementation_digest: str
@@ -308,6 +331,9 @@ class GovernanceObservation:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "governance", _freeze(self.governance))
+        object.__setattr__(
+            self, "remote_collection_provenance", _freeze(self.remote_collection_provenance)
+        )
         object.__setattr__(self, "redaction", _freeze(self.redaction))
 
     def as_dict(self) -> dict[str, Any]:

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -198,9 +198,10 @@ class RepositorySnapshot:
             raise ValueError(
                 "governance observation is not bound to this exact repository snapshot"
             )
+        immutable_unsupported = set(self.unsupported_categories) - {"active_divergent_work"}
         if (
             self.disposition != "COMPLETE"
-            or self.unsupported_categories
+            or immutable_unsupported
             or any(item.blocking for item in self.findings)
         ):
             raise ValueError("repository snapshot is not complete and cannot enter engineering")

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -115,6 +115,7 @@ class BoundaryCandidate:
 class AdapterMetadata:
     adapter_id: str
     version: str
+    detector_version: str
     file_patterns: tuple[str, ...]
     supported_categories: tuple[str, ...]
     failure_behavior: str = "VISIBLE_PARTIAL_OR_BLOCKED"

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -115,6 +115,7 @@ class RepositorySnapshot:
     commit_sha: str
     tree_sha: str
     default_branch: str | None
+    default_branch_source: str
     scanner_version: str
     scan_configuration_digest: str
     adapter_set_digest: str

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -229,6 +229,12 @@ class WorktreeObservation:
     path: str
     head_sha: str
     branch: str
+    bare: bool
+    detached: bool
+    locked: bool
+    locked_reason: str | None
+    prunable: bool
+    prunable_reason: str | None
 
 
 @dataclass(frozen=True)

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -142,6 +142,7 @@ class RepositorySnapshot:
     repository: str
     commit_sha: str
     tree_sha: str
+    git_object_format: str
     default_branch: str | None
     default_branch_source: str
     scanner_version: str
@@ -178,6 +179,8 @@ class RepositorySnapshot:
     def assessment_reference(self, observation: GovernanceObservation) -> dict[str, str]:
         """Return the narrow evidence seam consumed by later lifecycle work."""
 
+        if observation.repository != self.repository:
+            raise ValueError("snapshot and governance observation repositories do not match")
         return {
             "repository_snapshot_digest": self.snapshot_digest,
             "repository_commit": self.commit_sha,
@@ -192,6 +195,7 @@ class LocalState:
     worktree_dirty: bool
     untracked: bool
     head_sha: str
+    git_object_format: str
 
 
 @dataclass(frozen=True)

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -32,6 +32,7 @@ class ScanConfig:
     max_directories: int = 5_000
     max_total_bytes: int = 250_000_000
     max_file_bytes: int = 5_000_000
+    max_tree_output_bytes: int = 32_000_000
     max_commands: int = 50_000
     command_timeout_seconds: int = 20
     max_path_depth: int = 64
@@ -120,6 +121,9 @@ class RepositorySnapshot:
     scan_configuration_digest: str
     adapter_set_digest: str
     tracked_tree_digest: str
+    scanned_content_digest: str
+    scan_scope: str
+    included_paths: tuple[str, ...]
     tooling_digest: str
     adapters: tuple[AdapterMetadata, ...]
     command_provenance: tuple[CommandProvenance, ...]
@@ -197,6 +201,8 @@ class QueryProvenance:
     query: str
     cursor: str | None
     page: int | None
+    has_next_page: bool
+    result_count: int | None
 
 
 @dataclass(frozen=True)

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -1,0 +1,236 @@
+"""Canonical data models for repository intelligence artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from pmpe.contracts.canonical import canonical_json_bytes
+
+AUDIT_CATEGORIES = (
+    "repository_topology",
+    "languages_build_ecosystems",
+    "architecture_boundaries",
+    "apis_data",
+    "tests_quality",
+    "delivery_environments",
+    "security_privacy",
+    "observability_operations",
+    "documentation_governance",
+    "active_divergent_work",
+    "debt_risk",
+)
+
+
+@dataclass(frozen=True)
+class ScanConfig:
+    """Bounded, deterministic inputs for an exact-commit scan."""
+
+    repository: str
+    default_branch: str | None = None
+    max_files: int = 20_000
+    max_directories: int = 5_000
+    max_total_bytes: int = 250_000_000
+    max_file_bytes: int = 5_000_000
+    max_commands: int = 50_000
+    command_timeout_seconds: int = 20
+    max_path_depth: int = 64
+    include_paths: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    args: tuple[str, ...]
+    returncode: int
+    stdout: str | bytes
+    stderr: str | bytes
+    timed_out: bool = False
+
+
+@dataclass(frozen=True)
+class EvidenceItem:
+    kind: str
+    path: str
+    file_digest: str
+    detector_id: str
+    detector_version: str
+    location: str = "file"
+    confidence: str = "HIGH"
+    redaction_status: str = "SANITIZED"
+
+
+@dataclass(frozen=True)
+class InventoryCategory:
+    status: str
+    items: tuple[EvidenceItem, ...] = ()
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class Finding:
+    code: str
+    category: str
+    severity: str
+    confidence: str
+    explanation: str
+    evidence_refs: tuple[str, ...]
+    detector_id: str
+    detector_version: str
+    blocking: bool = False
+
+
+@dataclass(frozen=True)
+class BoundaryCandidate:
+    kind: str
+    name: str
+    evidence_paths: tuple[str, ...]
+    confidence: str
+    detector_id: str
+    detector_version: str
+
+
+@dataclass(frozen=True)
+class AdapterMetadata:
+    adapter_id: str
+    version: str
+    file_patterns: tuple[str, ...]
+    supported_categories: tuple[str, ...]
+    failure_behavior: str = "VISIBLE_PARTIAL_OR_BLOCKED"
+    detection_logic: str = "TRACKED_PATH_AND_SAFE_STRUCTURE_ONLY"
+    evidence_emitted: str = "DIGEST_BOUND_FILE_EVIDENCE"
+    confidence_semantics: str = "HIGH_EXACT_MEDIUM_HEURISTIC_LOW_SIGNAL"
+
+
+@dataclass(frozen=True)
+class CommandProvenance:
+    args: tuple[str, ...]
+    tool_identity: str
+    exit_status: int
+    timed_out: bool
+
+
+@dataclass(frozen=True)
+class RepositorySnapshot:
+    repository: str
+    commit_sha: str
+    tree_sha: str
+    default_branch: str | None
+    scanner_version: str
+    scan_configuration_digest: str
+    adapter_set_digest: str
+    tracked_tree_digest: str
+    tooling_digest: str
+    adapters: tuple[AdapterMetadata, ...]
+    command_provenance: tuple[CommandProvenance, ...]
+    inventory: dict[str, InventoryCategory]
+    findings: tuple[Finding, ...]
+    boundary_candidates: tuple[BoundaryCandidate, ...]
+    unsupported_categories: tuple[str, ...]
+    disposition: str
+    redaction: dict[str, Any]
+    snapshot_digest: str
+    artifact_kind: str = "REPOSITORY_SNAPSHOT"
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.as_dict())
+
+    def assessment_reference(self, observation: GovernanceObservation) -> dict[str, str]:
+        """Return the narrow evidence seam consumed by later lifecycle work."""
+
+        return {
+            "repository_snapshot_digest": self.snapshot_digest,
+            "repository_commit": self.commit_sha,
+            "governance_observation_id": observation.observation_id,
+            "governance_observation_digest": observation.observation_output_digest,
+        }
+
+
+@dataclass(frozen=True)
+class LocalState:
+    index_dirty: bool
+    worktree_dirty: bool
+    untracked: bool
+    head_sha: str
+
+
+@dataclass(frozen=True)
+class BranchObservation:
+    name: str
+    sha: str
+    ahead: int
+    behind: int
+    status: str = "OBSERVED"
+
+
+@dataclass(frozen=True)
+class WorktreeObservation:
+    path: str
+    head_sha: str
+    branch: str
+
+
+@dataclass(frozen=True)
+class RemoteBranchObservation:
+    name: str
+    sha: str
+
+
+@dataclass(frozen=True)
+class PullRequestObservation:
+    number: int
+    draft: bool
+    head: str
+
+
+@dataclass(frozen=True)
+class IssueObservation:
+    number: int
+    state: str
+
+
+@dataclass(frozen=True)
+class QueryProvenance:
+    query: str
+    cursor: str | None
+    page: int | None
+
+
+@dataclass(frozen=True)
+class UnknownFact:
+    fact: str
+    status: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class GovernanceObservation:
+    observation_id: str
+    observed_at: str
+    repository: str
+    ref: str
+    local_state: LocalState
+    local_branches: tuple[BranchObservation, ...]
+    worktrees: tuple[WorktreeObservation, ...]
+    command_provenance: tuple[CommandProvenance, ...]
+    remote_branches: tuple[RemoteBranchObservation, ...]
+    pull_requests: tuple[PullRequestObservation, ...]
+    issues: tuple[IssueObservation, ...]
+    governance: dict[str, Any]
+    query_provenance: tuple[QueryProvenance, ...]
+    unknowns: tuple[UnknownFact, ...]
+    tool_identity: str
+    api_query_version: str
+    observation_input_digest: str
+    observation_output_digest: str
+    disposition: str
+    redaction: dict[str, Any] = field(default_factory=dict)
+    artifact_kind: str = "GOVERNANCE_OBSERVATION"
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.as_dict())

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -181,6 +181,13 @@ class RepositorySnapshot:
 
         if observation.repository != self.repository:
             raise ValueError("snapshot and governance observation repositories do not match")
+        if (
+            observation.repository_snapshot_digest != self.snapshot_digest
+            or observation.repository_snapshot_commit != self.commit_sha
+        ):
+            raise ValueError(
+                "governance observation is not bound to this exact repository snapshot"
+            )
         return {
             "repository_snapshot_digest": self.snapshot_digest,
             "repository_commit": self.commit_sha,
@@ -256,6 +263,8 @@ class GovernanceObservation:
     observed_at: str
     repository: str
     ref: str
+    repository_snapshot_digest: str | None
+    repository_snapshot_commit: str | None
     local_state: LocalState
     local_branches: tuple[BranchObservation, ...]
     worktrees: tuple[WorktreeObservation, ...]

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -2,12 +2,52 @@
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Mapping
 from dataclasses import dataclass, field, fields, is_dataclass
 from types import MappingProxyType
 from typing import Any, cast
 
+import rfc8785
+
+from pmpe.contracts import canonical as canonical_module
 from pmpe.contracts.canonical import canonical_digest, canonical_json_bytes
+
+_SEALED_MODEL_DIGEST_PROCESS_IDENTITIES = (
+    ("canonical-module", id(canonical_module)),
+    ("canonical-digest", id(canonical_digest)),
+    ("canonical-json-bytes", id(canonical_json_bytes)),
+    ("hashlib-module", id(hashlib)),
+    ("hashlib-sha256", id(hashlib.sha256)),
+    ("rfc8785-module", id(rfc8785)),
+    ("rfc8785-dumps", id(rfc8785.dumps)),
+)
+
+
+def _assert_repository_model_bindings_sealed() -> None:
+    """Reject forged digest callables or globals before artifact verification."""
+
+    identities = (
+        ("canonical-module", id(canonical_module)),
+        ("canonical-digest", id(canonical_digest)),
+        ("canonical-json-bytes", id(canonical_json_bytes)),
+        ("hashlib-module", id(hashlib)),
+        ("hashlib-sha256", id(hashlib.sha256)),
+        ("rfc8785-module", id(rfc8785)),
+        ("rfc8785-dumps", id(rfc8785.dumps)),
+    )
+    canonical_namespace = vars(canonical_module)
+    if (
+        identities != _SEALED_MODEL_DIGEST_PROCESS_IDENTITIES
+        or canonical_digest is not canonical_namespace.get("canonical_digest")
+        or canonical_json_bytes is not canonical_namespace.get("canonical_json_bytes")
+        or canonical_namespace.get("hashlib") is not hashlib
+        or canonical_namespace.get("rfc8785") is not rfc8785
+        or canonical_digest.__globals__ is not canonical_namespace
+        or canonical_json_bytes.__globals__ is not canonical_namespace
+    ):
+        raise ValueError("repository artifact digest bindings changed")
+
 
 AUDIT_CATEGORIES = (
     "repository_topology",
@@ -175,9 +215,11 @@ class RepositorySnapshot:
         return cast(dict[str, Any], _plain(self))
 
     def canonical_bytes(self) -> bytes:
+        _assert_repository_model_bindings_sealed()
         return canonical_json_bytes(self.as_dict())
 
     def digest_is_valid(self) -> bool:
+        _assert_repository_model_bindings_sealed()
         payload = self.as_dict()
         claimed = str(payload.pop("snapshot_digest", ""))
         return bool(claimed) and claimed == canonical_digest(payload)
@@ -185,6 +227,7 @@ class RepositorySnapshot:
     def assessment_reference(self, observation: GovernanceObservation) -> dict[str, Any]:
         """Return the narrow evidence seam consumed by later lifecycle work."""
 
+        _assert_repository_model_bindings_sealed()
         if not self.digest_is_valid():
             raise ValueError("repository snapshot digest is invalid")
         if not observation.digest_is_valid():
@@ -341,9 +384,11 @@ class GovernanceObservation:
         return cast(dict[str, Any], _plain(self))
 
     def canonical_bytes(self) -> bytes:
+        _assert_repository_model_bindings_sealed()
         return canonical_json_bytes(self.as_dict())
 
     def digest_is_valid(self) -> bool:
+        _assert_repository_model_bindings_sealed()
         payload = self.as_dict()
         claimed = str(payload.pop("observation_output_digest", ""))
         return bool(claimed) and claimed == canonical_digest(payload)

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field, fields, is_dataclass
 from types import MappingProxyType
 from typing import Any, cast
 
-from pmpe.contracts.canonical import canonical_json_bytes
+from pmpe.contracts.canonical import canonical_digest, canonical_json_bytes
 
 AUDIT_CATEGORIES = (
     "repository_topology",
@@ -177,9 +177,18 @@ class RepositorySnapshot:
     def canonical_bytes(self) -> bytes:
         return canonical_json_bytes(self.as_dict())
 
+    def digest_is_valid(self) -> bool:
+        payload = self.as_dict()
+        claimed = str(payload.pop("snapshot_digest", ""))
+        return bool(claimed) and claimed == canonical_digest(payload)
+
     def assessment_reference(self, observation: GovernanceObservation) -> dict[str, str]:
         """Return the narrow evidence seam consumed by later lifecycle work."""
 
+        if not self.digest_is_valid():
+            raise ValueError("repository snapshot digest is invalid")
+        if not observation.digest_is_valid():
+            raise ValueError("governance observation digest is invalid")
         if observation.repository != self.repository:
             raise ValueError("snapshot and governance observation repositories do not match")
         if (
@@ -297,3 +306,8 @@ class GovernanceObservation:
 
     def canonical_bytes(self) -> bytes:
         return canonical_json_bytes(self.as_dict())
+
+    def digest_is_valid(self) -> bool:
+        payload = self.as_dict()
+        claimed = str(payload.pop("observation_output_digest", ""))
+        return bool(claimed) and claimed == canonical_digest(payload)

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -231,6 +231,7 @@ class IssueObservation:
 
 @dataclass(frozen=True)
 class QueryProvenance:
+    surface: str
     query: str
     cursor: str | None
     page: int | None

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -242,6 +242,9 @@ class PullRequestObservation:
     number: int
     draft: bool
     head: str
+    updated_at: str
+    mergeability: str
+    stale: bool
 
 
 @dataclass(frozen=True)

--- a/src/pmpe/repository/models.py
+++ b/src/pmpe/repository/models.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
-from typing import Any
+from collections.abc import Mapping
+from dataclasses import dataclass, field, fields, is_dataclass
+from types import MappingProxyType
+from typing import Any, cast
 
 from pmpe.contracts.canonical import canonical_json_bytes
 
@@ -12,6 +14,7 @@ AUDIT_CATEGORIES = (
     "languages_build_ecosystems",
     "architecture_boundaries",
     "apis_data",
+    "integrations",
     "tests_quality",
     "delivery_environments",
     "security_privacy",
@@ -20,6 +23,24 @@ AUDIT_CATEGORIES = (
     "active_divergent_work",
     "debt_risk",
 )
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _plain(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return {item.name: _plain(getattr(value, item.name)) for item in fields(value)}
+    if isinstance(value, Mapping):
+        return {str(key): _plain(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain(item) for item in value]
+    return value
 
 
 @dataclass(frozen=True)
@@ -111,6 +132,12 @@ class CommandProvenance:
 
 
 @dataclass(frozen=True)
+class ToolVersion:
+    tool: str
+    version: str
+
+
+@dataclass(frozen=True)
 class RepositorySnapshot:
     repository: str
     commit_sha: str
@@ -120,24 +147,30 @@ class RepositorySnapshot:
     scanner_version: str
     scan_configuration_digest: str
     adapter_set_digest: str
+    implementation_digest: str
     tracked_tree_digest: str
     scanned_content_digest: str
     scan_scope: str
     included_paths: tuple[str, ...]
     tooling_digest: str
+    tool_versions: tuple[ToolVersion, ...]
     adapters: tuple[AdapterMetadata, ...]
     command_provenance: tuple[CommandProvenance, ...]
-    inventory: dict[str, InventoryCategory]
+    inventory: Mapping[str, InventoryCategory]
     findings: tuple[Finding, ...]
     boundary_candidates: tuple[BoundaryCandidate, ...]
     unsupported_categories: tuple[str, ...]
     disposition: str
-    redaction: dict[str, Any]
+    redaction: Mapping[str, Any]
     snapshot_digest: str
     artifact_kind: str = "REPOSITORY_SNAPSHOT"
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "inventory", _freeze(self.inventory))
+        object.__setattr__(self, "redaction", _freeze(self.redaction))
+
     def as_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        return cast(dict[str, Any], _plain(self))
 
     def canonical_bytes(self) -> bytes:
         return canonical_json_bytes(self.as_dict())
@@ -225,19 +258,27 @@ class GovernanceObservation:
     remote_branches: tuple[RemoteBranchObservation, ...]
     pull_requests: tuple[PullRequestObservation, ...]
     issues: tuple[IssueObservation, ...]
-    governance: dict[str, Any]
+    governance: Mapping[str, Any]
     query_provenance: tuple[QueryProvenance, ...]
+    remote_observed_at: str | None
+    remote_query_coverage: tuple[str, ...]
     unknowns: tuple[UnknownFact, ...]
+    collector_version: str
+    collector_implementation_digest: str
     tool_identity: str
     api_query_version: str
     observation_input_digest: str
     observation_output_digest: str
     disposition: str
-    redaction: dict[str, Any] = field(default_factory=dict)
+    redaction: Mapping[str, Any] = field(default_factory=dict)
     artifact_kind: str = "GOVERNANCE_OBSERVATION"
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "governance", _freeze(self.governance))
+        object.__setattr__(self, "redaction", _freeze(self.redaction))
+
     def as_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        return cast(dict[str, Any], _plain(self))
 
     def canonical_bytes(self) -> bytes:
         return canonical_json_bytes(self.as_dict())

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -15,7 +15,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/1.2.0"
+    version = "central-redactor/1.3.0"
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
         r"|glpat-[A-Za-z0-9_-]{16,}"
@@ -35,6 +35,12 @@ class EvidenceRedactor:
         r"(?:AIza[0-9A-Za-z_-]{35}|sk_(?:live|test)_[0-9A-Za-z]{16,}"
         r"|rk_(?:live|test)_[0-9A-Za-z]{16,}|npm_[0-9A-Za-z]{20,}"
         r"|pypi-[0-9A-Za-z_-]{20,})"
+    )
+    _sensitive_assignment = re.compile(
+        r"(?i)\b(?P<key>accountkey|sharedaccesskey|sharedaccesssignature|pwd|password|passwd"
+        r"|cookie|set-cookie|aws_access_key_id|aws_secret_access_key|aws_session_token"
+        r"|client_secret|private_key|api_key|access_token|refresh_token)"
+        r"(?P<separator>\s*[=:]\s*)(?P<value>\{[^}]*\}|[^\s,;]+)"
     )
     _sensitive_query = re.compile(r"(?i)(token|key|secret|password|signature|credential)")
     _sensitive_field = re.compile(
@@ -74,6 +80,10 @@ class EvidenceRedactor:
         sanitized = self._url_credentials.sub(r"\1[REDACTED]@", sanitized)
         sanitized = self._common_access_key.sub("[REDACTED]", sanitized)
         sanitized = self._vendor_token.sub("[REDACTED]", sanitized)
+        sanitized = self._sensitive_assignment.sub(
+            lambda match: f"{match.group('key')}{match.group('separator')}[REDACTED]",
+            sanitized,
+        )
         sanitized = self._token.sub("[REDACTED]", sanitized)
         sanitized = self._embedded_url.sub(
             lambda match: self._sanitize_url(match.group(0)), sanitized

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -25,7 +25,15 @@ class EvidenceRedactor:
         r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
         re.DOTALL,
     )
+    _private_key_header = re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*", re.DOTALL)
+    _url_credentials = re.compile(r"(?i)(https?://)[^/@\s:]+:[^/@\s]+@")
+    _common_access_key = re.compile(r"(?:AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,})")
     _sensitive_query = re.compile(r"(?i)(token|key|secret|password|signature|credential)")
+    _sensitive_field = re.compile(
+        r"(?i)(?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|api[_-]?key"
+        r"|access[_-]?token|refresh[_-]?token|client[_-]?secret|password|passwd|secret"
+        r"|private[_-]?key|credential)"
+    )
 
     def __init__(self) -> None:
         self._home = str(Path.home())
@@ -50,6 +58,9 @@ class EvidenceRedactor:
 
     def _sanitize_string(self, value: str) -> str:
         sanitized = self._private_key.sub("[REDACTED_PRIVATE_KEY]", value)
+        sanitized = self._private_key_header.sub("[REDACTED_PRIVATE_KEY]", sanitized)
+        sanitized = self._url_credentials.sub(r"\1[REDACTED]@", sanitized)
+        sanitized = self._common_access_key.sub("[REDACTED]", sanitized)
         sanitized = self._token.sub("[REDACTED]", sanitized)
         if "://" in sanitized:
             sanitized = self._sanitize_url(sanitized)
@@ -64,7 +75,17 @@ class EvidenceRedactor:
             if isinstance(value, bytes):
                 return self._sanitize_string(value.decode("utf-8", errors="replace"))
             if isinstance(value, dict):
-                return {str(self.sanitize(key)): self.sanitize(item) for key, item in value.items()}
+                result: dict[str, Any] = {}
+                for key, item in value.items():
+                    safe_key = str(self.sanitize(key))
+                    if safe_key in result:
+                        raise RedactionError("redacted object keys collide")
+                    result[safe_key] = (
+                        "[REDACTED]"
+                        if self._sensitive_field.search(safe_key)
+                        else self.sanitize(item)
+                    )
+                return result
             if isinstance(value, (list, tuple)):
                 return [self.sanitize(item) for item in value]
             if value is None or isinstance(value, (bool, int, float)):

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -15,12 +15,14 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/1.0.0"
+    version = "central-redactor/1.1.0"
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
+        r"|glpat-[A-Za-z0-9_-]{16,}"
         r"|(?:api[_-]?key|token|secret|password)\s*[=:]\s*[^\s,;]+"
-        r"|bearer\s+[A-Za-z0-9._~+\-/=]{12,})"
+        r"|(?:basic|bearer)\s+[A-Za-z0-9._~+\-/=]{8,})"
     )
+    _authorization = re.compile(r"(?i)authorization\s*:\s*(?:basic|bearer|digest)\s+[^\s,;]+")
     _private_key = re.compile(
         r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
         re.DOTALL,
@@ -59,6 +61,7 @@ class EvidenceRedactor:
     def _sanitize_string(self, value: str) -> str:
         sanitized = self._private_key.sub("[REDACTED_PRIVATE_KEY]", value)
         sanitized = self._private_key_header.sub("[REDACTED_PRIVATE_KEY]", sanitized)
+        sanitized = self._authorization.sub("Authorization: [REDACTED]", sanitized)
         sanitized = self._url_credentials.sub(r"\1[REDACTED]@", sanitized)
         sanitized = self._common_access_key.sub("[REDACTED]", sanitized)
         sanitized = self._token.sub("[REDACTED]", sanitized)

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -17,7 +17,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/2.1.0"
+    version = "central-redactor/2.2.0"
     __slots__ = ("_environment_secrets",)
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
@@ -75,6 +75,14 @@ class EvidenceRedactor:
         }
     )
 
+    @classmethod
+    def _host_has_secret_path(cls, hostname: str) -> bool:
+        normalized = hostname.rstrip(".").lower()
+        return any(
+            normalized == protected or normalized.endswith(f".{protected}")
+            for protected in cls._path_secret_hosts
+        )
+
     def __init__(self, *, environment: Mapping[str, str] | None = None) -> None:
         source = os.environ if environment is None else environment
         self._environment_secrets = tuple(
@@ -110,7 +118,7 @@ class EvidenceRedactor:
             return value
         try:
             parts = urlsplit(value)
-            hostname = parts.hostname or ""
+            hostname = (parts.hostname or "").rstrip(".").lower()
             if ":" in hostname and not hostname.startswith("["):
                 hostname = f"[{hostname}]"
             netloc = hostname
@@ -118,7 +126,7 @@ class EvidenceRedactor:
                 netloc = f"{netloc}:{parts.port}"
             path = (
                 "/[REDACTED_PATH]"
-                if parts.hostname in self._path_secret_hosts and parts.path not in {"", "/"}
+                if self._host_has_secret_path(hostname) and parts.path not in {"", "/"}
                 else parts.path
             )
             query = urlencode(

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -15,7 +15,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/1.4.0"
+    version = "central-redactor/1.5.0"
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
         r"|glpat-[A-Za-z0-9_-]{16,}"
@@ -37,10 +37,13 @@ class EvidenceRedactor:
         r"|pypi-[0-9A-Za-z_-]{20,})"
     )
     _sensitive_assignment = re.compile(
-        r"(?i)\b(?P<key>accountkey|sharedaccesskey|sharedaccesssignature|pwd|password|passwd"
+        r"(?i)(?P<quote>[\"']?)\b(?P<key>accountkey|sharedaccesskey|sharedaccesssignature"
+        r"|pwd|password|passwd"
         r"|cookie|set-cookie|aws_access_key_id|aws_secret_access_key|aws_session_token"
-        r"|client_secret|private_key|api_key|access_token|refresh_token)"
-        r"(?P<separator>\s*[=:]\s*)(?P<value>\{[^}]*\}|[^\s,;]+)"
+        r"|client_secret|private_key|api[-_]?key|access[-_]?token|refresh[-_]?token"
+        r"|token|secret|signature|sig|credential)"
+        r"(?P=quote)(?P<separator>\s*[=:]\s*)"
+        r"(?P<value>\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\{[^}]*\}|[^\s,;]+)"
     )
     _sensitive_query = re.compile(
         r"(?i)(?:^|[-_])(?:access[-_]?token|refresh[-_]?token|api[-_]?key|token|key"
@@ -54,6 +57,21 @@ class EvidenceRedactor:
 
     def __init__(self) -> None:
         self._home = str(Path.home())
+
+    @staticmethod
+    def _redact_assignment(match: re.Match[str]) -> str:
+        value = match.group("value")
+        replacement = (
+            '"[REDACTED]"'
+            if value.startswith('"')
+            else "'[REDACTED]'"
+            if value.startswith("'")
+            else "[REDACTED]"
+        )
+        return (
+            f"{match.group('quote')}{match.group('key')}{match.group('quote')}"
+            f"{match.group('separator')}{replacement}"
+        )
 
     def _sanitize_url(self, value: str) -> str:
         if "://" not in value:
@@ -83,10 +101,7 @@ class EvidenceRedactor:
         sanitized = self._url_credentials.sub(r"\1[REDACTED]@", sanitized)
         sanitized = self._common_access_key.sub("[REDACTED]", sanitized)
         sanitized = self._vendor_token.sub("[REDACTED]", sanitized)
-        sanitized = self._sensitive_assignment.sub(
-            lambda match: f"{match.group('key')}{match.group('separator')}[REDACTED]",
-            sanitized,
-        )
+        sanitized = self._sensitive_assignment.sub(self._redact_assignment, sanitized)
         sanitized = self._token.sub("[REDACTED]", sanitized)
         sanitized = self._embedded_url.sub(
             lambda match: self._sanitize_url(match.group(0)), sanitized

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -17,7 +17,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/2.4.0"
+    version = "central-redactor/2.5.0"
     __slots__ = ("_environment_secrets",)
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
@@ -27,6 +27,10 @@ class EvidenceRedactor:
     )
     _authorization = re.compile(
         r"(?im)\b(?:proxy-)?authorization[ \t]*:[ \t]*[^\r\n]*"
+        r"(?:\r?\n[ \t]+[^\r\n]*)*"
+    )
+    _cookie_header = re.compile(
+        r"(?im)\b(?:set-)?cookie[ \t]*:[ \t]*[^\r\n]*"
         r"(?:\r?\n[ \t]+[^\r\n]*)*"
     )
     _private_key = re.compile(
@@ -149,6 +153,7 @@ class EvidenceRedactor:
         sanitized = self._private_key.sub("[REDACTED_PRIVATE_KEY]", sanitized)
         sanitized = self._private_key_header.sub("[REDACTED_PRIVATE_KEY]", sanitized)
         sanitized = self._authorization.sub("Authorization: [REDACTED]", sanitized)
+        sanitized = self._cookie_header.sub("Cookie: [REDACTED]", sanitized)
         sanitized = self._url_credentials.sub(r"\1[REDACTED]@", sanitized)
         sanitized = self._common_access_key.sub("[REDACTED]", sanitized)
         sanitized = self._vendor_token.sub("[REDACTED]", sanitized)

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -17,7 +17,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/2.0.0"
+    version = "central-redactor/2.1.0"
     __slots__ = ("_environment_secrets",)
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
@@ -66,6 +66,14 @@ class EvidenceRedactor:
         r"(?<![A-Za-z0-9_])(?:(?:/Users|/home|/usr/home)/[^/\s]+|/var/root|/root)"
         r"(?=/|\s|$)"
     )
+    _path_secret_hosts = frozenset(
+        {
+            "api.telegram.org",
+            "discord.com",
+            "discordapp.com",
+            "hooks.slack.com",
+        }
+    )
 
     def __init__(self, *, environment: Mapping[str, str] | None = None) -> None:
         source = os.environ if environment is None else environment
@@ -108,6 +116,11 @@ class EvidenceRedactor:
             netloc = hostname
             if parts.port:
                 netloc = f"{netloc}:{parts.port}"
+            path = (
+                "/[REDACTED_PATH]"
+                if parts.hostname in self._path_secret_hosts and parts.path not in {"", "/"}
+                else parts.path
+            )
             query = urlencode(
                 [
                     (key, "[REDACTED]" if self._sensitive_query.search(key) else item)
@@ -116,7 +129,7 @@ class EvidenceRedactor:
             )
         except (UnicodeError, ValueError):
             return "[REDACTED_URL]"
-        return urlunsplit((parts.scheme, netloc, parts.path, query, ""))
+        return urlunsplit((parts.scheme, netloc, path, query, ""))
 
     def _sanitize_string(self, value: str) -> str:
         sanitized = value

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import re
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Any, final
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -13,11 +13,24 @@ class RedactionError(RuntimeError):
     """Raised when evidence cannot be safely sanitized."""
 
 
+def assert_distinct_identities_preserved(
+    namespace: str,
+    identities: Iterable[tuple[str, str]],
+) -> None:
+    """Fail when redaction maps different persisted identities to one value."""
+
+    originals_by_sanitized: dict[str, str] = {}
+    for original, sanitized in identities:
+        previous = originals_by_sanitized.setdefault(sanitized, original)
+        if previous != original:
+            raise RedactionError(f"redaction collapsed distinct identities in {namespace}")
+
+
 @final
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/2.6.0"
+    version = "central-redactor/2.7.0"
     __slots__ = ("_environment_secrets",)
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
@@ -48,7 +61,8 @@ class EvidenceRedactor:
     )
     _modern_service_token = re.compile(
         r"(?i)(?:sk-(?:proj|svcacct|ant)-[A-Za-z0-9_-]{16,}"
-        r"|sk-[A-Za-z0-9]{20,})"
+        r"|sk-or-v1-[A-Za-z0-9_-]{16,}|sk-[A-Za-z0-9]{20,}"
+        r"|hf_[A-Za-z0-9_-]{20,})"
     )
     _sensitive_assignment = re.compile(
         r"(?i)(?P<quote>[\"']?)\b(?P<key>accountkey|sharedaccesskey|sharedaccesssignature"
@@ -62,7 +76,8 @@ class EvidenceRedactor:
     _sensitive_whitespace_assignment = re.compile(
         r"(?i)(?P<prefix>^|[\s,;({\[])(?P<key>authorization|credential|password|passwd|pwd"
         r"|api[-_]?key|x-api-key|access[-_]?token|refresh[-_]?token|client[-_]?secret"
-        r"|private[-_]?key|aws_access_key_id|aws_secret_access_key|aws_session_token)"
+        r"|private[-_]?key|aws_access_key_id|aws_secret_access_key|aws_session_token"
+        r"|token|secret|cookie|set-cookie)"
         r"(?P<separator>[ \t]+)"
         r"(?P<value>\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\{[^}]*\}|[^\s,;]+)"
     )

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import re
 from collections.abc import Mapping
-from pathlib import Path
 from typing import Any, final
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -18,8 +17,8 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/1.7.0"
-    __slots__ = ("_environment_secrets", "_home")
+    version = "central-redactor/1.8.0"
+    __slots__ = ("_environment_secrets",)
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
         r"|glpat-[A-Za-z0-9_-]{16,}"
@@ -63,9 +62,9 @@ class EvidenceRedactor:
         r"|redis[_-]?url|api[_-]?key|access[_-]?key|private[_-]?key|password|passwd"
         r"|pwd|secret|signature|token)"
     )
+    _home_path = re.compile(r"^(?:/Users|/home)/[^/]+(?=/|$)")
 
     def __init__(self, *, environment: Mapping[str, str] | None = None) -> None:
-        self._home = str(Path.home())
         source = os.environ if environment is None else environment
         self._environment_secrets = tuple(
             sorted(
@@ -131,9 +130,7 @@ class EvidenceRedactor:
         sanitized = self._embedded_url.sub(
             lambda match: self._sanitize_url(match.group(0)), sanitized
         )
-        if self._home and sanitized.startswith(self._home):
-            sanitized = "$HOME" + sanitized[len(self._home) :]
-        return sanitized
+        return self._home_path.sub("$HOME", sanitized)
 
     def sanitize(self, value: Any) -> Any:
         try:

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -17,7 +17,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/1.8.0"
+    version = "central-redactor/1.9.0"
     __slots__ = ("_environment_secrets",)
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
@@ -62,7 +62,7 @@ class EvidenceRedactor:
         r"|redis[_-]?url|api[_-]?key|access[_-]?key|private[_-]?key|password|passwd"
         r"|pwd|secret|signature|token)"
     )
-    _home_path = re.compile(r"^(?:/Users|/home)/[^/]+(?=/|$)")
+    _home_path = re.compile(r"(?<![A-Za-z0-9_])(?:/Users|/home)/[^/\s]+")
 
     def __init__(self, *, environment: Mapping[str, str] | None = None) -> None:
         source = os.environ if environment is None else environment

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -17,7 +17,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/1.9.0"
+    version = "central-redactor/2.0.0"
     __slots__ = ("_environment_secrets",)
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
@@ -62,7 +62,10 @@ class EvidenceRedactor:
         r"|redis[_-]?url|api[_-]?key|access[_-]?key|private[_-]?key|password|passwd"
         r"|pwd|secret|signature|token)"
     )
-    _home_path = re.compile(r"(?<![A-Za-z0-9_])(?:/Users|/home)/[^/\s]+")
+    _home_path = re.compile(
+        r"(?<![A-Za-z0-9_])(?:(?:/Users|/home|/usr/home)/[^/\s]+|/var/root|/root)"
+        r"(?=/|\s|$)"
+    )
 
     def __init__(self, *, environment: Mapping[str, str] | None = None) -> None:
         source = os.environ if environment is None else environment
@@ -144,9 +147,10 @@ class EvidenceRedactor:
                     safe_key = str(self.sanitize(key))
                     if safe_key in result:
                         raise RedactionError("redacted object keys collide")
+                    sensitive_field = self._sensitive_field.search(safe_key) is not None
                     result[safe_key] = (
                         "[REDACTED]"
-                        if self._sensitive_field.search(safe_key)
+                        if sensitive_field and not isinstance(item, bool)
                         else self.sanitize(item)
                     )
                 return result

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -15,7 +15,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/1.1.0"
+    version = "central-redactor/1.2.0"
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
         r"|glpat-[A-Za-z0-9_-]{16,}"
@@ -28,8 +28,14 @@ class EvidenceRedactor:
         re.DOTALL,
     )
     _private_key_header = re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*", re.DOTALL)
-    _url_credentials = re.compile(r"(?i)(https?://)[^/@\s:]+:[^/@\s]+@")
+    _url_credentials = re.compile(r"(?i)([a-z][a-z0-9+.-]*://)[^/@\s]+@")
+    _embedded_url = re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s<>'\"]+")
     _common_access_key = re.compile(r"(?:AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,})")
+    _vendor_token = re.compile(
+        r"(?:AIza[0-9A-Za-z_-]{35}|sk_(?:live|test)_[0-9A-Za-z]{16,}"
+        r"|rk_(?:live|test)_[0-9A-Za-z]{16,}|npm_[0-9A-Za-z]{20,}"
+        r"|pypi-[0-9A-Za-z_-]{20,})"
+    )
     _sensitive_query = re.compile(r"(?i)(token|key|secret|password|signature|credential)")
     _sensitive_field = re.compile(
         r"(?i)(?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|api[_-]?key"
@@ -45,17 +51,20 @@ class EvidenceRedactor:
             return value
         try:
             parts = urlsplit(value)
-        except ValueError:
+            hostname = parts.hostname or ""
+            if ":" in hostname and not hostname.startswith("["):
+                hostname = f"[{hostname}]"
+            netloc = hostname
+            if parts.port:
+                netloc = f"{netloc}:{parts.port}"
+            query = urlencode(
+                [
+                    (key, "[REDACTED]" if self._sensitive_query.search(key) else item)
+                    for key, item in parse_qsl(parts.query, keep_blank_values=True)
+                ]
+            )
+        except (UnicodeError, ValueError):
             return "[REDACTED_URL]"
-        netloc = parts.hostname or ""
-        if parts.port:
-            netloc = f"{netloc}:{parts.port}"
-        query = urlencode(
-            [
-                (key, "[REDACTED]" if self._sensitive_query.search(key) else item)
-                for key, item in parse_qsl(parts.query, keep_blank_values=True)
-            ]
-        )
         return urlunsplit((parts.scheme, netloc, parts.path, query, ""))
 
     def _sanitize_string(self, value: str) -> str:
@@ -64,9 +73,11 @@ class EvidenceRedactor:
         sanitized = self._authorization.sub("Authorization: [REDACTED]", sanitized)
         sanitized = self._url_credentials.sub(r"\1[REDACTED]@", sanitized)
         sanitized = self._common_access_key.sub("[REDACTED]", sanitized)
+        sanitized = self._vendor_token.sub("[REDACTED]", sanitized)
         sanitized = self._token.sub("[REDACTED]", sanitized)
-        if "://" in sanitized:
-            sanitized = self._sanitize_url(sanitized)
+        sanitized = self._embedded_url.sub(
+            lambda match: self._sanitize_url(match.group(0)), sanitized
+        )
         if self._home and sanitized.startswith(self._home):
             sanitized = "$HOME" + sanitized[len(self._home) :]
         return sanitized

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -17,7 +17,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/2.2.0"
+    version = "central-redactor/2.3.0"
     __slots__ = ("_environment_secrets",)
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
@@ -25,7 +25,7 @@ class EvidenceRedactor:
         r"|(?:api[_-]?key|token|secret|password)\s*[=:]\s*[^\s,;]+"
         r"|(?:basic|bearer)\s+[A-Za-z0-9._~+\-/=]{8,})"
     )
-    _authorization = re.compile(r"(?i)authorization\s*:\s*(?:basic|bearer|digest)\s+[^\s,;]+")
+    _authorization = re.compile(r"(?i)\b(?:proxy-)?authorization\s*:\s*[^\r\n]*")
     _private_key = re.compile(
         r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
         re.DOTALL,

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import re
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
@@ -15,7 +17,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/1.6.0"
+    version = "central-redactor/1.7.0"
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
         r"|glpat-[A-Za-z0-9_-]{16,}"
@@ -54,9 +56,27 @@ class EvidenceRedactor:
         r"|access[_-]?token|refresh[_-]?token|client[_-]?secret|password|passwd|secret"
         r"|private[_-]?key|credential|token|signature|sig)"
     )
+    _sensitive_environment_field = re.compile(
+        r"(?i)(?:auth|authorization|cookie|credential|database[_-]?url|db[_-]?url"
+        r"|redis[_-]?url|api[_-]?key|access[_-]?key|private[_-]?key|password|passwd"
+        r"|pwd|secret|signature|token)"
+    )
 
-    def __init__(self) -> None:
+    def __init__(self, *, environment: Mapping[str, str] | None = None) -> None:
         self._home = str(Path.home())
+        source = os.environ if environment is None else environment
+        self._environment_secrets = tuple(
+            sorted(
+                {
+                    value
+                    for key, value in source.items()
+                    if self._sensitive_environment_field.search(key)
+                    and isinstance(value, str)
+                    and len(value) >= 4
+                },
+                key=lambda item: (-len(item), item),
+            )
+        )
 
     @staticmethod
     def _redact_assignment(match: re.Match[str]) -> str:
@@ -95,7 +115,10 @@ class EvidenceRedactor:
         return urlunsplit((parts.scheme, netloc, parts.path, query, ""))
 
     def _sanitize_string(self, value: str) -> str:
-        sanitized = self._private_key.sub("[REDACTED_PRIVATE_KEY]", value)
+        sanitized = value
+        for secret in self._environment_secrets:
+            sanitized = sanitized.replace(secret, "[REDACTED_ENV]")
+        sanitized = self._private_key.sub("[REDACTED_PRIVATE_KEY]", sanitized)
         sanitized = self._private_key_header.sub("[REDACTED_PRIVATE_KEY]", sanitized)
         sanitized = self._authorization.sub("Authorization: [REDACTED]", sanitized)
         sanitized = self._url_credentials.sub(r"\1[REDACTED]@", sanitized)

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -17,7 +17,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/2.5.0"
+    version = "central-redactor/2.6.0"
     __slots__ = ("_environment_secrets",)
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
@@ -46,6 +46,10 @@ class EvidenceRedactor:
         r"|rk_(?:live|test)_[0-9A-Za-z]{16,}|npm_[0-9A-Za-z]{20,}"
         r"|pypi-[0-9A-Za-z_-]{20,})"
     )
+    _modern_service_token = re.compile(
+        r"(?i)(?:sk-(?:proj|svcacct|ant)-[A-Za-z0-9_-]{16,}"
+        r"|sk-[A-Za-z0-9]{20,})"
+    )
     _sensitive_assignment = re.compile(
         r"(?i)(?P<quote>[\"']?)\b(?P<key>accountkey|sharedaccesskey|sharedaccesssignature"
         r"|pwd|password|passwd"
@@ -53,6 +57,13 @@ class EvidenceRedactor:
         r"|client_secret|private_key|api[-_]?key|access[-_]?token|refresh[-_]?token"
         r"|token|secret|signature|sig|credential)"
         r"(?P=quote)(?P<separator>\s*[=:]\s*)"
+        r"(?P<value>\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\{[^}]*\}|[^\s,;]+)"
+    )
+    _sensitive_whitespace_assignment = re.compile(
+        r"(?i)(?P<prefix>^|[\s,;({\[])(?P<key>authorization|credential|password|passwd|pwd"
+        r"|api[-_]?key|x-api-key|access[-_]?token|refresh[-_]?token|client[-_]?secret"
+        r"|private[-_]?key|aws_access_key_id|aws_secret_access_key|aws_session_token)"
+        r"(?P<separator>[ \t]+)"
         r"(?P<value>\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\{[^}]*\}|[^\s,;]+)"
     )
     _sensitive_query = re.compile(
@@ -120,6 +131,20 @@ class EvidenceRedactor:
             f"{match.group('separator')}{replacement}"
         )
 
+    @staticmethod
+    def _redact_whitespace_assignment(match: re.Match[str]) -> str:
+        value = match.group("value")
+        unquoted = value.strip("\"'{}")
+        credential_like = (
+            value[:1] in {'"', "'", "{"}
+            or len(unquoted) >= 16
+            or any(character.isdigit() for character in unquoted)
+            or any(character in "_-+=/@." for character in unquoted)
+        )
+        if not credential_like:
+            return match.group(0)
+        return f"{match.group('prefix')}{match.group('key')}{match.group('separator')}[REDACTED]"
+
     def _sanitize_url(self, value: str) -> str:
         if "://" not in value:
             return value
@@ -157,7 +182,11 @@ class EvidenceRedactor:
         sanitized = self._url_credentials.sub(r"\1[REDACTED]@", sanitized)
         sanitized = self._common_access_key.sub("[REDACTED]", sanitized)
         sanitized = self._vendor_token.sub("[REDACTED]", sanitized)
+        sanitized = self._modern_service_token.sub("[REDACTED]", sanitized)
         sanitized = self._sensitive_assignment.sub(self._redact_assignment, sanitized)
+        sanitized = self._sensitive_whitespace_assignment.sub(
+            self._redact_whitespace_assignment, sanitized
+        )
         sanitized = self._token.sub("[REDACTED]", sanitized)
         sanitized = self._embedded_url.sub(
             lambda match: self._sanitize_url(match.group(0)), sanitized

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -1,0 +1,74 @@
+"""Central fail-closed redaction for persisted repository evidence."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+class RedactionError(RuntimeError):
+    """Raised when evidence cannot be safely sanitized."""
+
+
+class EvidenceRedactor:
+    """Sanitize all strings before they enter an artifact or diagnostic."""
+
+    version = "central-redactor/1.0.0"
+    _token = re.compile(
+        r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
+        r"|(?:api[_-]?key|token|secret|password)\s*[=:]\s*[^\s,;]+"
+        r"|bearer\s+[A-Za-z0-9._~+\-/=]{12,})"
+    )
+    _private_key = re.compile(
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+        re.DOTALL,
+    )
+    _sensitive_query = re.compile(r"(?i)(token|key|secret|password|signature|credential)")
+
+    def __init__(self) -> None:
+        self._home = str(Path.home())
+
+    def _sanitize_url(self, value: str) -> str:
+        if "://" not in value:
+            return value
+        try:
+            parts = urlsplit(value)
+        except ValueError:
+            return "[REDACTED_URL]"
+        netloc = parts.hostname or ""
+        if parts.port:
+            netloc = f"{netloc}:{parts.port}"
+        query = urlencode(
+            [
+                (key, "[REDACTED]" if self._sensitive_query.search(key) else item)
+                for key, item in parse_qsl(parts.query, keep_blank_values=True)
+            ]
+        )
+        return urlunsplit((parts.scheme, netloc, parts.path, query, ""))
+
+    def _sanitize_string(self, value: str) -> str:
+        sanitized = self._private_key.sub("[REDACTED_PRIVATE_KEY]", value)
+        sanitized = self._token.sub("[REDACTED]", sanitized)
+        if "://" in sanitized:
+            sanitized = self._sanitize_url(sanitized)
+        if self._home and sanitized.startswith(self._home):
+            sanitized = "$HOME" + sanitized[len(self._home) :]
+        return sanitized
+
+    def sanitize(self, value: Any) -> Any:
+        try:
+            if isinstance(value, str):
+                return self._sanitize_string(value)
+            if isinstance(value, bytes):
+                return self._sanitize_string(value.decode("utf-8", errors="replace"))
+            if isinstance(value, dict):
+                return {str(self.sanitize(key)): self.sanitize(item) for key, item in value.items()}
+            if isinstance(value, (list, tuple)):
+                return [self.sanitize(item) for item in value]
+            if value is None or isinstance(value, (bool, int, float)):
+                return value
+        except Exception as exc:
+            raise RedactionError("evidence redaction failed") from exc
+        raise RedactionError("unsupported evidence type during redaction")

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -15,7 +15,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/1.5.0"
+    version = "central-redactor/1.6.0"
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
         r"|glpat-[A-Za-z0-9_-]{16,}"
@@ -52,7 +52,7 @@ class EvidenceRedactor:
     _sensitive_field = re.compile(
         r"(?i)(?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|api[_-]?key"
         r"|access[_-]?token|refresh[_-]?token|client[_-]?secret|password|passwd|secret"
-        r"|private[_-]?key|credential)"
+        r"|private[_-]?key|credential|token|signature|sig)"
     )
 
     def __init__(self) -> None:

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -6,7 +6,7 @@ import os
 import re
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, final
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 
@@ -14,10 +14,12 @@ class RedactionError(RuntimeError):
     """Raised when evidence cannot be safely sanitized."""
 
 
+@final
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
     version = "central-redactor/1.7.0"
+    __slots__ = ("_environment_secrets", "_home")
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
         r"|glpat-[A-Za-z0-9_-]{16,}"

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -17,7 +17,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/2.3.0"
+    version = "central-redactor/2.4.0"
     __slots__ = ("_environment_secrets",)
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
@@ -25,7 +25,10 @@ class EvidenceRedactor:
         r"|(?:api[_-]?key|token|secret|password)\s*[=:]\s*[^\s,;]+"
         r"|(?:basic|bearer)\s+[A-Za-z0-9._~+\-/=]{8,})"
     )
-    _authorization = re.compile(r"(?i)\b(?:proxy-)?authorization\s*:\s*[^\r\n]*")
+    _authorization = re.compile(
+        r"(?im)\b(?:proxy-)?authorization[ \t]*:[ \t]*[^\r\n]*"
+        r"(?:\r?\n[ \t]+[^\r\n]*)*"
+    )
     _private_key = re.compile(
         r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
         re.DOTALL,

--- a/src/pmpe/repository/redaction.py
+++ b/src/pmpe/repository/redaction.py
@@ -15,7 +15,7 @@ class RedactionError(RuntimeError):
 class EvidenceRedactor:
     """Sanitize all strings before they enter an artifact or diagnostic."""
 
-    version = "central-redactor/1.3.0"
+    version = "central-redactor/1.4.0"
     _token = re.compile(
         r"(?i)(?:gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}"
         r"|glpat-[A-Za-z0-9_-]{16,}"
@@ -42,7 +42,10 @@ class EvidenceRedactor:
         r"|client_secret|private_key|api_key|access_token|refresh_token)"
         r"(?P<separator>\s*[=:]\s*)(?P<value>\{[^}]*\}|[^\s,;]+)"
     )
-    _sensitive_query = re.compile(r"(?i)(token|key|secret|password|signature|credential)")
+    _sensitive_query = re.compile(
+        r"(?i)(?:^|[-_])(?:access[-_]?token|refresh[-_]?token|api[-_]?key|token|key"
+        r"|secret|password|passwd|signature|sig|credential|code)(?:$|[-_])"
+    )
     _sensitive_field = re.compile(
         r"(?i)(?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|api[_-]?key"
         r"|access[_-]?token|refresh[_-]?token|client[_-]?secret|password|passwd|secret"

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -41,7 +41,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/1.3.0"
+SCANNER_VERSION = "repository-scanner/1.4.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -49,7 +49,7 @@ IMPLEMENTATION_MODULES = (
     "repository.scanner",
     "contracts.canonical",
 )
-_SHA = re.compile(r"^[0-9a-f]{40}$")
+_OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
 
 
 class RepositoryIntelligenceError(RuntimeError):
@@ -81,7 +81,7 @@ class TreeListingResult:
 class SubprocessCommandRunner:
     """Allowlisted local Git reader; it never invokes shells or project code."""
 
-    identity = "git-readonly-subprocess/1.3.0"
+    identity = "git-readonly-subprocess/1.4.0"
     _allowed = {"rev-parse", "ls-tree", "cat-file", "version"}
 
     @staticmethod
@@ -195,11 +195,21 @@ class SubprocessCommandRunner:
         finally:
             selector.close()
             process.stdout.close()
+        graceful_timeout = 0.25 if cancelled or record_limit or byte_limit else 0.1
         try:
-            returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
+            returncode = process.wait(
+                timeout=(
+                    graceful_timeout
+                    if cancelled or record_limit or byte_limit
+                    else max(0.1, deadline - time.monotonic())
+                )
+            )
         except subprocess.TimeoutExpired:
             _signal_process_group(process, signal.SIGKILL)
-            returncode = process.wait()
+            try:
+                returncode = process.wait(timeout=1.0)
+            except subprocess.TimeoutExpired as exc:
+                raise RepositorySecurityError("bounded Git process could not be reaped") from exc
             timed_out = True
         complete_records = bytes(payload[:max_output_bytes]).split(b"\0")
         if complete_records and complete_records[-1]:
@@ -231,13 +241,32 @@ def _signal_process_group(process: subprocess.Popen[bytes], action: signal.Signa
         os.killpg(process.pid, action)
     except ProcessLookupError:
         return
-    except PermissionError:
-        # Some constrained hosts prohibit group signalling. The allowlisted
-        # immutable-object Git commands cannot invoke repository-defined code,
-        # so terminating the parent remains safe and fail-bounded there.
-        process.send_signal(action)
-    except OSError as exc:
-        raise RepositorySecurityError("bounded Git process group could not be terminated") from exc
+    except OSError:
+        # Always make a best-effort parent termination if process-group signalling
+        # is unavailable. These immutable-object commands cannot invoke repository
+        # code, so a successfully signalled and reaped parent is a safe fallback.
+        try:
+            process.send_signal(action)
+        except ProcessLookupError:
+            return
+        except OSError:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                return
+            except OSError as exc:
+                raise RepositorySecurityError(
+                    "bounded Git process group and parent could not be terminated"
+                ) from exc
+
+
+def _valid_object_id(value: str, object_format: str) -> bool:
+    length = _OBJECT_FORMAT_LENGTH.get(object_format)
+    return (
+        length is not None
+        and len(value) == length
+        and all(character in "0123456789abcdef" for character in value)
+    )
 
 
 def _implementation_digest() -> str:
@@ -352,6 +381,7 @@ def _snapshot_from_dict(value: dict[str, Any]) -> RepositorySnapshot:
         repository=str(value["repository"]),
         commit_sha=str(value["commit_sha"]),
         tree_sha=str(value["tree_sha"]),
+        git_object_format=str(value["git_object_format"]),
         default_branch=cast(str | None, value["default_branch"]),
         default_branch_source=str(value["default_branch_source"]),
         scanner_version=str(value["scanner_version"]),
@@ -409,6 +439,24 @@ class RepositoryScanner:
         self._commands = 0
         self._command_provenance: list[CommandProvenance] = []
         self._tool_versions: tuple[ToolVersion, ...] = ()
+
+    def _is_cancelled(self) -> bool:
+        if self.cancellation is None:
+            return False
+        try:
+            return self.cancellation.cancelled()
+        except Exception:
+            return True
+
+    @staticmethod
+    def _cancelled_finding(evidence_ref: str) -> Finding:
+        return _finding(
+            "SCAN.CANCELLED",
+            "repository_topology",
+            "The scan was cancelled before a complete repository artifact was finalized.",
+            (evidence_ref,),
+            blocking=True,
+        )
 
     def _run(
         self, args: tuple[str, ...], root: Path, *, essential: bool = False
@@ -536,6 +584,7 @@ class RepositoryScanner:
         root: Path,
         commit_sha: str,
         tree_sha: str,
+        git_object_format: str,
         config_digest: str,
         adapter_digest: str,
     ) -> RepositorySnapshot:
@@ -549,6 +598,7 @@ class RepositoryScanner:
         return self._finalize(
             commit_sha=commit_sha,
             tree_sha=tree_sha,
+            git_object_format=git_object_format,
             config_digest=config_digest,
             adapter_digest=adapter_digest,
             inventory_items={},
@@ -559,7 +609,7 @@ class RepositoryScanner:
             disposition="BLOCKED",
         )
 
-    def _resolve_identity(self, requested: Path) -> tuple[Path, str, str]:
+    def _resolve_identity(self, requested: Path) -> tuple[Path, str, str, str]:
         root_result = self._run(("git", "rev-parse", "--show-toplevel"), requested, essential=True)
         assert root_result is not None
         try:
@@ -570,10 +620,11 @@ class RepositoryScanner:
             raise RepositorySecurityError(
                 "resolved Git repository root is outside the requested path"
             )
-        commit_result = self._run(
+        identity_result = self._run(
             (
                 "git",
                 "rev-parse",
+                "--show-object-format",
                 "--verify",
                 "--end-of-options",
                 f"{self._requested_commit}^{{commit}}",
@@ -581,12 +632,18 @@ class RepositoryScanner:
             root,
             essential=True,
         )
-        assert commit_result is not None
+        assert identity_result is not None
         try:
-            commit_sha = _text(commit_result.stdout).strip()
+            object_format, commit_sha = _text(identity_result.stdout).splitlines()
         except UnicodeDecodeError as exc:
-            raise RepositoryIntelligenceError("Git commit identity is malformed") from exc
-        if not _SHA.fullmatch(commit_sha):
+            raise RepositoryIntelligenceError("Git repository identity is malformed") from exc
+        except ValueError as exc:
+            raise RepositoryIntelligenceError("Git repository identity is malformed") from exc
+        if object_format not in _OBJECT_FORMAT_LENGTH:
+            raise RepositoryIntelligenceError(
+                f"Git object format {object_format!r} is explicitly unsupported"
+            )
+        if not _valid_object_id(commit_sha, object_format):
             raise RepositoryIntelligenceError("Git commit identity is malformed")
         tree_result = self._run(
             (
@@ -599,21 +656,23 @@ class RepositoryScanner:
             root,
         )
         if tree_result is None:
-            return root, commit_sha, "0" * 40
+            return root, commit_sha, "0" * _OBJECT_FORMAT_LENGTH[object_format], object_format
         try:
             tree_sha = _text(tree_result.stdout).strip()
         except UnicodeDecodeError as exc:
             raise RepositoryIntelligenceError("Git tree identity is malformed") from exc
-        if not _SHA.fullmatch(tree_sha):
+        if not _valid_object_id(tree_sha, object_format):
             raise RepositoryIntelligenceError("Git tree identity is malformed")
-        return root, commit_sha, tree_sha
+        return root, commit_sha, tree_sha, object_format
 
     def _list_files(
-        self, root: Path, tree_sha: str
+        self, root: Path, tree_sha: str, object_format: str
     ) -> tuple[list[TrackedFile], list[Finding], str, str]:
         findings: list[Finding] = []
-        tracked_tree_digest = canonical_digest({"git_object_format": "sha1", "tree_sha": tree_sha})
-        if tree_sha == "0" * 40:
+        tracked_tree_digest = canonical_digest(
+            {"git_object_format": object_format, "tree_sha": tree_sha}
+        )
+        if tree_sha == "0" * _OBJECT_FORMAT_LENGTH[object_format]:
             findings.append(
                 _finding(
                     "BUDGET.COMMAND_COUNT",
@@ -669,7 +728,9 @@ class RepositoryScanner:
                 size = int(raw_size) if raw_size != "-" else 0
             except (ValueError, UnicodeDecodeError) as exc:
                 raise RepositoryIntelligenceError("tracked-tree output is malformed") from exc
-            if object_type not in {"blob", "commit"} or not _SHA.fullmatch(object_id):
+            if object_type not in {"blob", "commit"} or not _valid_object_id(
+                object_id, object_format
+            ):
                 raise RepositoryIntelligenceError("tracked-tree output is malformed")
             if object_type == "commit" and mode != "160000":
                 raise RepositoryIntelligenceError("tracked-tree output is malformed")
@@ -722,7 +783,7 @@ class RepositoryScanner:
         total = 0
         total_exhausted = False
         for mode, object_type, object_id, path, size in entries:
-            if self.cancellation is not None and self.cancellation.cancelled():
+            if self._is_cancelled():
                 findings.append(
                     _finding(
                         "SCAN.CANCELLED",
@@ -836,7 +897,7 @@ class RepositoryScanner:
         supported: set[str] = set()
         context = AdapterContext(files=files)
         for adapter in self.adapters:
-            if self.cancellation is not None and self.cancellation.cancelled():
+            if self._is_cancelled():
                 findings.append(
                     _finding(
                         "SCAN.CANCELLED",
@@ -864,6 +925,9 @@ class RepositoryScanner:
                     )
                 )
                 continue
+            if self._is_cancelled():
+                findings.append(self._cancelled_finding(f"adapter:{adapter.adapter_id}"))
+                break
             for category, item in result.items:
                 if category in inventory:
                     inventory[category].append(item)
@@ -1128,6 +1192,7 @@ class RepositoryScanner:
         *,
         commit_sha: str,
         tree_sha: str,
+        git_object_format: str,
         config_digest: str,
         adapter_digest: str,
         inventory_items: dict[str, list[EvidenceItem]],
@@ -1139,6 +1204,14 @@ class RepositoryScanner:
         tracked_tree_digest: str | None = None,
         scanned_content_digest: str | None = None,
     ) -> RepositorySnapshot:
+        findings = list(findings)
+        statuses = dict(statuses)
+        reasons = dict(reasons)
+        if self._is_cancelled() and not any(item.code == "SCAN.CANCELLED" for item in findings):
+            findings.append(self._cancelled_finding("repository:finalization"))
+            statuses.update(dict.fromkeys(AUDIT_CATEGORIES, "BLOCKED"))
+            reasons.update(dict.fromkeys(AUDIT_CATEGORIES, "scan cancelled"))
+            disposition = "BLOCKED"
         implementation_digest = _implementation_digest()
         inventory = {
             name: InventoryCategory(
@@ -1157,6 +1230,7 @@ class RepositoryScanner:
             repository=self.config.repository,
             commit_sha=commit_sha,
             tree_sha=tree_sha,
+            git_object_format=git_object_format,
             default_branch=self.config.default_branch,
             default_branch_source="SCAN_CONFIGURATION_NOT_OBSERVED",
             scanner_version=SCANNER_VERSION,
@@ -1208,6 +1282,22 @@ class RepositoryScanner:
             raise RepositorySecurityError(
                 "evidence redaction failed; artifact was not created"
             ) from exc
+        if self._is_cancelled() and not any(item.code == "SCAN.CANCELLED" for item in findings):
+            return self._finalize(
+                commit_sha=commit_sha,
+                tree_sha=tree_sha,
+                git_object_format=git_object_format,
+                config_digest=config_digest,
+                adapter_digest=adapter_digest,
+                inventory_items=inventory_items,
+                findings=[*findings, self._cancelled_finding("repository:finalization")],
+                boundaries=boundaries,
+                statuses=dict.fromkeys(AUDIT_CATEGORIES, "BLOCKED"),
+                reasons=dict.fromkeys(AUDIT_CATEGORIES, "scan cancelled"),
+                disposition="BLOCKED",
+                tracked_tree_digest=tracked_tree_digest,
+                scanned_content_digest=scanned_content_digest,
+            )
         sanitized["snapshot_digest"] = canonical_digest(
             {key: value for key, value in sanitized.items() if key != "snapshot_digest"}
         )
@@ -1219,7 +1309,7 @@ class RepositoryScanner:
         self._command_provenance = []
         self._requested_commit = commit
         requested = Path(repository_root).resolve()
-        root, commit_sha, tree_sha = self._resolve_identity(requested)
+        root, commit_sha, tree_sha, object_format = self._resolve_identity(requested)
         # Root/ref resolution establishes the immutable identity but is excluded from
         # commit-stable provenance because equivalent refs (HEAD versus the exact SHA)
         # must yield byte-equivalent snapshots. Remaining commands are SHA-bound.
@@ -1227,11 +1317,13 @@ class RepositoryScanner:
         self._tool_versions = self._collect_tool_versions(root)
         adapter_digest = canonical_digest([asdict(_metadata(item)) for item in self.adapters])
         config_digest = canonical_digest(asdict(self.config))
-        if self.cancellation is not None and self.cancellation.cancelled():
+        if self._is_cancelled():
             return self._cancelled_snapshot(
-                root, commit_sha, tree_sha, config_digest, adapter_digest
+                root, commit_sha, tree_sha, object_format, config_digest, adapter_digest
             )
-        files, budget_findings, tree_digest, scanned_digest = self._list_files(root, tree_sha)
+        files, budget_findings, tree_digest, scanned_digest = self._list_files(
+            root, tree_sha, object_format
+        )
         inventory, adapter_findings, boundaries, supported = self._apply_adapters(tuple(files))
         findings = budget_findings + adapter_findings
         if self.config.include_paths:
@@ -1301,6 +1393,7 @@ class RepositoryScanner:
         return self._finalize(
             commit_sha=commit_sha,
             tree_sha=tree_sha,
+            git_object_format=object_format,
             config_digest=config_digest,
             adapter_digest=adapter_digest,
             tracked_tree_digest=tree_digest,

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -50,9 +50,13 @@ from pmpe.repository.models import (
     ScanConfig,
     ToolVersion,
 )
-from pmpe.repository.redaction import EvidenceRedactor, RedactionError
+from pmpe.repository.redaction import (
+    EvidenceRedactor,
+    RedactionError,
+    assert_distinct_identities_preserved,
+)
 
-SCANNER_VERSION = "repository-scanner/2.16.0"
+SCANNER_VERSION = "repository-scanner/2.17.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -223,7 +227,15 @@ class Cancellation(Protocol):
 class CancellationSignal:
     """Sealed cancellation capability with no caller-executed callback."""
 
-    __slots__ = ("_cancel_after_checks", "_checks", "_event", "_lock")
+    __slots__ = (
+        "_cancel_after_checks",
+        "_checks",
+        "_event",
+        "_lock",
+        "_sealed_cancel_after_checks",
+        "_sealed_event",
+        "_sealed_lock",
+    )
 
     def __init__(self, *, cancel_after_checks: int | None = None) -> None:
         if cancel_after_checks is not None and cancel_after_checks < 1:
@@ -232,17 +244,34 @@ class CancellationSignal:
         self._checks = 0
         self._event = threading.Event()
         self._lock = threading.Lock()
+        self._sealed_cancel_after_checks = cancel_after_checks
+        self._sealed_event = self._event
+        self._sealed_lock = self._lock
+
+    def _integrity_is_valid(self) -> bool:
+        return (
+            self._event is self._sealed_event
+            and self._lock is self._sealed_lock
+            and self._cancel_after_checks == self._sealed_cancel_after_checks
+            and isinstance(self._checks, int)
+            and self._checks >= 0
+        )
 
     def cancel(self) -> None:
-        self._event.set()
+        if not self._integrity_is_valid():
+            raise RepositorySecurityError("cancellation signal integrity is invalid")
+        self._sealed_event.set()
 
     def cancelled(self) -> bool:
-        with self._lock:
+        if not self._integrity_is_valid():
+            raise RepositorySecurityError("cancellation signal integrity is invalid")
+        with self._sealed_lock:
             self._checks += 1
             threshold_reached = (
-                self._cancel_after_checks is not None and self._checks >= self._cancel_after_checks
+                self._sealed_cancel_after_checks is not None
+                and self._checks >= self._sealed_cancel_after_checks
             )
-        return self._event.is_set() or threshold_reached
+        return self._sealed_event.is_set() or threshold_reached
 
 
 _PROCESS_GROUP_GUARD = "import signal\nwhile True:\n signal.pause()"
@@ -1258,7 +1287,15 @@ def _implementation_digest(
     )
 
 
-def _adapter_worker(connection: Any, adapter: RepositoryAdapter, context: AdapterContext) -> None:
+def _adapter_worker(
+    connection: Any,
+    adapter: RepositoryAdapter,
+    context: AdapterContext,
+    expected_state_digest: str,
+    expected_adapter_identity: int,
+    expected_evaluator_identity: int,
+    expected_module_state_digest: str,
+) -> None:
     """Evaluate one adapter in a killable, environment-isolated process."""
 
     isolated = False
@@ -1267,6 +1304,13 @@ def _adapter_worker(connection: Any, adapter: RepositoryAdapter, context: Adapte
         isolated = True
         os.environ.clear()
         os.environ.update({"PATH": "/usr/bin:/bin", "LC_ALL": "C"})
+        if (
+            id(adapter) != expected_adapter_identity
+            or id(adapter.evaluator) != expected_evaluator_identity
+            or _adapter_execution_state_digest((adapter,)) != expected_state_digest
+            or _module_runtime_digest("repository.adapters") != expected_module_state_digest
+        ):
+            raise RepositorySecurityError("adapter execution state changed before evaluation")
         result = adapter.evaluator(context)
         if not isinstance(result, AdapterResult):
             raise TypeError("adapter result has an invalid type")
@@ -1393,6 +1437,82 @@ def _metadata(adapter: RepositoryAdapter) -> AdapterMetadata:
     )
 
 
+def _adapter_execution_state_digest(adapters: Sequence[RepositoryAdapter]) -> str:
+    """Bind declarations and live evaluator code for every executable adapter."""
+
+    return canonical_digest(
+        [
+            {
+                "declaration": asdict(_metadata(adapter)),
+                "evaluator": _implementation_source_evidence(
+                    f"adapter:{adapter.adapter_id}", adapter.evaluator
+                ),
+            }
+            for adapter in adapters
+        ]
+    )
+
+
+_SEALED_BUILTIN_ADAPTERS = default_adapters()
+_SEALED_BUILTIN_ADAPTER_STATE_DIGEST = _adapter_execution_state_digest(_SEALED_BUILTIN_ADAPTERS)
+_SEALED_ADAPTER_MODULE_STATE_DIGEST = _module_runtime_digest("repository.adapters")
+
+
+def _snapshot_identity_groups(
+    original: Mapping[str, Any], sanitized: Mapping[str, Any]
+) -> dict[str, list[tuple[str, str]]]:
+    """Pair persisted snapshot identities before and after redaction."""
+
+    groups: dict[str, list[tuple[str, str]]] = {
+        "snapshot paths": [],
+        "boundary names": [],
+    }
+    try:
+        for raw_included_path, safe_included_path in zip(
+            cast(list[str], original["included_paths"]),
+            cast(list[str], sanitized["included_paths"]),
+            strict=True,
+        ):
+            groups["snapshot paths"].append((raw_included_path, safe_included_path))
+        original_inventory = cast(dict[str, dict[str, Any]], original["inventory"])
+        sanitized_inventory = cast(dict[str, dict[str, Any]], sanitized["inventory"])
+        if set(original_inventory) != set(sanitized_inventory):
+            raise ValueError("inventory categories changed during redaction")
+        for category in original_inventory:
+            for raw_item, safe_item in zip(
+                cast(list[dict[str, Any]], original_inventory[category]["items"]),
+                cast(list[dict[str, Any]], sanitized_inventory[category]["items"]),
+                strict=True,
+            ):
+                groups["snapshot paths"].append((str(raw_item["path"]), str(safe_item["path"])))
+        for raw_finding, safe_finding in zip(
+            cast(list[dict[str, Any]], original["findings"]),
+            cast(list[dict[str, Any]], sanitized["findings"]),
+            strict=True,
+        ):
+            for raw_ref, safe_ref in zip(
+                cast(list[str], raw_finding["evidence_refs"]),
+                cast(list[str], safe_finding["evidence_refs"]),
+                strict=True,
+            ):
+                groups["snapshot paths"].append((raw_ref, safe_ref))
+        for raw_boundary, safe_boundary in zip(
+            cast(list[dict[str, Any]], original["boundary_candidates"]),
+            cast(list[dict[str, Any]], sanitized["boundary_candidates"]),
+            strict=True,
+        ):
+            groups["boundary names"].append((str(raw_boundary["name"]), str(safe_boundary["name"])))
+            for raw_path, safe_path in zip(
+                cast(list[str], raw_boundary["evidence_paths"]),
+                cast(list[str], safe_boundary["evidence_paths"]),
+                strict=True,
+            ):
+                groups["snapshot paths"].append((raw_path, safe_path))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RedactionError("redaction changed snapshot identity structure") from exc
+    return groups
+
+
 def _snapshot_from_dict(value: dict[str, Any]) -> RepositorySnapshot:
     inventory = {
         name: InventoryCategory(
@@ -1468,7 +1588,13 @@ class RepositoryScanner:
         cancellation: Cancellation | None = None,
     ) -> None:
         self.config = config
-        registered_adapters = default_adapters()
+        registered_adapters = _SEALED_BUILTIN_ADAPTERS
+        if (
+            _adapter_execution_state_digest(registered_adapters)
+            != _SEALED_BUILTIN_ADAPTER_STATE_DIGEST
+            or _module_runtime_digest("repository.adapters") != _SEALED_ADAPTER_MODULE_STATE_DIGEST
+        ):
+            raise RepositorySecurityError("sealed built-in adapter registry integrity failed")
         requested_adapters = tuple(adapters) if adapters is not None else registered_adapters
         registered_by_id = {item.adapter_id: item for item in registered_adapters}
         if len(requested_adapters) != len(registered_adapters) or any(
@@ -1513,12 +1639,23 @@ class RepositoryScanner:
         self._sealed_extension_evidence_digest = canonical_digest(
             self._extension_implementation_evidence
         )
+        self._sealed_adapter_execution_state_digest = _adapter_execution_state_digest(self.adapters)
+        self._sealed_adapter_runtime_guards = tuple(
+            (
+                item.adapter_id,
+                id(item),
+                id(item.evaluator),
+                _adapter_execution_state_digest((item,)),
+            )
+            for item in self.adapters
+        )
         self._sealed_execution_collaborators = (
             self.adapters,
             self.runner,
             self.redactor,
             self.cancellation,
             self._extension_implementation_evidence,
+            self._sealed_adapter_runtime_guards,
         )
         self._sealed_execution_config = self.config
         self._commands = 0
@@ -1549,6 +1686,7 @@ class RepositoryScanner:
             self.redactor,
             self.cancellation,
             self._extension_implementation_evidence,
+            self._sealed_adapter_runtime_guards,
         )
         if any(
             observed is not expected
@@ -1561,6 +1699,16 @@ class RepositoryScanner:
             )
         try:
             extension_evidence_digest = canonical_digest(self._extension_implementation_evidence)
+            adapter_execution_state_digest = _adapter_execution_state_digest(self.adapters)
+            adapter_runtime_guards = tuple(
+                (
+                    item.adapter_id,
+                    id(item),
+                    id(item.evaluator),
+                    _adapter_execution_state_digest((item,)),
+                )
+                for item in self.adapters
+            )
         except Exception as exc:
             raise RepositorySecurityError(
                 "repository scan implementation provenance evidence is malformed"
@@ -1568,10 +1716,15 @@ class RepositoryScanner:
         if (
             self.config is not self._sealed_execution_config
             or extension_evidence_digest != self._sealed_extension_evidence_digest
+            or adapter_execution_state_digest != self._sealed_adapter_execution_state_digest
+            or adapter_execution_state_digest != _SEALED_BUILTIN_ADAPTER_STATE_DIGEST
+            or adapter_runtime_guards != self._sealed_adapter_runtime_guards
+            or _module_runtime_digest("repository.adapters") != _SEALED_ADAPTER_MODULE_STATE_DIGEST
             or self.redactor._environment_secrets != ()
             or type(self.runner) is not SubprocessCommandRunner
             or type(self.redactor) is not EvidenceRedactor
             or (self.cancellation is not None and type(self.cancellation) is not CancellationSignal)
+            or (self.cancellation is not None and not self.cancellation._integrity_is_valid())
         ):
             raise RepositorySecurityError(
                 "repository scan execution collaborators are no longer sealed"
@@ -2252,13 +2405,31 @@ class RepositoryScanner:
     def _run_adapter_bounded(
         self, adapter: RepositoryAdapter, context: AdapterContext
     ) -> tuple[str, AdapterResult | None]:
+        self._assert_execution_collaborators_sealed()
         if not hasattr(os, "fork") or not hasattr(os, "setsid"):
             return "ERROR", None
+        sealed_guards = {
+            adapter_id: (adapter_identity, evaluator_identity, state_digest)
+            for adapter_id, adapter_identity, evaluator_identity, state_digest in (
+                self._sealed_adapter_runtime_guards
+            )
+        }
+        expected_adapter_identity, expected_evaluator_identity, expected_state_digest = (
+            sealed_guards[adapter.adapter_id]
+        )
         process_context = multiprocessing.get_context("fork")
         receiver, sender = process_context.Pipe(duplex=False)
         process = process_context.Process(
             target=_adapter_worker,
-            args=(sender, adapter, context),
+            args=(
+                sender,
+                adapter,
+                context,
+                expected_state_digest,
+                expected_adapter_identity,
+                expected_evaluator_identity,
+                _SEALED_ADAPTER_MODULE_STATE_DIGEST,
+            ),
             daemon=True,
             name=f"pmpe-readonly-adapter-{adapter.adapter_id}",
         )
@@ -2957,8 +3128,11 @@ class RepositoryScanner:
             },
             snapshot_digest="",
         )
+        original = draft.as_dict()
         try:
-            sanitized = cast(dict[str, Any], redactor.sanitize(draft.as_dict()))
+            sanitized = cast(dict[str, Any], redactor.sanitize(original))
+            for namespace, identities in _snapshot_identity_groups(original, sanitized).items():
+                assert_distinct_identities_preserved(namespace, identities)
         except (RedactionError, Exception) as exc:
             raise RepositorySecurityError(
                 "evidence redaction failed; artifact was not created"

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -49,7 +49,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.4.0"
+SCANNER_VERSION = "repository-scanner/2.5.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -1508,9 +1508,39 @@ class RepositoryScanner:
                 (),
             ),
             (
+                "architecture_boundaries",
+                "CLI boundaries",
+                ("BOUNDARY_CLI",),
+            ),
+            (
+                "architecture_boundaries",
+                "worker boundaries",
+                ("BOUNDARY_WORKER",),
+            ),
+            (
+                "architecture_boundaries",
+                "library boundaries",
+                ("BOUNDARY_LIBRARY",),
+            ),
+            (
+                "architecture_boundaries",
+                "infrastructure-area boundaries",
+                ("BOUNDARY_INFRASTRUCTURE_AREA",),
+            ),
+            (
+                "architecture_boundaries",
+                "module boundaries",
+                ("BOUNDARY_MODULE",),
+            ),
+            (
+                "architecture_boundaries",
+                "bounded-context boundaries",
+                ("BOUNDARY_BOUNDED_CONTEXT",),
+            ),
+            (
                 "apis_data",
                 "storage models",
-                ("DATABASE_SCHEMA_SIGNAL", "MIGRATION_SIGNAL"),
+                (),
             ),
             (
                 "delivery_environments",

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -41,7 +41,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/1.2.0"
+SCANNER_VERSION = "repository-scanner/1.3.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -81,7 +81,7 @@ class TreeListingResult:
 class SubprocessCommandRunner:
     """Allowlisted local Git reader; it never invokes shells or project code."""
 
-    identity = "git-readonly-subprocess/1.2.0"
+    identity = "git-readonly-subprocess/1.3.0"
     _allowed = {"rev-parse", "ls-tree", "cat-file", "version"}
 
     @staticmethod
@@ -93,6 +93,7 @@ class SubprocessCommandRunner:
             "GIT_TERMINAL_PROMPT": "0",
             "GIT_OPTIONAL_LOCKS": "0",
             "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
             "GIT_CONFIG_COUNT": "6",
             "GIT_CONFIG_KEY_0": "core.fsmonitor",
             "GIT_CONFIG_VALUE_0": "false",
@@ -608,7 +609,7 @@ class RepositoryScanner:
         return root, commit_sha, tree_sha
 
     def _list_files(
-        self, root: Path, commit_sha: str, tree_sha: str
+        self, root: Path, tree_sha: str
     ) -> tuple[list[TrackedFile], list[Finding], str, str]:
         findings: list[Finding] = []
         tracked_tree_digest = canonical_digest({"git_object_format": "sha1", "tree_sha": tree_sha})
@@ -623,7 +624,7 @@ class RepositoryScanner:
             )
             return [], findings, tracked_tree_digest, canonical_digest([])
         bounded_listing = self._list_tree(
-            ("git", "ls-tree", "-r", "-z", "-l", "--full-tree", commit_sha), root
+            ("git", "ls-tree", "-r", "-z", "-l", "--full-tree", tree_sha), root
         )
         if bounded_listing is None:
             findings.append(
@@ -790,7 +791,7 @@ class RepositoryScanner:
                     )
                 )
                 continue
-            result = self._run(("git", "cat-file", "blob", f"{commit_sha}:{path}"), root)
+            result = self._run(("git", "cat-file", "blob", object_id), root)
             if result is None:
                 findings.append(
                     _finding(
@@ -1230,9 +1231,7 @@ class RepositoryScanner:
             return self._cancelled_snapshot(
                 root, commit_sha, tree_sha, config_digest, adapter_digest
             )
-        files, budget_findings, tree_digest, scanned_digest = self._list_files(
-            root, commit_sha, tree_sha
-        )
+        files, budget_findings, tree_digest, scanned_digest = self._list_files(root, tree_sha)
         inventory, adapter_findings, boundaries, supported = self._apply_adapters(tuple(files))
         findings = budget_findings + adapter_findings
         if self.config.include_paths:

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -51,7 +51,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.7.0"
+SCANNER_VERSION = "repository-scanner/2.8.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -652,7 +652,11 @@ def _module_runtime_digest(module_name: str) -> str:
     module = importlib.import_module(f"pmpe.{module_name}")
     symbols: list[dict[str, Any]] = []
     for name, target in sorted(vars(module).items()):
-        if name.startswith("__"):
+        if (
+            name.startswith("__")
+            or name.endswith("IMPLEMENTATION_PATHS")
+            or name.endswith("IMPORTED_SOURCE_DIGESTS")
+        ):
             continue
         if inspect.isfunction(target) or inspect.isclass(target) or callable(target):
             code = _runtime_code_evidence(target)

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -51,7 +51,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.8.0"
+SCANNER_VERSION = "repository-scanner/2.9.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -84,6 +84,12 @@ _IMPORTED_SOURCE_DIGESTS = MappingProxyType(
     {
         name: "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
         for name, path in _IMPLEMENTATION_PATHS.items()
+    }
+)
+_RUNTIME_DEPENDENCY_PATHS = MappingProxyType(
+    {
+        "pyyaml.safe_load": ("yaml", "safe_load"),
+        "rfc8785.dumps": ("rfc8785", "dumps"),
     }
 )
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
@@ -568,6 +574,8 @@ def _runtime_code_evidence(target: Any) -> list[dict[str, Any]]:
     if inspect.isclass(target):
         evidence: list[dict[str, Any]] = []
         for name, member in sorted(vars(target).items()):
+            if name.startswith("__") and name.endswith("__"):
+                continue
             if isinstance(member, (staticmethod, classmethod)):
                 member = member.__func__
             elif isinstance(member, property):
@@ -587,6 +595,13 @@ def _runtime_code_evidence(target: Any) -> list[dict[str, Any]]:
                 continue
             if inspect.isfunction(member) or inspect.ismethod(member):
                 evidence.extend({**item, "member": name} for item in _runtime_code_evidence(member))
+            else:
+                evidence.append(
+                    {
+                        "member": name,
+                        "runtime_value": _runtime_value_evidence(member),
+                    }
+                )
         return evidence
     if callable(target):
         return _runtime_code_evidence(target.__class__)
@@ -726,6 +741,21 @@ def _implementation_source_evidence(label: str, target: Any) -> dict[str, str]:
     }
 
 
+def _runtime_dependency_evidence() -> list[dict[str, str]]:
+    """Bind live third-party callables that materially affect canonical scan output."""
+
+    evidence: list[dict[str, str]] = []
+    for label, (module_name, attribute_name) in _RUNTIME_DEPENDENCY_PATHS.items():
+        try:
+            dependency = getattr(importlib.import_module(module_name), attribute_name)
+        except (AttributeError, ImportError) as exc:
+            raise RepositoryIntelligenceError(
+                f"{label} runtime dependency is unavailable for provenance binding"
+            ) from exc
+        evidence.append(_implementation_source_evidence(label, dependency))
+    return evidence
+
+
 def _implementation_digest(
     extension_evidence: Sequence[dict[str, str]] = (),
 ) -> str:
@@ -733,6 +763,7 @@ def _implementation_digest(
         _IMPLEMENTATION_PATHS,
         _IMPORTED_SOURCE_DIGESTS,
     )
+    evidence.extend(_runtime_dependency_evidence())
     evidence.extend(extension_evidence)
     return canonical_digest(
         sorted(evidence, key=lambda item: (item.get("label", ""), item["module"]))

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as datetime_module
 import hashlib
 import importlib
 import importlib.metadata
@@ -51,7 +52,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.12.0"
+SCANNER_VERSION = "repository-scanner/2.13.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -141,6 +142,23 @@ _NATIVE_IMPLEMENTATION_MODULES = (
     "_json",
     "_sre",
     "math",
+)
+_RUNTIME_DEPENDENCY_GLOBALS = MappingProxyType(
+    {
+        "urllib.parse": (
+            "_ALWAYS_SAFE",
+            "_ALWAYS_SAFE_BYTES",
+            "_UNSAFE_URL_BYTES_TO_REMOVE",
+            "_WHATWG_C0_CONTROL_OR_SPACE",
+            "non_hierarchical",
+            "scheme_chars",
+            "uses_fragment",
+            "uses_netloc",
+            "uses_params",
+            "uses_query",
+            "uses_relative",
+        ),
+    }
 )
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
 
@@ -677,6 +695,31 @@ def _runtime_value_evidence(value: Any, *, depth: int = 0) -> Any:
         return {"numeric_type": type(value).__name__, "value": repr(value)}
     if isinstance(value, PurePosixPath):
         return {"path": value.as_posix()}
+    if isinstance(value, datetime_module.tzinfo):
+        try:
+            offset = value.utcoffset(None)
+            daylight = value.dst(None)
+            name = value.tzname(None)
+        except Exception as exc:
+            raise RepositoryIntelligenceError(
+                "runtime timezone state is unavailable for provenance binding"
+            ) from exc
+
+        def duration_evidence(duration: datetime_module.timedelta | None) -> Any:
+            if duration is None:
+                return None
+            return {
+                "days": duration.days,
+                "seconds": duration.seconds,
+                "microseconds": duration.microseconds,
+            }
+
+        return {
+            "timezone_type": f"{type(value).__module__}.{type(value).__qualname__}",
+            "offset": duration_evidence(offset),
+            "daylight": duration_evidence(daylight),
+            "name": name,
+        }
     if isinstance(value, re.Pattern):
         return {
             "pattern": _runtime_value_evidence(value.pattern, depth=depth + 1),
@@ -743,11 +786,80 @@ def _runtime_module_namespace_digest(module: Any) -> str:
     return canonical_digest(symbols)
 
 
+def _is_runtime_semantic_constant(
+    value: Any,
+    *,
+    module_name: str,
+    depth: int = 0,
+    seen: frozenset[int] = frozenset(),
+) -> bool:
+    """Recognize bounded state whose value, rather than identity, affects execution."""
+
+    if depth > 16:
+        raise RepositoryIntelligenceError(
+            f"{module_name} runtime semantic state exceeds depth limit"
+        )
+    if isinstance(
+        value,
+        (
+            type(None),
+            bool,
+            int,
+            float,
+            complex,
+            str,
+            bytes,
+            PurePosixPath,
+            re.Pattern,
+            datetime_module.tzinfo,
+        ),
+    ):
+        return True
+    if isinstance(value, Mapping):
+        if len(value) > 4_096 or id(value) in seen:
+            raise RepositoryIntelligenceError(
+                f"{module_name} runtime semantic mapping is cyclic or unbounded"
+            )
+        nested_seen = seen | {id(value)}
+        return all(
+            _is_runtime_semantic_constant(
+                key,
+                module_name=module_name,
+                depth=depth + 1,
+                seen=nested_seen,
+            )
+            and _is_runtime_semantic_constant(
+                item,
+                module_name=module_name,
+                depth=depth + 1,
+                seen=nested_seen,
+            )
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple, set, frozenset)):
+        if len(value) > 4_096 or id(value) in seen:
+            raise RepositoryIntelligenceError(
+                f"{module_name} runtime semantic sequence is cyclic or unbounded"
+            )
+        nested_seen = seen | {id(value)}
+        return all(
+            _is_runtime_semantic_constant(
+                item,
+                module_name=module_name,
+                depth=depth + 1,
+                seen=nested_seen,
+            )
+            for item in value
+        )
+    return False
+
+
 def _runtime_dependency_module_digest(module: Any) -> str:
     """Bind a dependency module without recursively traversing arbitrary objects."""
 
     symbols: list[dict[str, Any]] = []
     module_name = str(getattr(module, "__name__", "unknown"))
+    explicit_globals = frozenset(_RUNTIME_DEPENDENCY_GLOBALS.get(module_name, ()))
     for name, target in sorted(vars(module).items()):
         if name.startswith("__"):
             continue
@@ -762,6 +874,7 @@ def _runtime_dependency_module_digest(module: Any) -> str:
             continue
         if inspect.isclass(target):
             methods: list[dict[str, Any]] = []
+            constants: list[dict[str, Any]] = []
             for method_name, member in sorted(vars(target).items()):
                 implementations: tuple[Any, ...]
                 if isinstance(member, (classmethod, staticmethod)):
@@ -782,6 +895,17 @@ def _runtime_dependency_module_digest(module: Any) -> str:
                                 "code": _runtime_code_evidence(implementation),
                             }
                         )
+                if (
+                    method_name.lstrip("_").isupper()
+                    and not callable(member)
+                    and _is_runtime_semantic_constant(member, module_name=module_name)
+                ):
+                    constants.append(
+                        {
+                            "member": method_name,
+                            "value": _runtime_value_evidence(member),
+                        }
+                    )
             symbols.append(
                 {
                     "symbol": name,
@@ -789,6 +913,7 @@ def _runtime_dependency_module_digest(module: Any) -> str:
                     "module": str(getattr(target, "__module__", "unknown")),
                     "qualname": str(getattr(target, "__qualname__", name)),
                     "methods": methods,
+                    "constants": constants,
                 }
             )
             continue
@@ -813,7 +938,9 @@ def _runtime_dependency_module_digest(module: Any) -> str:
                 }
             )
             continue
-        if isinstance(target, (type(None), bool, int, float, complex, str, bytes, re.Pattern)):
+        if (
+            name in explicit_globals or name.lstrip("_").isupper()
+        ) and _is_runtime_semantic_constant(target, module_name=module_name):
             symbols.append(
                 {
                     "symbol": name,
@@ -1251,8 +1378,6 @@ class RepositoryScanner:
             ("redactor", self.redactor),
             *((f"adapter:{item.adapter_id}", item.evaluator) for item in self.adapters),
         ]
-        if cancellation is not None:
-            extension_targets.append(("cancellation", cancellation))
         self._extension_implementation_evidence = tuple(
             _implementation_source_evidence(label, target) for label, target in extension_targets
         )

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -51,7 +51,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.9.0"
+SCANNER_VERSION = "repository-scanner/2.10.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -90,6 +90,30 @@ _RUNTIME_DEPENDENCY_PATHS = MappingProxyType(
     {
         "pyyaml.safe_load": ("yaml", "safe_load"),
         "rfc8785.dumps": ("rfc8785", "dumps"),
+    }
+)
+_RUNTIME_DEPENDENCY_MODULES = MappingProxyType(
+    {
+        "yaml": (
+            "yaml",
+            "yaml.composer",
+            "yaml.constructor",
+            "yaml.cyaml",
+            "yaml.dumper",
+            "yaml.emitter",
+            "yaml.error",
+            "yaml.events",
+            "yaml.loader",
+            "yaml.nodes",
+            "yaml.parser",
+            "yaml.reader",
+            "yaml.representer",
+            "yaml.resolver",
+            "yaml.scanner",
+            "yaml.serializer",
+            "yaml.tokens",
+        ),
+        "rfc8785": ("rfc8785", "rfc8785._impl"),
     }
 )
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
@@ -661,10 +685,9 @@ def _runtime_value_evidence(value: Any, *, depth: int = 0) -> Any:
     return {"type": f"{type(value).__module__}.{type(value).__qualname__}"}
 
 
-def _module_runtime_digest(module_name: str) -> str:
-    """Bind the loaded module namespace rather than only its current source file."""
+def _runtime_module_namespace_digest(module: Any) -> str:
+    """Bind the loaded executable namespace of one implementation module."""
 
-    module = importlib.import_module(f"pmpe.{module_name}")
     symbols: list[dict[str, Any]] = []
     for name, target in sorted(vars(module).items()):
         if (
@@ -685,6 +708,12 @@ def _module_runtime_digest(module_name: str) -> str:
                 }
             )
     return canonical_digest(symbols)
+
+
+def _module_runtime_digest(module_name: str) -> str:
+    """Bind the loaded PMPE module namespace rather than only its source file."""
+
+    return _runtime_module_namespace_digest(importlib.import_module(f"pmpe.{module_name}"))
 
 
 def _implementation_module_evidence(
@@ -742,7 +771,7 @@ def _implementation_source_evidence(label: str, target: Any) -> dict[str, str]:
 
 
 def _runtime_dependency_evidence() -> list[dict[str, str]]:
-    """Bind live third-party callables that materially affect canonical scan output."""
+    """Bind third-party package bytes and their complete loaded implementation closure."""
 
     evidence: list[dict[str, str]] = []
     for label, (module_name, attribute_name) in _RUNTIME_DEPENDENCY_PATHS.items():
@@ -753,6 +782,54 @@ def _runtime_dependency_evidence() -> list[dict[str, str]]:
                 f"{label} runtime dependency is unavailable for provenance binding"
             ) from exc
         evidence.append(_implementation_source_evidence(label, dependency))
+    for package_name, implementation_modules in _RUNTIME_DEPENDENCY_MODULES.items():
+        package = importlib.import_module(package_name)
+        package_file = getattr(package, "__file__", None)
+        if not isinstance(package_file, str):
+            raise RepositoryIntelligenceError(
+                f"{package_name} package bytes are unavailable for provenance binding"
+            )
+        package_root = Path(package_file).resolve().parent
+        try:
+            source_files = tuple(sorted(package_root.rglob("*.py")))
+            if not source_files or len(source_files) > 10_000:
+                raise OSError("dependency source inventory is unavailable or unbounded")
+            source_evidence: list[dict[str, str]] = []
+            for path in source_files:
+                resolved_path = path.resolve()
+                if not path.is_file() or package_root not in resolved_path.parents:
+                    raise OSError("dependency source path escaped its package root")
+                source_evidence.append(
+                    {
+                        "path": path.relative_to(package_root).as_posix(),
+                        "digest": _sha256(path.read_bytes()),
+                    }
+                )
+        except (OSError, ValueError) as exc:
+            raise RepositoryIntelligenceError(
+                f"{package_name} package bytes are unavailable for provenance binding"
+            ) from exc
+        loaded_modules = [
+            {
+                "module": module_name,
+                "runtime_digest": _runtime_module_namespace_digest(
+                    importlib.import_module(module_name)
+                ),
+            }
+            for module_name in implementation_modules
+        ]
+        if not loaded_modules:
+            raise RepositoryIntelligenceError(
+                f"{package_name} runtime closure is unavailable for provenance binding"
+            )
+        evidence.append(
+            {
+                "label": f"{package_name}.implementation-closure",
+                "module": package_name,
+                "source_digest": canonical_digest(source_evidence),
+                "runtime_code_digest": canonical_digest(loaded_modules),
+            }
+        )
     return evidence
 
 

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -52,7 +52,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.14.0"
+SCANNER_VERSION = "repository-scanner/2.15.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -162,6 +162,18 @@ _RUNTIME_DEPENDENCY_GLOBALS = MappingProxyType(
             "uses_params",
             "uses_query",
             "uses_relative",
+        ),
+    }
+)
+_RUNTIME_CONFIGURED_CALLABLE_ATTRIBUTES = MappingProxyType(
+    {
+        "_json.Scanner": (
+            "object_hook",
+            "object_pairs_hook",
+            "parse_constant",
+            "parse_float",
+            "parse_int",
+            "strict",
         ),
     }
 )
@@ -894,18 +906,58 @@ def _runtime_configured_instance_evidence(value: Any, *, module_name: str) -> di
             )
             continue
         if inspect.isclass(member) or inspect.isbuiltin(member) or callable(member):
+            callable_type = f"{type(member).__module__}.{type(member).__qualname__}"
             callable_evidence: dict[str, Any] = {
                 "member": name,
                 "kind": "callable",
                 "module": str(getattr(member, "__module__", type(member).__module__)),
                 "qualname": str(getattr(member, "__qualname__", type(member).__qualname__)),
-                "type": f"{type(member).__module__}.{type(member).__qualname__}",
+                "type": callable_type,
             }
             bound_state = getattr(member, "__self__", None)
             if bound_state is not None and _is_runtime_semantic_constant(
                 bound_state, module_name=module_name
             ):
                 callable_evidence["bound_state"] = _runtime_value_evidence(bound_state)
+            configured_attributes = _RUNTIME_CONFIGURED_CALLABLE_ATTRIBUTES.get(callable_type, ())
+            if configured_attributes:
+                configured_state: list[dict[str, Any]] = []
+                for attribute_name in configured_attributes:
+                    try:
+                        attribute = getattr(member, attribute_name)
+                    except (AttributeError, RuntimeError) as exc:
+                        raise RepositoryIntelligenceError(
+                            f"{callable_type}.{attribute_name} state is unavailable"
+                        ) from exc
+                    if _is_runtime_semantic_constant(attribute, module_name=module_name):
+                        attribute_evidence: Any = _runtime_value_evidence(attribute)
+                    elif inspect.isclass(attribute) or inspect.isbuiltin(attribute):
+                        attribute_evidence = {
+                            "module": str(
+                                getattr(attribute, "__module__", type(attribute).__module__)
+                            ),
+                            "qualname": str(
+                                getattr(attribute, "__qualname__", type(attribute).__qualname__)
+                            ),
+                            "type": (
+                                f"{type(attribute).__module__}.{type(attribute).__qualname__}"
+                            ),
+                        }
+                        attribute_bound_state = getattr(attribute, "__self__", None)
+                        if attribute_bound_state is not None and _is_runtime_semantic_constant(
+                            attribute_bound_state, module_name=module_name
+                        ):
+                            attribute_evidence["bound_state"] = _runtime_value_evidence(
+                                attribute_bound_state
+                            )
+                    else:
+                        raise RepositoryIntelligenceError(
+                            f"{callable_type}.{attribute_name} state is unsupported"
+                        )
+                    configured_state.append(
+                        {"attribute": attribute_name, "value": attribute_evidence}
+                    )
+                callable_evidence["configured_state"] = configured_state
             members.append(callable_evidence)
             continue
         raise RepositoryIntelligenceError(

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -18,13 +18,12 @@ import signal
 import stat
 import subprocess
 import sys
-import threading
 import time
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import asdict, dataclass, fields, is_dataclass
 from pathlib import Path, PurePosixPath
-from types import CodeType, MappingProxyType
+from types import CodeType, MappingProxyType, ModuleType
 from typing import Any, Protocol, cast, final
 
 import yaml
@@ -56,7 +55,7 @@ from pmpe.repository.redaction import (
     assert_distinct_identities_preserved,
 )
 
-SCANNER_VERSION = "repository-scanner/2.17.0"
+SCANNER_VERSION = "repository-scanner/2.18.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -225,53 +224,38 @@ class Cancellation(Protocol):
 
 @final
 class CancellationSignal:
-    """Sealed cancellation capability with no caller-executed callback."""
+    """Scalar-only cancellation capability with no nested executable state."""
 
-    __slots__ = (
-        "_cancel_after_checks",
-        "_checks",
-        "_event",
-        "_lock",
-        "_sealed_cancel_after_checks",
-        "_sealed_event",
-        "_sealed_lock",
-    )
+    __slots__ = ("_cancel_after_checks", "_cancelled", "_checks")
 
     def __init__(self, *, cancel_after_checks: int | None = None) -> None:
         if cancel_after_checks is not None and cancel_after_checks < 1:
             raise ValueError("cancellation check limit must be positive")
         self._cancel_after_checks = cancel_after_checks
+        self._cancelled = False
         self._checks = 0
-        self._event = threading.Event()
-        self._lock = threading.Lock()
-        self._sealed_cancel_after_checks = cancel_after_checks
-        self._sealed_event = self._event
-        self._sealed_lock = self._lock
 
     def _integrity_is_valid(self) -> bool:
         return (
-            self._event is self._sealed_event
-            and self._lock is self._sealed_lock
-            and self._cancel_after_checks == self._sealed_cancel_after_checks
-            and isinstance(self._checks, int)
+            (self._cancel_after_checks is None or type(self._cancel_after_checks) is int)
+            and type(self._cancelled) is bool
+            and type(self._checks) is int
             and self._checks >= 0
         )
 
     def cancel(self) -> None:
         if not self._integrity_is_valid():
             raise RepositorySecurityError("cancellation signal integrity is invalid")
-        self._sealed_event.set()
+        self._cancelled = True
 
     def cancelled(self) -> bool:
         if not self._integrity_is_valid():
             raise RepositorySecurityError("cancellation signal integrity is invalid")
-        with self._sealed_lock:
-            self._checks += 1
-            threshold_reached = (
-                self._sealed_cancel_after_checks is not None
-                and self._checks >= self._sealed_cancel_after_checks
-            )
-        return self._sealed_event.is_set() or threshold_reached
+        self._checks += 1
+        threshold_reached = (
+            self._cancel_after_checks is not None and self._checks >= self._cancel_after_checks
+        )
+        return self._cancelled or threshold_reached
 
 
 _PROCESS_GROUP_GUARD = "import signal\nwhile True:\n signal.pause()"
@@ -816,6 +800,7 @@ def _runtime_module_namespace_digest(module: Any) -> str:
             name.startswith("__")
             or name.endswith("IMPLEMENTATION_PATHS")
             or name.endswith("IMPORTED_SOURCE_DIGESTS")
+            or name.endswith("PROCESS_IDENTITIES")
         ):
             continue
         if inspect.isfunction(target) or inspect.isclass(target) or callable(target):
@@ -1295,6 +1280,8 @@ def _adapter_worker(
     expected_adapter_identity: int,
     expected_evaluator_identity: int,
     expected_module_state_digest: str,
+    expected_import_state_digest: str,
+    expected_import_identities: tuple[tuple[str, int], ...],
 ) -> None:
     """Evaluate one adapter in a killable, environment-isolated process."""
 
@@ -1309,6 +1296,16 @@ def _adapter_worker(
             or id(adapter.evaluator) != expected_evaluator_identity
             or _adapter_execution_state_digest((adapter,)) != expected_state_digest
             or _module_runtime_digest("repository.adapters") != expected_module_state_digest
+            or _module_import_binding_state_digest(
+                "repository.adapters",
+                tuple(name for name, _identity in expected_import_identities),
+            )
+            != expected_import_state_digest
+            or _module_import_binding_identities(
+                "repository.adapters",
+                tuple(name for name, _identity in expected_import_identities),
+            )
+            != expected_import_identities
         ):
             raise RepositorySecurityError("adapter execution state changed before evaluation")
         result = adapter.evaluator(context)
@@ -1453,9 +1450,52 @@ def _adapter_execution_state_digest(adapters: Sequence[RepositoryAdapter]) -> st
     )
 
 
+def _module_import_binding_state_digest(module_name: str, names: tuple[str, ...]) -> str:
+    """Bind imported modules that adapter functions resolve through globals."""
+
+    module = importlib.import_module(f"pmpe.{module_name}")
+    evidence: list[dict[str, str]] = []
+    for name in names:
+        target = vars(module).get(name)
+        if type(target) is not ModuleType:
+            evidence.append({"binding": name, "module": "INVALID", "runtime_digest": "INVALID"})
+            continue
+        evidence.append(
+            {
+                "binding": name,
+                "module": target.__name__,
+                "runtime_digest": _runtime_dependency_module_digest(target),
+            }
+        )
+    return canonical_digest(evidence)
+
+
+def _module_import_binding_identities(
+    module_name: str, names: tuple[str, ...]
+) -> tuple[tuple[str, int], ...]:
+    """Guard same-code imported-module substitution inside a forked worker."""
+
+    module = importlib.import_module(f"pmpe.{module_name}")
+    return tuple(
+        (name, id(target) if type(target) is ModuleType else -1)
+        for name in names
+        for target in (vars(module).get(name),)
+    )
+
+
 _SEALED_BUILTIN_ADAPTERS = default_adapters()
 _SEALED_BUILTIN_ADAPTER_STATE_DIGEST = _adapter_execution_state_digest(_SEALED_BUILTIN_ADAPTERS)
 _SEALED_ADAPTER_MODULE_STATE_DIGEST = _module_runtime_digest("repository.adapters")
+_ADAPTER_MODULE = importlib.import_module("pmpe.repository.adapters")
+_SEALED_ADAPTER_IMPORT_NAMES = tuple(
+    sorted(name for name, target in vars(_ADAPTER_MODULE).items() if type(target) is ModuleType)
+)
+_SEALED_ADAPTER_IMPORT_STATE_DIGEST = _module_import_binding_state_digest(
+    "repository.adapters", _SEALED_ADAPTER_IMPORT_NAMES
+)
+_SEALED_ADAPTER_IMPORT_PROCESS_IDENTITIES = _module_import_binding_identities(
+    "repository.adapters", _SEALED_ADAPTER_IMPORT_NAMES
+)
 
 
 def _snapshot_identity_groups(
@@ -1593,6 +1633,14 @@ class RepositoryScanner:
             _adapter_execution_state_digest(registered_adapters)
             != _SEALED_BUILTIN_ADAPTER_STATE_DIGEST
             or _module_runtime_digest("repository.adapters") != _SEALED_ADAPTER_MODULE_STATE_DIGEST
+            or _module_import_binding_state_digest(
+                "repository.adapters", _SEALED_ADAPTER_IMPORT_NAMES
+            )
+            != _SEALED_ADAPTER_IMPORT_STATE_DIGEST
+            or _module_import_binding_identities(
+                "repository.adapters", _SEALED_ADAPTER_IMPORT_NAMES
+            )
+            != _SEALED_ADAPTER_IMPORT_PROCESS_IDENTITIES
         ):
             raise RepositorySecurityError("sealed built-in adapter registry integrity failed")
         requested_adapters = tuple(adapters) if adapters is not None else registered_adapters
@@ -2406,6 +2454,15 @@ class RepositoryScanner:
         self, adapter: RepositoryAdapter, context: AdapterContext
     ) -> tuple[str, AdapterResult | None]:
         self._assert_execution_collaborators_sealed()
+        if (
+            _module_import_binding_state_digest("repository.adapters", _SEALED_ADAPTER_IMPORT_NAMES)
+            != _SEALED_ADAPTER_IMPORT_STATE_DIGEST
+            or _module_import_binding_identities(
+                "repository.adapters", _SEALED_ADAPTER_IMPORT_NAMES
+            )
+            != _SEALED_ADAPTER_IMPORT_PROCESS_IDENTITIES
+        ):
+            raise RepositorySecurityError("adapter imported-module bindings changed")
         if not hasattr(os, "fork") or not hasattr(os, "setsid"):
             return "ERROR", None
         sealed_guards = {
@@ -2429,6 +2486,8 @@ class RepositoryScanner:
                 expected_adapter_identity,
                 expected_evaluator_identity,
                 _SEALED_ADAPTER_MODULE_STATE_DIGEST,
+                _SEALED_ADAPTER_IMPORT_STATE_DIGEST,
+                _SEALED_ADAPTER_IMPORT_PROCESS_IDENTITIES,
             ),
             daemon=True,
             name=f"pmpe-readonly-adapter-{adapter.adapter_id}",

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -57,7 +57,7 @@ from pmpe.repository.redaction import (
     assert_distinct_identities_preserved,
 )
 
-SCANNER_VERSION = "repository-scanner/2.20.0"
+SCANNER_VERSION = "repository-scanner/2.21.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -1626,7 +1626,7 @@ def _module_attribute_value_evidence(module_name: str, attribute_name: str, targ
         return {"type": f"{type(target).__module__}.{type(target).__qualname__}"}
     if module_name == "sys" and attribute_name == "executable":
         return {"type": "python-executable", "binary_digest": _sha256(Path(target).read_bytes())}
-    if isinstance(target, (type(None), bool, int, float, complex, str, bytes, tuple, frozenset)):
+    if _is_runtime_semantic_constant(target, module_name=module_name):
         return _runtime_value_evidence(target)
     return {
         "type": f"{type(target).__module__}.{type(target).__qualname__}",
@@ -1635,20 +1635,109 @@ def _module_attribute_value_evidence(module_name: str, attribute_name: str, targ
     }
 
 
-def _external_global_binding_names() -> tuple[str, ...]:
-    return tuple(
-        sorted(
-            name
-            for name, target in globals().items()
-            if (
-                type(target) is ModuleType
-                or inspect.isfunction(target)
-                or inspect.isclass(target)
-                or inspect.isbuiltin(target)
+def _direct_imported_global_names(source_path: Path) -> tuple[str, ...]:
+    """Derive every top-level name introduced by an import statement."""
+
+    try:
+        tree = ast.parse(source_path.read_text())
+    except (OSError, SyntaxError, UnicodeError) as exc:
+        raise RepositoryIntelligenceError(
+            "implementation imports are unavailable for provenance binding"
+        ) from exc
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            names.update(
+                alias.asname or alias.name.split(".", maxsplit=1)[0] for alias in node.names
             )
-            and str(getattr(target, "__module__", "")) != __name__
+        elif isinstance(node, ast.ImportFrom) and node.module != "__future__":
+            names.update(alias.asname or alias.name for alias in node.names if alias.name != "*")
+    return tuple(sorted(names))
+
+
+def _external_global_binding_state_digest(names: tuple[str, ...]) -> str:
+    """Bind non-executable imported values; executable imports are identity-sealed."""
+
+    evidence: list[dict[str, Any]] = []
+    for name in names:
+        if name not in globals():
+            raise RepositorySecurityError("scanner imported global binding is unavailable")
+        target = globals()[name]
+        evidence.append(
+            {
+                "binding": name,
+                "state": (
+                    {"guard": "identity"}
+                    if type(target) is ModuleType or callable(target)
+                    else _module_attribute_value_evidence("scanner-imported-global", name, target)
+                ),
+            }
         )
+    return canonical_digest(evidence)
+
+
+_MULTIPROCESSING_CONTEXT_MEMBER_NAMES = ("Event", "Pipe", "Process")
+_SEALED_MULTIPROCESSING_CONTEXT = multiprocessing.get_context("fork")
+
+
+def _multiprocessing_context_member_identities(context: Any) -> tuple[tuple[str, int], ...]:
+    context_type = type(context)
+    return tuple(
+        (name, id(inspect.getattr_static(context_type, name)))
+        for name in _MULTIPROCESSING_CONTEXT_MEMBER_NAMES
     )
+
+
+def _multiprocessing_context_state_digest(context: Any) -> str:
+    context_type = type(context)
+    return canonical_digest(
+        [
+            {
+                "member": name,
+                "state": _module_attribute_value_evidence(
+                    "multiprocessing-context",
+                    name,
+                    inspect.getattr_static(context_type, name),
+                ),
+            }
+            for name in _MULTIPROCESSING_CONTEXT_MEMBER_NAMES
+        ]
+    )
+
+
+_SEALED_MULTIPROCESSING_CONTEXT_PROCESS_IDENTITIES = (
+    ("context-global", id(_SEALED_MULTIPROCESSING_CONTEXT)),
+    ("resolved-context", id(_SEALED_MULTIPROCESSING_CONTEXT)),
+    ("context-type", id(type(_SEALED_MULTIPROCESSING_CONTEXT))),
+    *_multiprocessing_context_member_identities(_SEALED_MULTIPROCESSING_CONTEXT),
+)
+_SEALED_MULTIPROCESSING_CONTEXT_STATE_DIGEST = _multiprocessing_context_state_digest(
+    _SEALED_MULTIPROCESSING_CONTEXT
+)
+
+
+def _assert_multiprocessing_context_sealed(*, verify_state: bool = True) -> None:
+    """Reject replacement of the fork context or any primitive it constructs."""
+
+    current_context = multiprocessing.get_context("fork")
+    current_identities = (
+        ("context-global", id(_SEALED_MULTIPROCESSING_CONTEXT)),
+        ("resolved-context", id(current_context)),
+        ("context-type", id(type(current_context))),
+        *_multiprocessing_context_member_identities(current_context),
+    )
+    if current_identities != _SEALED_MULTIPROCESSING_CONTEXT_PROCESS_IDENTITIES:
+        raise RepositorySecurityError("multiprocessing context or members changed")
+    if verify_state and (
+        _multiprocessing_context_state_digest(current_context)
+        != _SEALED_MULTIPROCESSING_CONTEXT_STATE_DIGEST
+    ):
+        raise RepositorySecurityError("multiprocessing context member state changed")
+
+
+def _sealed_multiprocessing_context() -> Any:
+    _assert_multiprocessing_context_sealed()
+    return _SEALED_MULTIPROCESSING_CONTEXT
 
 
 _SEALED_SCANNER_MODULE_ATTRIBUTE_NAMES = _direct_module_attribute_names(
@@ -1660,9 +1749,14 @@ _SEALED_SCANNER_MODULE_ATTRIBUTE_STATE_DIGEST = _module_attribute_binding_state_
 _SEALED_SCANNER_MODULE_ATTRIBUTE_PROCESS_IDENTITIES = _module_attribute_binding_identities(
     _SEALED_SCANNER_MODULE_ATTRIBUTE_NAMES
 )
-_SEALED_SCANNER_EXTERNAL_GLOBAL_NAMES = _external_global_binding_names()
+_SEALED_SCANNER_EXTERNAL_GLOBAL_NAMES = _direct_imported_global_names(
+    _IMPLEMENTATION_PATHS["repository.scanner"]
+)
 _SEALED_SCANNER_EXTERNAL_GLOBAL_PROCESS_IDENTITIES = tuple(
     (name, id(globals()[name])) for name in _SEALED_SCANNER_EXTERNAL_GLOBAL_NAMES
+)
+_SEALED_SCANNER_EXTERNAL_GLOBAL_STATE_DIGEST = _external_global_binding_state_digest(
+    _SEALED_SCANNER_EXTERNAL_GLOBAL_NAMES
 )
 
 
@@ -1684,6 +1778,7 @@ def _assert_scanner_import_bindings_sealed(*, verify_state: bool = False) -> Non
         != _SEALED_SCANNER_MODULE_ATTRIBUTE_PROCESS_IDENTITIES
     ):
         raise RepositorySecurityError("scanner imported-module attributes changed")
+    _assert_multiprocessing_context_sealed(verify_state=verify_state)
     if (
         tuple((name, id(globals().get(name))) for name in _SEALED_SCANNER_EXTERNAL_GLOBAL_NAMES)
         != _SEALED_SCANNER_EXTERNAL_GLOBAL_PROCESS_IDENTITIES
@@ -1694,6 +1789,11 @@ def _assert_scanner_import_bindings_sealed(*, verify_state: bool = False) -> Non
         != _SEALED_SCANNER_MODULE_ATTRIBUTE_STATE_DIGEST
     ):
         raise RepositorySecurityError("scanner imported-module attribute state changed")
+    if verify_state and (
+        _external_global_binding_state_digest(_SEALED_SCANNER_EXTERNAL_GLOBAL_NAMES)
+        != _SEALED_SCANNER_EXTERNAL_GLOBAL_STATE_DIGEST
+    ):
+        raise RepositorySecurityError("scanner imported global binding state changed")
 
 
 def _snapshot_identity_groups(
@@ -2693,7 +2793,7 @@ class RepositoryScanner:
         expected_adapter_identity, expected_evaluator_identity, expected_state_digest = (
             sealed_guards[adapter.adapter_id]
         )
-        process_context = multiprocessing.get_context("fork")
+        process_context = _sealed_multiprocessing_context()
         receiver, sender = process_context.Pipe(duplex=False)
         process = process_context.Process(
             target=_adapter_worker,

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -49,7 +49,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.3.0"
+SCANNER_VERSION = "repository-scanner/2.4.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -1296,7 +1296,10 @@ class RepositoryScanner:
                 )
                 break
             supported.update(adapter.supported_categories)
-            matched_context = AdapterContext(files=context.matching(adapter.file_patterns))
+            matched_context = AdapterContext(
+                files=context.matching(adapter.file_patterns),
+                repository_files=files,
+            )
             status, result = self._run_adapter_bounded(
                 adapter,
                 matched_context,
@@ -1356,7 +1359,7 @@ class RepositoryScanner:
         context: AdapterContext,
         result: AdapterResult,
     ) -> bool:
-        files = {item.path: item for item in context.files}
+        files = {item.path: item for item in (context.repository_files or context.files)}
         allowed_categories = set(adapter.supported_categories)
         allowed_confidence = {"HIGH", "MEDIUM", "LOW"}
         allowed_severity = {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
@@ -1488,6 +1491,49 @@ class RepositoryScanner:
                 severity="MEDIUM",
             )
         ]
+        required_subcategories = (
+            (
+                "repository_topology",
+                "ignored paths",
+                (),
+            ),
+            (
+                "architecture_boundaries",
+                "internal dependency direction",
+                (),
+            ),
+            (
+                "architecture_boundaries",
+                "shared-library relationships",
+                (),
+            ),
+            (
+                "apis_data",
+                "storage models",
+                ("DATABASE_SCHEMA_SIGNAL", "MIGRATION_SIGNAL"),
+            ),
+            (
+                "delivery_environments",
+                "deployment-evidence mechanisms",
+                (),
+            ),
+        )
+        for category, capability, supported_kinds in required_subcategories:
+            if not supported_kinds or not any(
+                item.kind in supported_kinds for item in inventory[category]
+            ):
+                findings.append(
+                    _finding(
+                        "AUDIT.REQUIRED_SUBCATEGORY_UNSUPPORTED",
+                        category,
+                        f"The required {capability} audit subcategory has no complete "
+                        "deterministic detector for this snapshot; it remains explicitly "
+                        "unsupported rather than inferred or silently omitted.",
+                        ("repository:tracked-tree",),
+                        severity="HIGH",
+                        blocking=True,
+                    )
+                )
         gitlinks = tuple(sorted(file.path for file in files if file.mode == "160000"))
         if gitlinks:
             findings.append(
@@ -2024,7 +2070,10 @@ class RepositoryScanner:
                 "The tracked ecosystem has no deterministic adapter."
             )
         for finding in findings:
-            if finding.code == "AUDIT.UNSUPPORTED_SUBCATEGORY":
+            if finding.code in {
+                "AUDIT.REQUIRED_SUBCATEGORY_UNSUPPORTED",
+                "AUDIT.UNSUPPORTED_SUBCATEGORY",
+            }:
                 statuses[finding.category] = "BLOCKED"
                 reasons[finding.category] = (
                     "Relevant tracked content has no deterministic subcategory adapter."

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -1364,32 +1364,65 @@ class RepositoryScanner:
                 )
             )
             entries = entries[: self.config.max_files]
-        directories = sorted(
-            {
-                "/".join(PurePosixPath(path).parts[:depth])
-                for _, _, _, path, _ in entries
-                for depth in range(1, len(PurePosixPath(path).parts))
-            }
-        )
-        if len(directories) > self.config.max_directories:
-            allowed_directories = set(directories[: self.config.max_directories])
-            findings.append(
-                _finding(
-                    "BUDGET.DIRECTORY_COUNT",
-                    "repository_topology",
-                    "The tracked directory-count budget was exceeded; results are explicitly "
-                    "partial.",
-                    ("repository:tracked-tree",),
+        bounded_entries: list[tuple[str, str, str, str, int]] = []
+        directory_trie: dict[str, Any] = {}
+        directory_count = 0
+        directory_exhausted = False
+        cancelled_during_path_bounding = False
+        for entry in entries:
+            path = entry[3]
+            if self._is_cancelled():
+                findings.append(
+                    _finding(
+                        "SCAN.CANCELLED",
+                        "repository_topology",
+                        "The scan was cancelled during bounded tracked-path evaluation.",
+                        (path,),
+                        blocking=True,
+                    )
                 )
-            )
-            entries = [
-                entry
-                for entry in entries
-                if all(
-                    "/".join(PurePosixPath(entry[3]).parts[:depth]) in allowed_directories
-                    for depth in range(1, len(PurePosixPath(entry[3]).parts))
+                cancelled_during_path_bounding = True
+                break
+            parts = PurePosixPath(path).parts
+            if len(parts) > self.config.max_path_depth:
+                findings.append(
+                    _finding(
+                        "BUDGET.PATH_DEPTH",
+                        "repository_topology",
+                        "A tracked path exceeds the configured traversal depth.",
+                        (path,),
+                    )
                 )
-            ]
+                continue
+            node = directory_trie
+            missing_index = len(parts) - 1
+            for index, component in enumerate(parts[:-1]):
+                child = node.get(component)
+                if child is None:
+                    missing_index = index
+                    break
+                node = child
+            new_directories = max(0, len(parts) - 1 - missing_index)
+            if directory_count + new_directories > self.config.max_directories:
+                if not directory_exhausted:
+                    findings.append(
+                        _finding(
+                            "BUDGET.DIRECTORY_COUNT",
+                            "repository_topology",
+                            "The tracked directory-count budget was exceeded; results are "
+                            "explicitly partial.",
+                            ("repository:tracked-tree",),
+                        )
+                    )
+                    directory_exhausted = True
+                continue
+            for component in parts[missing_index:-1]:
+                child = {}
+                node[component] = child
+                node = child
+                directory_count += 1
+            bounded_entries.append(entry)
+        entries = [] if cancelled_during_path_bounding else bounded_entries
         files: list[TrackedFile] = []
         total = 0
         total_exhausted = False
@@ -1405,16 +1438,6 @@ class RepositoryScanner:
                     )
                 )
                 break
-            if len(PurePosixPath(path).parts) > self.config.max_path_depth:
-                findings.append(
-                    _finding(
-                        "BUDGET.PATH_DEPTH",
-                        "repository_topology",
-                        "A tracked path exceeds the configured traversal depth.",
-                        (path,),
-                    )
-                )
-                continue
             if total + size > self.config.max_total_bytes:
                 if not total_exhausted:
                     findings.append(

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import _thread
+import ast
 import datetime as datetime_module
 import hashlib
 import importlib
@@ -56,7 +57,7 @@ from pmpe.repository.redaction import (
     assert_distinct_identities_preserved,
 )
 
-SCANNER_VERSION = "repository-scanner/2.19.0"
+SCANNER_VERSION = "repository-scanner/2.20.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -1549,12 +1550,119 @@ _SEALED_ADAPTER_IMPORT_PROCESS_IDENTITIES = _module_import_binding_identities(
 _SEALED_SCANNER_IMPORT_NAMES = tuple(
     sorted(name for name, target in globals().items() if type(target) is ModuleType)
 )
-_SEALED_SCANNER_IMPORT_STATE_NAMES = ("importlib_metadata", "platform")
-_SEALED_SCANNER_IMPORT_STATE_DIGEST = _module_import_binding_state_digest(
-    "repository.scanner", _SEALED_SCANNER_IMPORT_STATE_NAMES
-)
 _SEALED_SCANNER_IMPORT_PROCESS_IDENTITIES = tuple(
     (name, id(globals()[name])) for name in _SEALED_SCANNER_IMPORT_NAMES
+)
+
+
+def _direct_module_attribute_names(
+    source_path: Path, module_names: tuple[str, ...]
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Derive direct module-attribute dependencies from the loaded implementation."""
+
+    try:
+        tree = ast.parse(source_path.read_text())
+    except (OSError, SyntaxError, UnicodeError) as exc:
+        raise RepositoryIntelligenceError(
+            "implementation module attributes are unavailable for provenance binding"
+        ) from exc
+    attributes: dict[str, set[str]] = {name: set() for name in module_names}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in attributes
+        ):
+            attributes[node.value.id].add(node.attr)
+    return tuple(
+        (name, tuple(sorted(names))) for name, names in sorted(attributes.items()) if names
+    )
+
+
+def _module_attribute_binding_identities(
+    attribute_names: tuple[tuple[str, tuple[str, ...]], ...],
+) -> tuple[tuple[str, str, int], ...]:
+    identities: list[tuple[str, str, int]] = []
+    for module_name, names in attribute_names:
+        module = globals().get(module_name)
+        namespace = vars(module) if type(module) is ModuleType else {}
+        for name in names:
+            target = namespace.get(name)
+            identities.append((module_name, name, id(target) if target is not None else -1))
+    return tuple(identities)
+
+
+def _module_attribute_binding_state_digest(
+    attribute_names: tuple[tuple[str, tuple[str, ...]], ...],
+) -> str:
+    evidence: list[dict[str, Any]] = []
+    for module_name, names in attribute_names:
+        module = globals().get(module_name)
+        if type(module) is not ModuleType:
+            raise RepositorySecurityError("scanner imported-module binding changed")
+        namespace = vars(module)
+        for name in names:
+            if name not in namespace:
+                raise RepositorySecurityError("scanner imported-module attribute is unavailable")
+            evidence.append(
+                {
+                    "module": module_name,
+                    "attribute": name,
+                    "state": _module_attribute_value_evidence(module_name, name, namespace[name]),
+                }
+            )
+    return canonical_digest(evidence)
+
+
+def _module_attribute_value_evidence(module_name: str, attribute_name: str, target: Any) -> Any:
+    """Bind executable or immutable attribute state without host caches or secrets."""
+
+    code = _runtime_code_evidence(target)
+    if code:
+        return {"runtime_code": code}
+    if type(target) is ModuleType:
+        return {"module": target.__name__}
+    if module_name == "os" and attribute_name == "environ":
+        return {"type": f"{type(target).__module__}.{type(target).__qualname__}"}
+    if module_name == "sys" and attribute_name == "executable":
+        return {"type": "python-executable", "binary_digest": _sha256(Path(target).read_bytes())}
+    if isinstance(target, (type(None), bool, int, float, complex, str, bytes, tuple, frozenset)):
+        return _runtime_value_evidence(target)
+    return {
+        "type": f"{type(target).__module__}.{type(target).__qualname__}",
+        "module": str(getattr(target, "__module__", type(target).__module__)),
+        "qualname": str(getattr(target, "__qualname__", type(target).__qualname__)),
+    }
+
+
+def _external_global_binding_names() -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            name
+            for name, target in globals().items()
+            if (
+                type(target) is ModuleType
+                or inspect.isfunction(target)
+                or inspect.isclass(target)
+                or inspect.isbuiltin(target)
+            )
+            and str(getattr(target, "__module__", "")) != __name__
+        )
+    )
+
+
+_SEALED_SCANNER_MODULE_ATTRIBUTE_NAMES = _direct_module_attribute_names(
+    _IMPLEMENTATION_PATHS["repository.scanner"], _SEALED_SCANNER_IMPORT_NAMES
+)
+_SEALED_SCANNER_MODULE_ATTRIBUTE_STATE_DIGEST = _module_attribute_binding_state_digest(
+    _SEALED_SCANNER_MODULE_ATTRIBUTE_NAMES
+)
+_SEALED_SCANNER_MODULE_ATTRIBUTE_PROCESS_IDENTITIES = _module_attribute_binding_identities(
+    _SEALED_SCANNER_MODULE_ATTRIBUTE_NAMES
+)
+_SEALED_SCANNER_EXTERNAL_GLOBAL_NAMES = _external_global_binding_names()
+_SEALED_SCANNER_EXTERNAL_GLOBAL_PROCESS_IDENTITIES = tuple(
+    (name, id(globals()[name])) for name in _SEALED_SCANNER_EXTERNAL_GLOBAL_NAMES
 )
 
 
@@ -1571,13 +1679,21 @@ def _assert_scanner_import_bindings_sealed(*, verify_state: bool = False) -> Non
     )
     if current_identities != _SEALED_SCANNER_IMPORT_PROCESS_IDENTITIES:
         raise RepositorySecurityError("scanner imported-module bindings changed")
-    if verify_state and (
-        _module_import_binding_state_digest(
-            "repository.scanner", _SEALED_SCANNER_IMPORT_STATE_NAMES
-        )
-        != _SEALED_SCANNER_IMPORT_STATE_DIGEST
+    if (
+        _module_attribute_binding_identities(_SEALED_SCANNER_MODULE_ATTRIBUTE_NAMES)
+        != _SEALED_SCANNER_MODULE_ATTRIBUTE_PROCESS_IDENTITIES
     ):
-        raise RepositorySecurityError("scanner imported-module state changed")
+        raise RepositorySecurityError("scanner imported-module attributes changed")
+    if (
+        tuple((name, id(globals().get(name))) for name in _SEALED_SCANNER_EXTERNAL_GLOBAL_NAMES)
+        != _SEALED_SCANNER_EXTERNAL_GLOBAL_PROCESS_IDENTITIES
+    ):
+        raise RepositorySecurityError("scanner imported global bindings changed")
+    if verify_state and (
+        _module_attribute_binding_state_digest(_SEALED_SCANNER_MODULE_ATTRIBUTE_NAMES)
+        != _SEALED_SCANNER_MODULE_ATTRIBUTE_STATE_DIGEST
+    ):
+        raise RepositorySecurityError("scanner imported-module attribute state changed")
 
 
 def _snapshot_identity_groups(
@@ -3342,6 +3458,7 @@ class RepositoryScanner:
 
     def scan(self, repository_root: Path | str, *, commit: str = "HEAD") -> RepositorySnapshot:
         self._assert_execution_collaborators_sealed()
+        _assert_scanner_import_bindings_sealed(verify_state=True)
         self._validate_config()
         self._commands = 0
         self._command_provenance = []

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -47,7 +47,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/1.8.0"
+SCANNER_VERSION = "repository-scanner/1.9.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -1372,6 +1372,58 @@ class RepositoryScanner:
                 severity="MEDIUM",
             )
         ]
+        evidenced_paths = {
+            category: {item.path for item in category_items}
+            for category, category_items in inventory.items()
+        }
+        unsupported_relevant: dict[str, list[str]] = {
+            "apis_data": [],
+            "security_privacy": [],
+            "observability_operations": [],
+        }
+        for file in files:
+            lowered = file.path.lower()
+            name = PurePosixPath(lowered).name
+            suffix = PurePosixPath(lowered).suffix
+            if file.binary:
+                continue
+            if (
+                suffix == ".sql"
+                or (
+                    suffix in {".json", ".yaml", ".yml"}
+                    and any(token in name for token in ("schema", "data-model", "data_model"))
+                )
+            ) and file.path not in evidenced_paths["apis_data"]:
+                unsupported_relevant["apis_data"].append(file.path)
+            if (
+                any(
+                    token in lowered
+                    for token in ("privacy", "data-retention", "data_retention", "gdpr", "pii")
+                )
+                and file.path not in evidenced_paths["security_privacy"]
+            ):
+                unsupported_relevant["security_privacy"].append(file.path)
+            if (
+                any(
+                    token in lowered
+                    for token in ("prometheus", "grafana", "opentelemetry", "otel", "telemetry")
+                )
+                and file.path not in evidenced_paths["observability_operations"]
+            ):
+                unsupported_relevant["observability_operations"].append(file.path)
+        for category, paths in unsupported_relevant.items():
+            if paths:
+                findings.append(
+                    _finding(
+                        "AUDIT.UNSUPPORTED_SUBCATEGORY",
+                        category,
+                        "Tracked content appears relevant to a required audit subcategory but "
+                        "no versioned adapter emitted evidence; the category is blocked rather "
+                        "than reported as not observed.",
+                        tuple(sorted(set(paths))),
+                        blocking=True,
+                    )
+                )
         expected_test_kinds = {
             "unit": "UNIT_TEST_FILE_SIGNAL",
             "integration": "INTEGRATION_TEST_FILE_SIGNAL",
@@ -1829,6 +1881,12 @@ class RepositoryScanner:
             reasons["languages_build_ecosystems"] = (
                 "The tracked ecosystem has no deterministic adapter."
             )
+        for finding in findings:
+            if finding.code == "AUDIT.UNSUPPORTED_SUBCATEGORY":
+                statuses[finding.category] = "BLOCKED"
+                reasons[finding.category] = (
+                    "Relevant tracked content has no deterministic subcategory adapter."
+                )
         unsupported_required = any(
             status in {"UNSUPPORTED", "BLOCKED"} and name != "active_divergent_work"
             for name, status in statuses.items()

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import importlib.metadata
+import inspect
+import json
+import marshal
+import multiprocessing
 import os
 import platform
 import posixpath
@@ -13,6 +17,7 @@ import signal
 import subprocess
 import time
 from collections.abc import Sequence
+from contextlib import suppress
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, cast
@@ -22,6 +27,7 @@ import yaml
 from pmpe.contracts.canonical import canonical_digest
 from pmpe.repository.adapters import (
     AdapterContext,
+    AdapterResult,
     RepositoryAdapter,
     TrackedFile,
     default_adapters,
@@ -41,7 +47,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/1.4.0"
+SCANNER_VERSION = "repository-scanner/1.5.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -70,6 +76,10 @@ class Cancellation(Protocol):
     def cancelled(self) -> bool: ...
 
 
+class _ScanCancelledError(RepositoryIntelligenceError):
+    """An in-flight bounded scan operation was cancelled."""
+
+
 @dataclass(frozen=True)
 class TreeListingResult:
     result: CommandResult
@@ -81,7 +91,7 @@ class TreeListingResult:
 class SubprocessCommandRunner:
     """Allowlisted local Git reader; it never invokes shells or project code."""
 
-    identity = "git-readonly-subprocess/1.4.0"
+    identity = "git-readonly-subprocess/1.5.0"
     _allowed = {"rev-parse", "ls-tree", "cat-file", "version"}
 
     @staticmethod
@@ -110,25 +120,69 @@ class SubprocessCommandRunner:
             "LC_ALL": "C",
         }
 
-    def run(self, args: tuple[str, ...], cwd: Path, timeout: int) -> CommandResult:
+    def run(
+        self,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        cancellation: Cancellation | None = None,
+    ) -> CommandResult:
         if len(args) < 2 or args[0] != "git" or args[1] not in self._allowed:
             raise RepositorySecurityError("command is outside the read-only Git allowlist")
         try:
-            result = subprocess.run(
+            process = subprocess.Popen(
                 args,
                 cwd=cwd,
-                capture_output=True,
-                check=False,
-                timeout=timeout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
                 env=self._environment(),
+                start_new_session=True,
             )
-        except subprocess.TimeoutExpired:
-            return CommandResult(args=args, returncode=124, stdout=b"", stderr=b"", timed_out=True)
+        except OSError:
+            raise
+        if process.stdout is None:
+            _stop_subprocess_group(process)
+            raise RepositoryIntelligenceError("bounded Git command output is unavailable")
+        selector = selectors.DefaultSelector()
+        selector.register(process.stdout, selectors.EVENT_READ)
+        payload = bytearray()
+        deadline = time.monotonic() + timeout
+        timed_out = False
+        cancelled = False
+        try:
+            while True:
+                if cancellation is not None and cancellation.cancelled():
+                    cancelled = True
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    timed_out = True
+                    break
+                events = selector.select(min(remaining, 0.05))
+                if events:
+                    chunk = os.read(process.stdout.fileno(), 65_536)
+                    if not chunk:
+                        break
+                    payload.extend(chunk)
+                    if len(payload) > 8_000_000:
+                        timed_out = True
+                        break
+                elif process.poll() is not None:
+                    break
+        finally:
+            selector.close()
+            process.stdout.close()
+        if cancelled or timed_out or process.poll() is None:
+            _stop_subprocess_group(process)
+        else:
+            process.wait(timeout=1.0)
         return CommandResult(
             args=args,
-            returncode=result.returncode,
-            stdout=result.stdout,
-            stderr=result.stderr,
+            returncode=126 if cancelled else 124 if timed_out else process.returncode,
+            stdout=bytes(payload),
+            stderr=b"",
+            timed_out=timed_out,
         )
 
     def list_tree(
@@ -260,6 +314,20 @@ def _signal_process_group(process: subprocess.Popen[bytes], action: signal.Signa
                 ) from exc
 
 
+def _stop_subprocess_group(process: subprocess.Popen[bytes]) -> None:
+    """Terminate and reap a bounded process group, including surviving descendants."""
+
+    _signal_process_group(process, signal.SIGTERM)
+    try:
+        process.wait(timeout=0.25)
+    except subprocess.TimeoutExpired:
+        _signal_process_group(process, signal.SIGKILL)
+        try:
+            process.wait(timeout=1.0)
+        except subprocess.TimeoutExpired as exc:
+            raise RepositorySecurityError("bounded Git process could not be reaped") from exc
+
+
 def _valid_object_id(value: str, object_format: str) -> bool:
     length = _OBJECT_FORMAT_LENGTH.get(object_format)
     return (
@@ -269,7 +337,37 @@ def _valid_object_id(value: str, object_format: str) -> bool:
     )
 
 
-def _implementation_digest() -> str:
+def _implementation_source_evidence(label: str, target: Any) -> dict[str, str]:
+    """Bind an injected output-affecting implementation without persisting its state."""
+
+    implementation = target if inspect.isfunction(target) else target.__class__
+    try:
+        source_path_value = inspect.getsourcefile(implementation)
+        if source_path_value is None:
+            raise OSError("implementation source path is unavailable")
+        source_digest = _sha256(Path(source_path_value).read_bytes())
+        callable_target = target if callable(target) else getattr(target, "run", None)
+        code = getattr(callable_target, "__code__", None)
+        if code is None and not inspect.isfunction(target) and callable(target):
+            method = inspect.getattr_static(implementation, "__call__", None)
+            code = getattr(method, "__code__", None)
+        code_digest = _sha256(marshal.dumps(code)) if code is not None else source_digest
+    except (OSError, TypeError, ValueError) as exc:
+        raise RepositoryIntelligenceError(
+            f"{label} implementation bytes are unavailable for provenance binding"
+        ) from exc
+    return {
+        "label": label,
+        "module": str(getattr(implementation, "__module__", "unknown")),
+        "qualname": str(getattr(implementation, "__qualname__", type(target).__qualname__)),
+        "source_digest": source_digest,
+        "code_digest": code_digest,
+    }
+
+
+def _implementation_digest(
+    extension_evidence: Sequence[dict[str, str]] = (),
+) -> str:
     package_root = Path(__file__).resolve().parent
     paths = {
         "repository.adapters": package_root / "adapters.py",
@@ -279,7 +377,7 @@ def _implementation_digest() -> str:
         "contracts.canonical": package_root.parent / "contracts" / "canonical.py",
     }
     try:
-        evidence = [
+        evidence: list[dict[str, str]] = [
             {"module": name, "source_digest": _sha256(paths[name].read_bytes())}
             for name in IMPLEMENTATION_MODULES
         ]
@@ -287,7 +385,58 @@ def _implementation_digest() -> str:
         raise RepositoryIntelligenceError(
             "scanner implementation bytes are unavailable for provenance binding"
         ) from exc
-    return canonical_digest(evidence)
+    evidence.extend(extension_evidence)
+    return canonical_digest(
+        sorted(evidence, key=lambda item: (item.get("label", ""), item["module"]))
+    )
+
+
+def _adapter_worker(connection: Any, adapter: RepositoryAdapter, context: AdapterContext) -> None:
+    """Evaluate one adapter in a killable, environment-isolated process."""
+
+    try:
+        os.setsid()
+        os.environ.clear()
+        os.environ.update({"PATH": "/usr/bin:/bin", "LC_ALL": "C"})
+        result = adapter.evaluator(context)
+        if not isinstance(result, AdapterResult):
+            raise TypeError("adapter result has an invalid type")
+        payload = json.dumps(
+            {"status": "RESULT", "result": asdict(result)},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        connection.send_bytes(payload)
+    except BaseException as exc:
+        with suppress(BrokenPipeError, EOFError, OSError):
+            connection.send_bytes(
+                json.dumps(
+                    {"status": "ERROR", "error_type": type(exc).__name__},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            )
+    finally:
+        connection.close()
+
+
+def _stop_isolated_process(process: Any) -> None:
+    """Terminate a forked evaluator and its descendants even if its parent exited."""
+
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        if process.is_alive():
+            process.terminate()
+    process.join(timeout=0.25)
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        if process.is_alive():
+            process.kill()
+    process.join(timeout=1.0)
+    if process.is_alive():
+        raise RepositorySecurityError("bounded adapter process could not be reaped")
 
 
 def _sha256(payload: bytes) -> str:
@@ -436,9 +585,20 @@ class RepositoryScanner:
         self.runner = command_runner or SubprocessCommandRunner()
         self.redactor = redactor or EvidenceRedactor()
         self.cancellation = cancellation
+        extension_targets: list[tuple[str, Any]] = [
+            ("command_runner", self.runner),
+            ("redactor", self.redactor),
+            *((f"adapter:{item.adapter_id}", item.evaluator) for item in self.adapters),
+        ]
+        if cancellation is not None:
+            extension_targets.append(("cancellation", cancellation))
+        self._extension_implementation_evidence = tuple(
+            _implementation_source_evidence(label, target) for label, target in extension_targets
+        )
         self._commands = 0
         self._command_provenance: list[CommandProvenance] = []
         self._tool_versions: tuple[ToolVersion, ...] = ()
+        self._identity_resolved = False
 
     def _is_cancelled(self) -> bool:
         if self.cancellation is None:
@@ -467,7 +627,15 @@ class RepositoryScanner:
             return None
         self._commands += 1
         try:
-            result = self.runner.run(args, root, self.config.command_timeout_seconds)
+            if isinstance(self.runner, SubprocessCommandRunner):
+                result = self.runner.run(
+                    args,
+                    root,
+                    self.config.command_timeout_seconds,
+                    cancellation=self.cancellation if self._identity_resolved else None,
+                )
+            else:
+                result = self.runner.run(args, root, self.config.command_timeout_seconds)
         except (FileNotFoundError, OSError) as exc:
             raise RepositoryIntelligenceError("read-only Git command is unavailable") from exc
         self._command_provenance.append(
@@ -480,6 +648,8 @@ class RepositoryScanner:
         )
         if result.timed_out:
             raise RepositoryIntelligenceError("read-only Git command timed out")
+        if result.returncode == 126 and self._identity_resolved:
+            raise _ScanCancelledError("read-only Git command was cancelled")
         if result.returncode != 0:
             if essential:
                 raise RepositoryIntelligenceError("path is not an accessible Git repository")
@@ -551,9 +721,19 @@ class RepositoryScanner:
 
     def _collect_tool_versions(self, root: Path) -> tuple[ToolVersion, ...]:
         try:
-            git_result = self.runner.run(
-                ("git", "version"), root, self.config.command_timeout_seconds
-            )
+            if isinstance(self.runner, SubprocessCommandRunner):
+                git_result = self.runner.run(
+                    ("git", "version"),
+                    root,
+                    self.config.command_timeout_seconds,
+                    cancellation=self.cancellation,
+                )
+            else:
+                git_result = self.runner.run(
+                    ("git", "version"), root, self.config.command_timeout_seconds
+                )
+            if git_result.returncode == 126:
+                raise _ScanCancelledError("Git version observation was cancelled")
             if git_result.timed_out or git_result.returncode != 0:
                 raise RepositoryIntelligenceError("Git version command failed")
             git_version = _text(git_result.stdout).strip()
@@ -909,11 +1089,14 @@ class RepositoryScanner:
                 )
                 break
             supported.update(adapter.supported_categories)
-            try:
-                result = adapter.evaluator(
-                    AdapterContext(files=context.matching(adapter.file_patterns))
-                )
-            except Exception:
+            status, result = self._run_adapter_bounded(
+                adapter,
+                AdapterContext(files=context.matching(adapter.file_patterns)),
+            )
+            if status == "CANCELLED":
+                findings.append(self._cancelled_finding(f"adapter:{adapter.adapter_id}"))
+                break
+            if status != "RESULT" or result is None:
                 findings.append(
                     _finding(
                         "ADAPTER.FAILURE",
@@ -921,7 +1104,7 @@ class RepositoryScanner:
                         f"Adapter {adapter.adapter_id} failed; its categories remain visibly "
                         "partial.",
                         (f"adapter:{adapter.adapter_id}",),
-                        blocking=False,
+                        blocking=True,
                     )
                 )
                 continue
@@ -948,6 +1131,63 @@ class RepositoryScanner:
             for item in boundaries
         )
         return inventory, findings, boundaries, supported
+
+    def _run_adapter_bounded(
+        self, adapter: RepositoryAdapter, context: AdapterContext
+    ) -> tuple[str, AdapterResult | None]:
+        if not hasattr(os, "fork") or not hasattr(os, "setsid"):
+            return "ERROR", None
+        process_context = multiprocessing.get_context("fork")
+        receiver, sender = process_context.Pipe(duplex=False)
+        process = process_context.Process(
+            target=_adapter_worker,
+            args=(sender, adapter, context),
+            daemon=True,
+            name=f"pmpe-readonly-adapter-{adapter.adapter_id}",
+        )
+        try:
+            process.start()
+        except (OSError, RuntimeError):
+            receiver.close()
+            sender.close()
+            return "ERROR", None
+        sender.close()
+        deadline = time.monotonic() + self.config.command_timeout_seconds
+        try:
+            while True:
+                if self._is_cancelled():
+                    return "CANCELLED", None
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return "ERROR", None
+                if receiver.poll(min(remaining, 0.05)):
+                    try:
+                        payload = receiver.recv_bytes(self.config.max_tree_output_bytes)
+                        decoded = json.loads(payload)
+                    except (EOFError, OSError, UnicodeDecodeError, ValueError, TypeError):
+                        return "ERROR", None
+                    if not isinstance(decoded, dict) or decoded.get("status") != "RESULT":
+                        return "ERROR", None
+                    try:
+                        raw_result = decoded["result"]
+                        result = AdapterResult(
+                            items=tuple(
+                                (str(category), EvidenceItem(**item))
+                                for category, item in raw_result["items"]
+                            ),
+                            findings=tuple(Finding(**item) for item in raw_result["findings"]),
+                            boundaries=tuple(
+                                BoundaryCandidate(**item) for item in raw_result["boundaries"]
+                            ),
+                        )
+                    except (KeyError, TypeError, ValueError):
+                        return "ERROR", None
+                    return "RESULT", result
+                if not process.is_alive():
+                    return "ERROR", None
+        finally:
+            receiver.close()
+            _stop_isolated_process(process)
 
     def _cross_cutting_findings(
         self, files: tuple[TrackedFile, ...], inventory: dict[str, list[EvidenceItem]]
@@ -1126,7 +1366,24 @@ class RepositoryScanner:
             file.path
             for file in files
             if PurePosixPath(file.path).name
-            in {"Cargo.toml", "go.mod", "pom.xml", "build.gradle", "Gemfile"}
+            in {
+                "BUILD",
+                "BUILD.bazel",
+                "CMakeLists.txt",
+                "Cargo.toml",
+                "Gemfile",
+                "GNUmakefile",
+                "Jenkinsfile",
+                "MODULE.bazel",
+                "Makefile",
+                "Tiltfile",
+                "WORKSPACE",
+                "WORKSPACE.bazel",
+                "build.gradle",
+                "go.mod",
+                "justfile",
+                "pom.xml",
+            }
         )
         if unsupported_manifests:
             findings.append(
@@ -1212,7 +1469,7 @@ class RepositoryScanner:
             statuses.update(dict.fromkeys(AUDIT_CATEGORIES, "BLOCKED"))
             reasons.update(dict.fromkeys(AUDIT_CATEGORIES, "scan cancelled"))
             disposition = "BLOCKED"
-        implementation_digest = _implementation_digest()
+        implementation_digest = _implementation_digest(self._extension_implementation_evidence)
         inventory = {
             name: InventoryCategory(
                 status=statuses.get(name, "SUPPORTED"),
@@ -1307,24 +1564,29 @@ class RepositoryScanner:
         self._validate_config()
         self._commands = 0
         self._command_provenance = []
+        self._identity_resolved = False
         self._requested_commit = commit
         requested = Path(repository_root).resolve()
         root, commit_sha, tree_sha, object_format = self._resolve_identity(requested)
+        self._identity_resolved = True
         # Root/ref resolution establishes the immutable identity but is excluded from
         # commit-stable provenance because equivalent refs (HEAD versus the exact SHA)
         # must yield byte-equivalent snapshots. Remaining commands are SHA-bound.
         self._command_provenance = self._command_provenance[2:]
-        self._tool_versions = self._collect_tool_versions(root)
         adapter_digest = canonical_digest([asdict(_metadata(item)) for item in self.adapters])
         config_digest = canonical_digest(asdict(self.config))
-        if self._is_cancelled():
+        try:
+            self._tool_versions = self._collect_tool_versions(root)
+            if self._is_cancelled():
+                raise _ScanCancelledError("scan cancelled after immutable identity resolution")
+            files, budget_findings, tree_digest, scanned_digest = self._list_files(
+                root, tree_sha, object_format
+            )
+            inventory, adapter_findings, boundaries, supported = self._apply_adapters(tuple(files))
+        except _ScanCancelledError:
             return self._cancelled_snapshot(
                 root, commit_sha, tree_sha, object_format, config_digest, adapter_digest
             )
-        files, budget_findings, tree_digest, scanned_digest = self._list_files(
-            root, tree_sha, object_format
-        )
-        inventory, adapter_findings, boundaries, supported = self._apply_adapters(tuple(files))
         findings = budget_findings + adapter_findings
         if self.config.include_paths:
             findings.append(

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -6,7 +6,6 @@ import hashlib
 import importlib.metadata
 import inspect
 import json
-import marshal
 import multiprocessing
 import os
 import platform
@@ -47,7 +46,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/1.5.0"
+SCANNER_VERSION = "repository-scanner/1.6.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -80,6 +79,15 @@ class _ScanCancelledError(RepositoryIntelligenceError):
     """An in-flight bounded scan operation was cancelled."""
 
 
+def _cancellation_requested(cancellation: Cancellation | None) -> bool:
+    if cancellation is None:
+        return False
+    try:
+        return cancellation.cancelled()
+    except Exception:
+        return True
+
+
 @dataclass(frozen=True)
 class TreeListingResult:
     result: CommandResult
@@ -91,7 +99,7 @@ class TreeListingResult:
 class SubprocessCommandRunner:
     """Allowlisted local Git reader; it never invokes shells or project code."""
 
-    identity = "git-readonly-subprocess/1.5.0"
+    identity = "git-readonly-subprocess/1.6.0"
     _allowed = {"rev-parse", "ls-tree", "cat-file", "version"}
 
     @staticmethod
@@ -152,7 +160,7 @@ class SubprocessCommandRunner:
         cancelled = False
         try:
             while True:
-                if cancellation is not None and cancellation.cancelled():
+                if _cancellation_requested(cancellation):
                     cancelled = True
                     break
                 remaining = deadline - time.monotonic()
@@ -170,13 +178,25 @@ class SubprocessCommandRunner:
                         break
                 elif process.poll() is not None:
                     break
+        except BaseException:
+            _stop_subprocess_group(process)
+            raise
         finally:
             selector.close()
             process.stdout.close()
-        if cancelled or timed_out or process.poll() is None:
+        if cancelled or timed_out:
             _stop_subprocess_group(process)
         else:
-            process.wait(timeout=1.0)
+            try:
+                process.wait(timeout=0.25)
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                _stop_subprocess_group(process)
+            else:
+                if not _signal_process_group(process, signal.SIGKILL):
+                    raise RepositorySecurityError(
+                        "bounded Git descendant termination could not be proven"
+                    )
         return CommandResult(
             args=args,
             returncode=126 if cancelled else 124 if timed_out else process.returncode,
@@ -221,14 +241,12 @@ class SubprocessCommandRunner:
         deadline = time.monotonic() + timeout
         try:
             while True:
-                if cancellation is not None and cancellation.cancelled():
+                if _cancellation_requested(cancellation):
                     cancelled = True
-                    _signal_process_group(process, signal.SIGTERM)
                     break
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     timed_out = True
-                    _signal_process_group(process, signal.SIGKILL)
                     break
                 events = selector.select(min(remaining, 0.1))
                 if not events:
@@ -240,31 +258,31 @@ class SubprocessCommandRunner:
                 record_count += chunk.count(0)
                 if len(payload) > max_output_bytes:
                     byte_limit = True
-                    _signal_process_group(process, signal.SIGTERM)
                     break
                 if record_count >= max_records:
                     record_limit = True
-                    _signal_process_group(process, signal.SIGTERM)
                     break
+        except BaseException:
+            _stop_subprocess_group(process)
+            raise
         finally:
             selector.close()
             process.stdout.close()
-        graceful_timeout = 0.25 if cancelled or record_limit or byte_limit else 0.1
-        try:
-            returncode = process.wait(
-                timeout=(
-                    graceful_timeout
-                    if cancelled or record_limit or byte_limit
-                    else max(0.1, deadline - time.monotonic())
-                )
-            )
-        except subprocess.TimeoutExpired:
-            _signal_process_group(process, signal.SIGKILL)
+        if cancelled or record_limit or byte_limit or timed_out:
+            _stop_subprocess_group(process)
+            returncode = process.returncode
+        else:
             try:
-                returncode = process.wait(timeout=1.0)
-            except subprocess.TimeoutExpired as exc:
-                raise RepositorySecurityError("bounded Git process could not be reaped") from exc
-            timed_out = True
+                returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                _stop_subprocess_group(process)
+                returncode = process.returncode
+            else:
+                if not _signal_process_group(process, signal.SIGKILL):
+                    raise RepositorySecurityError(
+                        "bounded Git descendant termination could not be proven"
+                    )
         complete_records = bytes(payload[:max_output_bytes]).split(b"\0")
         if complete_records and complete_records[-1]:
             complete_records = complete_records[:-1]
@@ -288,44 +306,53 @@ class SubprocessCommandRunner:
         )
 
 
-def _signal_process_group(process: subprocess.Popen[bytes], action: signal.Signals) -> None:
+def _signal_process_group(process: subprocess.Popen[bytes], action: signal.Signals) -> bool:
     """Stop the isolated immutable-object reader and any unexpected descendant."""
 
     try:
         os.killpg(process.pid, action)
+        return True
     except ProcessLookupError:
-        return
+        return True
     except OSError:
+        try:
+            os.killpg(process.pid, 0)
+        except ProcessLookupError:
+            return True
+        except OSError:
+            pass
         # Always make a best-effort parent termination if process-group signalling
         # is unavailable. These immutable-object commands cannot invoke repository
         # code, so a successfully signalled and reaped parent is a safe fallback.
         try:
             process.send_signal(action)
         except ProcessLookupError:
-            return
+            return False
         except OSError:
             try:
                 process.kill()
             except ProcessLookupError:
-                return
+                return False
             except OSError as exc:
                 raise RepositorySecurityError(
                     "bounded Git process group and parent could not be terminated"
                 ) from exc
+        return False
 
 
 def _stop_subprocess_group(process: subprocess.Popen[bytes]) -> None:
     """Terminate and reap a bounded process group, including surviving descendants."""
 
     _signal_process_group(process, signal.SIGTERM)
-    try:
+    with suppress(subprocess.TimeoutExpired):
         process.wait(timeout=0.25)
-    except subprocess.TimeoutExpired:
-        _signal_process_group(process, signal.SIGKILL)
-        try:
-            process.wait(timeout=1.0)
-        except subprocess.TimeoutExpired as exc:
-            raise RepositorySecurityError("bounded Git process could not be reaped") from exc
+    group_proven = _signal_process_group(process, signal.SIGKILL)
+    try:
+        process.wait(timeout=1.0)
+    except subprocess.TimeoutExpired as exc:
+        raise RepositorySecurityError("bounded Git process could not be reaped") from exc
+    if not group_proven:
+        raise RepositorySecurityError("bounded Git descendant termination could not be proven")
 
 
 def _valid_object_id(value: str, object_format: str) -> bool:
@@ -347,11 +374,13 @@ def _implementation_source_evidence(label: str, target: Any) -> dict[str, str]:
             raise OSError("implementation source path is unavailable")
         source_digest = _sha256(Path(source_path_value).read_bytes())
         callable_target = target if callable(target) else getattr(target, "run", None)
-        code = getattr(callable_target, "__code__", None)
-        if code is None and not inspect.isfunction(target) and callable(target):
-            method = inspect.getattr_static(implementation, "__call__", None)
-            code = getattr(method, "__code__", None)
-        code_digest = _sha256(marshal.dumps(code)) if code is not None else source_digest
+        if callable_target is None and not inspect.isfunction(target) and callable(target):
+            callable_target = inspect.getattr_static(implementation, "__call__", None)
+        code_digest = (
+            _sha256(inspect.getsource(callable_target).encode("utf-8"))
+            if callable_target is not None
+            else source_digest
+        )
     except (OSError, TypeError, ValueError) as exc:
         raise RepositoryIntelligenceError(
             f"{label} implementation bytes are unavailable for provenance binding"
@@ -425,18 +454,26 @@ def _stop_isolated_process(process: Any) -> None:
 
     try:
         os.killpg(process.pid, signal.SIGTERM)
-    except (ProcessLookupError, PermissionError, OSError):
+    except ProcessLookupError:
+        pass
+    except (PermissionError, OSError):
         if process.is_alive():
             process.terminate()
     process.join(timeout=0.25)
     try:
         os.killpg(process.pid, signal.SIGKILL)
-    except (ProcessLookupError, PermissionError, OSError):
+        group_proven = True
+    except ProcessLookupError:
+        group_proven = True
+    except (PermissionError, OSError):
+        group_proven = False
         if process.is_alive():
             process.kill()
     process.join(timeout=1.0)
     if process.is_alive():
         raise RepositorySecurityError("bounded adapter process could not be reaped")
+    if not group_proven:
+        raise RepositorySecurityError("bounded adapter descendant termination could not be proven")
 
 
 def _sha256(payload: bytes) -> str:
@@ -508,6 +545,7 @@ def _metadata(adapter: RepositoryAdapter) -> AdapterMetadata:
     return AdapterMetadata(
         adapter_id=adapter.adapter_id,
         version=adapter.version,
+        detector_version=adapter.detector_version,
         file_patterns=adapter.file_patterns,
         supported_categories=adapter.supported_categories,
         failure_behavior=adapter.failure_behavior,
@@ -582,6 +620,17 @@ class RepositoryScanner:
         self.adapters = tuple(
             sorted(adapters or default_adapters(), key=lambda item: item.adapter_id)
         )
+        adapter_ids = [item.adapter_id for item in self.adapters]
+        if len(set(adapter_ids)) != len(adapter_ids) or any(
+            not item.adapter_id
+            or not item.version
+            or not item.detector_version
+            or not item.file_patterns
+            or not item.supported_categories
+            or not set(item.supported_categories).issubset(AUDIT_CATEGORIES)
+            for item in self.adapters
+        ):
+            raise RepositoryIntelligenceError("repository adapter declaration is invalid")
         self.runner = command_runner or SubprocessCommandRunner()
         self.redactor = redactor or EvidenceRedactor()
         self.cancellation = cancellation
@@ -1089,9 +1138,10 @@ class RepositoryScanner:
                 )
                 break
             supported.update(adapter.supported_categories)
+            matched_context = AdapterContext(files=context.matching(adapter.file_patterns))
             status, result = self._run_adapter_bounded(
                 adapter,
-                AdapterContext(files=context.matching(adapter.file_patterns)),
+                matched_context,
             )
             if status == "CANCELLED":
                 findings.append(self._cancelled_finding(f"adapter:{adapter.adapter_id}"))
@@ -1108,6 +1158,18 @@ class RepositoryScanner:
                     )
                 )
                 continue
+            if not self._adapter_result_is_valid(adapter, matched_context, result):
+                findings.append(
+                    _finding(
+                        "ADAPTER.INVALID_EVIDENCE",
+                        adapter.supported_categories[0],
+                        f"Adapter {adapter.adapter_id} emitted evidence that was not bound to "
+                        "its declaration and matched immutable files.",
+                        (f"adapter:{adapter.adapter_id}",),
+                        blocking=True,
+                    )
+                )
+                continue
             if self._is_cancelled():
                 findings.append(self._cancelled_finding(f"adapter:{adapter.adapter_id}"))
                 break
@@ -1116,14 +1178,12 @@ class RepositoryScanner:
                     inventory[category].append(item)
             findings.extend(result.findings)
             boundaries.extend(result.boundaries)
+        files_by_path = {item.path: item for item in files}
         inventory["architecture_boundaries"].extend(
             EvidenceItem(
                 kind=f"BOUNDARY_{item.kind}",
                 path=item.evidence_paths[0],
-                file_digest=next(
-                    (file.digest for file in files if file.path == item.evidence_paths[0]),
-                    "sha256:" + "0" * 64,
-                ),
+                file_digest=files_by_path[item.evidence_paths[0]].digest,
                 detector_id=item.detector_id,
                 detector_version=item.detector_version,
                 confidence=item.confidence,
@@ -1131,6 +1191,62 @@ class RepositoryScanner:
             for item in boundaries
         )
         return inventory, findings, boundaries, supported
+
+    @staticmethod
+    def _adapter_result_is_valid(
+        adapter: RepositoryAdapter,
+        context: AdapterContext,
+        result: AdapterResult,
+    ) -> bool:
+        files = {item.path: item for item in context.files}
+        allowed_categories = set(adapter.supported_categories)
+        allowed_confidence = {"HIGH", "MEDIUM", "LOW"}
+        allowed_severity = {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
+
+        for category, item in result.items:
+            source = files.get(item.path)
+            if (
+                category not in allowed_categories
+                or source is None
+                or item.file_digest != source.digest
+                or item.detector_id != adapter.adapter_id
+                or item.detector_version != adapter.detector_version
+                or item.confidence not in allowed_confidence
+                or item.redaction_status != "SANITIZED"
+                or not item.kind
+                or not item.location
+            ):
+                return False
+        for finding in result.findings:
+            if (
+                finding.category not in allowed_categories
+                or finding.detector_id != adapter.adapter_id
+                or finding.detector_version != adapter.detector_version
+                or finding.confidence not in allowed_confidence
+                or finding.severity not in allowed_severity
+                or not finding.code
+                or not finding.explanation
+                or not finding.evidence_refs
+                or not all(
+                    reference == "repository:tracked-tree" or reference in files
+                    for reference in finding.evidence_refs
+                )
+            ):
+                return False
+        if result.boundaries and "architecture_boundaries" not in allowed_categories:
+            return False
+        for boundary in result.boundaries:
+            if (
+                not boundary.kind
+                or not boundary.name
+                or not boundary.evidence_paths
+                or not all(path in files for path in boundary.evidence_paths)
+                or boundary.detector_id != adapter.adapter_id
+                or boundary.detector_version != adapter.detector_version
+                or boundary.confidence not in allowed_confidence
+            ):
+                return False
+        return True
 
     def _run_adapter_bounded(
         self, adapter: RepositoryAdapter, context: AdapterContext
@@ -1376,7 +1492,13 @@ class RepositoryScanner:
                 "Jenkinsfile",
                 "MODULE.bazel",
                 "Makefile",
+                "Pipfile",
+                "Pipfile.lock",
+                "Procfile",
+                "Rakefile",
+                "SConstruct",
                 "Tiltfile",
+                "Vagrantfile",
                 "WORKSPACE",
                 "WORKSPACE.bazel",
                 "build.gradle",

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import importlib
 import importlib.metadata
 import inspect
 import json
@@ -18,10 +19,11 @@ import subprocess
 import sys
 import threading
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import suppress
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields, is_dataclass
 from pathlib import Path, PurePosixPath
+from types import CodeType, MappingProxyType
 from typing import Any, Protocol, cast, final
 
 import yaml
@@ -66,6 +68,23 @@ IMPLEMENTATION_MODULES = (
     "repository.redaction",
     "repository.scanner",
     "contracts.canonical",
+)
+_IMPLEMENTATION_PATHS = MappingProxyType(
+    {
+        "repository.adapters": Path(__file__).resolve().parent / "adapters.py",
+        "repository.models": Path(__file__).resolve().parent / "models.py",
+        "repository.redaction": Path(__file__).resolve().parent / "redaction.py",
+        "repository.scanner": Path(__file__).resolve(),
+        "contracts.canonical": Path(__file__).resolve().parent.parent
+        / "contracts"
+        / "canonical.py",
+    }
+)
+_IMPORTED_SOURCE_DIGESTS = MappingProxyType(
+    {
+        name: "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+        for name, path in _IMPLEMENTATION_PATHS.items()
+    }
 )
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
 
@@ -481,6 +500,202 @@ def _valid_object_id(value: str, object_format: str) -> bool:
     )
 
 
+def _stable_code_constant(value: Any) -> Any:
+    """Represent Python code constants without paths, addresses, or host state."""
+
+    if isinstance(value, CodeType):
+        return {"code": _code_object_evidence(value)}
+    if isinstance(value, bytes):
+        return {"bytes": value.hex()}
+    if isinstance(value, tuple):
+        return {"tuple": [_stable_code_constant(item) for item in value]}
+    if isinstance(value, frozenset):
+        items = [_stable_code_constant(item) for item in value]
+        return {
+            "frozenset": sorted(
+                items,
+                key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
+            )
+        }
+    if value is Ellipsis:
+        return {"singleton": "ELLIPSIS"}
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, (float, complex)):
+        return {"numeric_type": type(value).__name__, "value": repr(value)}
+    return {"unsupported_constant_type": f"{type(value).__module__}.{type(value).__qualname__}"}
+
+
+def _code_object_evidence(code: CodeType) -> dict[str, Any]:
+    """Canonicalize the loaded executable code, excluding host-specific filenames."""
+
+    return {
+        "name": code.co_name,
+        "qualname": code.co_qualname,
+        "argcount": code.co_argcount,
+        "posonlyargcount": code.co_posonlyargcount,
+        "kwonlyargcount": code.co_kwonlyargcount,
+        "nlocals": code.co_nlocals,
+        "stacksize": code.co_stacksize,
+        "flags": code.co_flags,
+        "bytecode": code.co_code.hex(),
+        "constants": [_stable_code_constant(item) for item in code.co_consts],
+        "names": list(code.co_names),
+        "varnames": list(code.co_varnames),
+        "freevars": list(code.co_freevars),
+        "cellvars": list(code.co_cellvars),
+        "line_table": code.co_linetable.hex(),
+        "exception_table": code.co_exceptiontable.hex(),
+    }
+
+
+def _runtime_code_evidence(target: Any) -> list[dict[str, Any]]:
+    """Collect the loaded code objects that can execute for a function or class."""
+
+    if inspect.ismethod(target):
+        target = target.__func__
+    if inspect.isfunction(target):
+        return [
+            {
+                "qualname": target.__qualname__,
+                "code": _code_object_evidence(target.__code__),
+                "defaults": _stable_code_constant(target.__defaults__),
+                "keyword_defaults": _stable_code_constant(
+                    tuple(sorted((target.__kwdefaults__ or {}).items()))
+                ),
+            }
+        ]
+    if inspect.isclass(target):
+        evidence: list[dict[str, Any]] = []
+        for name, member in sorted(vars(target).items()):
+            if isinstance(member, (staticmethod, classmethod)):
+                member = member.__func__
+            elif isinstance(member, property):
+                for accessor_name, accessor in (
+                    ("get", member.fget),
+                    ("set", member.fset),
+                    ("delete", member.fdel),
+                ):
+                    if accessor is not None:
+                        evidence.extend(
+                            {
+                                **item,
+                                "member": f"{name}:{accessor_name}",
+                            }
+                            for item in _runtime_code_evidence(accessor)
+                        )
+                continue
+            if inspect.isfunction(member) or inspect.ismethod(member):
+                evidence.extend({**item, "member": name} for item in _runtime_code_evidence(member))
+        return evidence
+    if callable(target):
+        return _runtime_code_evidence(target.__class__)
+    return []
+
+
+def _runtime_value_evidence(value: Any, *, depth: int = 0) -> Any:
+    """Canonicalize output-affecting runtime constants without object identities."""
+
+    if depth > 32:
+        raise RepositoryIntelligenceError("runtime implementation state exceeds depth limit")
+    if isinstance(value, CodeType):
+        return {"code": _code_object_evidence(value)}
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, bytes):
+        return {"bytes": value.hex()}
+    if isinstance(value, (float, complex)):
+        return {"numeric_type": type(value).__name__, "value": repr(value)}
+    if isinstance(value, PurePosixPath):
+        return {"path": value.as_posix()}
+    if isinstance(value, re.Pattern):
+        return {"pattern": value.pattern, "flags": value.flags}
+    if isinstance(value, Mapping):
+        return {
+            "mapping": [
+                [str(key), _runtime_value_evidence(item, depth=depth + 1)]
+                for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+            ]
+        }
+    if isinstance(value, (list, tuple)):
+        return {
+            type(value).__name__: [_runtime_value_evidence(item, depth=depth + 1) for item in value]
+        }
+    if isinstance(value, (set, frozenset)):
+        items = [_runtime_value_evidence(item, depth=depth + 1) for item in value]
+        return {
+            type(value).__name__: sorted(
+                items,
+                key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
+            )
+        }
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            "dataclass": f"{type(value).__module__}.{type(value).__qualname__}",
+            "fields": {
+                item.name: _runtime_value_evidence(
+                    getattr(value, item.name),
+                    depth=depth + 1,
+                )
+                for item in fields(value)
+            },
+        }
+    code = _runtime_code_evidence(value)
+    if code:
+        return {"runtime_code_digest": canonical_digest(code)}
+    return {"type": f"{type(value).__module__}.{type(value).__qualname__}"}
+
+
+def _module_runtime_digest(module_name: str) -> str:
+    """Bind the loaded module namespace rather than only its current source file."""
+
+    module = importlib.import_module(f"pmpe.{module_name}")
+    symbols: list[dict[str, Any]] = []
+    for name, target in sorted(vars(module).items()):
+        if name.startswith("__"):
+            continue
+        if inspect.isfunction(target) or inspect.isclass(target) or callable(target):
+            code = _runtime_code_evidence(target)
+            if code:
+                symbols.append({"symbol": name, "code": code})
+        elif name.lstrip("_").isupper() or (is_dataclass(target) and not isinstance(target, type)):
+            symbols.append(
+                {
+                    "symbol": name,
+                    "value": _runtime_value_evidence(target),
+                }
+            )
+    return canonical_digest(symbols)
+
+
+def _implementation_module_evidence(
+    paths: Mapping[str, Path],
+    imported_source_digests: Mapping[str, str],
+) -> list[dict[str, str]]:
+    """Bind import-time source, current source, and loaded runtime code fail closed."""
+
+    evidence: list[dict[str, str]] = []
+    try:
+        for name in paths:
+            source_digest = _sha256(paths[name].read_bytes())
+            if imported_source_digests.get(name) != source_digest:
+                raise RepositorySecurityError(
+                    f"{name} source changed after its executable module was imported"
+                )
+            evidence.append(
+                {
+                    "module": name,
+                    "source_digest": source_digest,
+                    "runtime_code_digest": _module_runtime_digest(name),
+                }
+            )
+    except OSError as exc:
+        raise RepositoryIntelligenceError(
+            "implementation bytes are unavailable for provenance binding"
+        ) from exc
+    return evidence
+
+
 def _implementation_source_evidence(label: str, target: Any) -> dict[str, str]:
     """Bind an injected output-affecting implementation without persisting its state."""
 
@@ -490,14 +705,10 @@ def _implementation_source_evidence(label: str, target: Any) -> dict[str, str]:
         if source_path_value is None:
             raise OSError("implementation source path is unavailable")
         source_digest = _sha256(Path(source_path_value).read_bytes())
-        callable_target = target if callable(target) else getattr(target, "run", None)
-        if callable_target is None and not inspect.isfunction(target) and callable(target):
-            callable_target = inspect.getattr_static(implementation, "__call__", None)
-        code_digest = (
-            _sha256(inspect.getsource(callable_target).encode("utf-8"))
-            if callable_target is not None
-            else source_digest
-        )
+        runtime_code = _runtime_code_evidence(implementation)
+        if not runtime_code:
+            raise ValueError("implementation has no inspectable runtime code")
+        code_digest = canonical_digest(runtime_code)
     except (OSError, TypeError, ValueError) as exc:
         raise RepositoryIntelligenceError(
             f"{label} implementation bytes are unavailable for provenance binding"
@@ -507,30 +718,17 @@ def _implementation_source_evidence(label: str, target: Any) -> dict[str, str]:
         "module": str(getattr(implementation, "__module__", "unknown")),
         "qualname": str(getattr(implementation, "__qualname__", type(target).__qualname__)),
         "source_digest": source_digest,
-        "code_digest": code_digest,
+        "runtime_code_digest": code_digest,
     }
 
 
 def _implementation_digest(
     extension_evidence: Sequence[dict[str, str]] = (),
 ) -> str:
-    package_root = Path(__file__).resolve().parent
-    paths = {
-        "repository.adapters": package_root / "adapters.py",
-        "repository.models": package_root / "models.py",
-        "repository.redaction": package_root / "redaction.py",
-        "repository.scanner": package_root / "scanner.py",
-        "contracts.canonical": package_root.parent / "contracts" / "canonical.py",
-    }
-    try:
-        evidence: list[dict[str, str]] = [
-            {"module": name, "source_digest": _sha256(paths[name].read_bytes())}
-            for name in IMPLEMENTATION_MODULES
-        ]
-    except OSError as exc:
-        raise RepositoryIntelligenceError(
-            "scanner implementation bytes are unavailable for provenance binding"
-        ) from exc
+    evidence = _implementation_module_evidence(
+        _IMPLEMENTATION_PATHS,
+        _IMPORTED_SOURCE_DIGESTS,
+    )
     evidence.extend(extension_evidence)
     return canonical_digest(
         sorted(evidence, key=lambda item: (item.get("label", ""), item["module"]))

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -9,6 +9,7 @@ import platform
 import posixpath
 import re
 import selectors
+import signal
 import subprocess
 import time
 from collections.abc import Sequence
@@ -40,7 +41,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/1.1.0"
+SCANNER_VERSION = "repository-scanner/1.2.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -80,7 +81,7 @@ class TreeListingResult:
 class SubprocessCommandRunner:
     """Allowlisted local Git reader; it never invokes shells or project code."""
 
-    identity = "git-readonly-subprocess/1.1.0"
+    identity = "git-readonly-subprocess/1.2.0"
     _allowed = {"rev-parse", "ls-tree", "cat-file", "version"}
 
     @staticmethod
@@ -92,13 +93,19 @@ class SubprocessCommandRunner:
             "GIT_TERMINAL_PROMPT": "0",
             "GIT_OPTIONAL_LOCKS": "0",
             "GIT_NO_LAZY_FETCH": "1",
-            "GIT_CONFIG_COUNT": "3",
+            "GIT_CONFIG_COUNT": "6",
             "GIT_CONFIG_KEY_0": "core.fsmonitor",
             "GIT_CONFIG_VALUE_0": "false",
             "GIT_CONFIG_KEY_1": "core.untrackedCache",
             "GIT_CONFIG_VALUE_1": "false",
             "GIT_CONFIG_KEY_2": "core.preloadIndex",
             "GIT_CONFIG_VALUE_2": "false",
+            "GIT_CONFIG_KEY_3": "core.attributesFile",
+            "GIT_CONFIG_VALUE_3": os.devnull,
+            "GIT_CONFIG_KEY_4": "core.excludesFile",
+            "GIT_CONFIG_VALUE_4": os.devnull,
+            "GIT_CONFIG_KEY_5": "submodule.recurse",
+            "GIT_CONFIG_VALUE_5": "false",
             "LC_ALL": "C",
         }
 
@@ -143,6 +150,7 @@ class SubprocessCommandRunner:
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             env=self._environment(),
+            start_new_session=True,
         )
         if process.stdout is None:
             process.kill()
@@ -160,18 +168,16 @@ class SubprocessCommandRunner:
             while True:
                 if cancellation is not None and cancellation.cancelled():
                     cancelled = True
-                    process.terminate()
+                    _signal_process_group(process, signal.SIGTERM)
                     break
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     timed_out = True
-                    process.kill()
+                    _signal_process_group(process, signal.SIGKILL)
                     break
-                events = selector.select(remaining)
+                events = selector.select(min(remaining, 0.1))
                 if not events:
-                    timed_out = True
-                    process.kill()
-                    break
+                    continue
                 chunk = os.read(process.stdout.fileno(), 65_536)
                 if not chunk:
                     break
@@ -179,11 +185,11 @@ class SubprocessCommandRunner:
                 record_count += chunk.count(0)
                 if len(payload) > max_output_bytes:
                     byte_limit = True
-                    process.terminate()
+                    _signal_process_group(process, signal.SIGTERM)
                     break
                 if record_count >= max_records:
                     record_limit = True
-                    process.terminate()
+                    _signal_process_group(process, signal.SIGTERM)
                     break
         finally:
             selector.close()
@@ -191,7 +197,7 @@ class SubprocessCommandRunner:
         try:
             returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
         except subprocess.TimeoutExpired:
-            process.kill()
+            _signal_process_group(process, signal.SIGKILL)
             returncode = process.wait()
             timed_out = True
         complete_records = bytes(payload[:max_output_bytes]).split(b"\0")
@@ -215,6 +221,22 @@ class SubprocessCommandRunner:
             byte_limit_exceeded=byte_limit,
             cancelled=cancelled,
         )
+
+
+def _signal_process_group(process: subprocess.Popen[bytes], action: signal.Signals) -> None:
+    """Stop the isolated immutable-object reader and any unexpected descendant."""
+
+    try:
+        os.killpg(process.pid, action)
+    except ProcessLookupError:
+        return
+    except PermissionError:
+        # Some constrained hosts prohibit group signalling. The allowlisted
+        # immutable-object Git commands cannot invoke repository-defined code,
+        # so terminating the parent remains safe and fail-bounded there.
+        process.send_signal(action)
+    except OSError as exc:
+        raise RepositorySecurityError("bounded Git process group could not be terminated") from exc
 
 
 def _implementation_digest() -> str:
@@ -918,7 +940,7 @@ class RepositoryScanner:
             ),
         )
         for category, code, explanation in absence_rules:
-            if not inventory[category]:
+            if not any(item.confidence == "HIGH" for item in inventory[category]):
                 findings.append(
                     _finding(
                         code,
@@ -929,7 +951,8 @@ class RepositoryScanner:
                     )
                 )
         if not any(
-            item.kind == "ROLLBACK_MECHANISM" for item in inventory["delivery_environments"]
+            item.kind == "ROLLBACK_MECHANISM" and item.confidence == "HIGH"
+            for item in inventory["delivery_environments"]
         ):
             findings.append(
                 _finding(

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -49,7 +49,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.2.0"
+SCANNER_VERSION = "repository-scanner/2.3.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -760,14 +760,16 @@ class RepositoryScanner:
             raise RepositoryIntelligenceError("repository adapter declaration is invalid")
         if command_runner is not None and type(command_runner) is not SubprocessCommandRunner:
             raise RepositorySecurityError("repository scans require the sealed Git reader")
-        if redactor is not None and type(redactor) is not EvidenceRedactor:
-            raise RepositorySecurityError("repository scans require the sealed redactor")
+        if redactor is not None:
+            raise RepositorySecurityError(
+                "exact repository scans use only the sealed fixed state-free redaction policy"
+            )
         if cancellation is not None and type(cancellation) is not CancellationSignal:
             raise RepositorySecurityError("repository scans require the sealed cancellation signal")
         self.runner = command_runner or SubprocessCommandRunner()
         # Exact-SHA snapshots never capture host environment values; excluding them
         # from the default redaction context preserves cross-host determinism.
-        self.redactor = redactor or EvidenceRedactor(environment={})
+        self.redactor = EvidenceRedactor(environment={})
         self.cancellation = cancellation
         extension_targets: list[tuple[str, Any]] = [
             ("command_runner", self.runner),
@@ -1486,6 +1488,20 @@ class RepositoryScanner:
                 severity="MEDIUM",
             )
         ]
+        gitlinks = tuple(sorted(file.path for file in files if file.mode == "160000"))
+        if gitlinks:
+            findings.append(
+                _finding(
+                    "REPOSITORY.SUBMODULE_SCOPE_UNSCANNED",
+                    "repository_topology",
+                    "Tracked gitlinks identify nested repositories whose content is outside "
+                    "this exact-tree scan; nested architecture, dependency, security, test, "
+                    "and delivery evidence remains unsupported.",
+                    gitlinks,
+                    severity="HIGH",
+                    blocking=True,
+                )
+            )
         evidenced_paths = {
             category: {item.path for item in category_items}
             for category, category_items in inventory.items()

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -52,7 +52,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.15.0"
+SCANNER_VERSION = "repository-scanner/2.16.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -1477,7 +1477,7 @@ class RepositoryScanner:
             raise RepositorySecurityError(
                 "repository scans only execute the sealed built-in adapter registry"
             )
-        self.adapters = tuple(sorted(requested_adapters, key=lambda item: item.adapter_id))
+        self._adapters = tuple(sorted(requested_adapters, key=lambda item: item.adapter_id))
         adapter_ids = [item.adapter_id for item in self.adapters]
         if len(set(adapter_ids)) != len(adapter_ids) or any(
             not item.adapter_id
@@ -1497,11 +1497,11 @@ class RepositoryScanner:
             )
         if cancellation is not None and type(cancellation) is not CancellationSignal:
             raise RepositorySecurityError("repository scans require the sealed cancellation signal")
-        self.runner = command_runner or SubprocessCommandRunner()
+        self._runner = command_runner or SubprocessCommandRunner()
         # Exact-SHA snapshots never capture host environment values; excluding them
         # from the default redaction context preserves cross-host determinism.
-        self.redactor = EvidenceRedactor(environment={})
-        self.cancellation = cancellation
+        self._redactor = EvidenceRedactor(environment={})
+        self._cancellation = cancellation
         extension_targets: list[tuple[str, Any]] = [
             ("command_runner", self.runner),
             ("redactor", self.redactor),
@@ -1510,12 +1510,75 @@ class RepositoryScanner:
         self._extension_implementation_evidence = tuple(
             _implementation_source_evidence(label, target) for label, target in extension_targets
         )
+        self._sealed_extension_evidence_digest = canonical_digest(
+            self._extension_implementation_evidence
+        )
+        self._sealed_execution_collaborators = (
+            self.adapters,
+            self.runner,
+            self.redactor,
+            self.cancellation,
+            self._extension_implementation_evidence,
+        )
+        self._sealed_execution_config = self.config
         self._commands = 0
         self._command_provenance: list[CommandProvenance] = []
         self._tool_versions: tuple[ToolVersion, ...] = ()
         self._identity_resolved = False
 
+    @property
+    def adapters(self) -> tuple[RepositoryAdapter, ...]:
+        return self._adapters
+
+    @property
+    def runner(self) -> SubprocessCommandRunner:
+        return self._runner
+
+    @property
+    def redactor(self) -> EvidenceRedactor:
+        return self._redactor
+
+    @property
+    def cancellation(self) -> CancellationSignal | None:
+        return self._cancellation
+
+    def _assert_execution_collaborators_sealed(self) -> None:
+        current = (
+            self.adapters,
+            self.runner,
+            self.redactor,
+            self.cancellation,
+            self._extension_implementation_evidence,
+        )
+        if any(
+            observed is not expected
+            for observed, expected in zip(
+                current, self._sealed_execution_collaborators, strict=True
+            )
+        ):
+            raise RepositorySecurityError(
+                "repository scan execution collaborators changed after provenance binding"
+            )
+        try:
+            extension_evidence_digest = canonical_digest(self._extension_implementation_evidence)
+        except Exception as exc:
+            raise RepositorySecurityError(
+                "repository scan implementation provenance evidence is malformed"
+            ) from exc
+        if (
+            self.config is not self._sealed_execution_config
+            or extension_evidence_digest != self._sealed_extension_evidence_digest
+            or self.redactor._environment_secrets != ()
+            or type(self.runner) is not SubprocessCommandRunner
+            or type(self.redactor) is not EvidenceRedactor
+            or (self.cancellation is not None and type(self.cancellation) is not CancellationSignal)
+        ):
+            raise RepositorySecurityError(
+                "repository scan execution collaborators are no longer sealed"
+            )
+
     def _is_cancelled(self) -> bool:
+        self._assert_execution_collaborators_sealed()
         if self.cancellation is None:
             return False
         try:
@@ -1536,31 +1599,35 @@ class RepositoryScanner:
     def _run(
         self, args: tuple[str, ...], root: Path, *, essential: bool = False
     ) -> CommandResult | None:
+        self._assert_execution_collaborators_sealed()
+        runner = self.runner
+        cancellation = self.cancellation
         if self._commands >= self.config.max_commands:
             if essential:
                 raise RepositoryIntelligenceError("read-only Git command budget was exhausted")
             return None
         self._commands += 1
         try:
-            if isinstance(self.runner, SubprocessCommandRunner):
-                result = self.runner.run(
+            if isinstance(runner, SubprocessCommandRunner):
+                result = runner.run(
                     args,
                     root,
                     self.config.command_timeout_seconds,
-                    cancellation=self.cancellation,
+                    cancellation=cancellation,
                 )
             else:
-                result = self.runner.run(args, root, self.config.command_timeout_seconds)
+                result = runner.run(args, root, self.config.command_timeout_seconds)
         except (FileNotFoundError, OSError) as exc:
             raise RepositoryIntelligenceError("read-only Git command is unavailable") from exc
         self._command_provenance.append(
             CommandProvenance(
                 args=args,
-                tool_identity=self.runner.identity,
+                tool_identity=runner.identity,
                 exit_status=result.returncode,
                 timed_out=result.timed_out,
             )
         )
+        self._assert_execution_collaborators_sealed()
         if result.timed_out:
             raise RepositoryIntelligenceError("read-only Git command timed out")
         if result.returncode == 126:
@@ -1574,22 +1641,25 @@ class RepositoryScanner:
         return result
 
     def _list_tree(self, args: tuple[str, ...], root: Path) -> TreeListingResult | None:
+        self._assert_execution_collaborators_sealed()
+        runner = self.runner
+        cancellation = self.cancellation
         if self._commands >= self.config.max_commands:
             return None
         self._commands += 1
         try:
-            if isinstance(self.runner, SubprocessCommandRunner):
-                listing = self.runner.list_tree(
+            if isinstance(runner, SubprocessCommandRunner):
+                listing = runner.list_tree(
                     args,
                     root,
                     self.config.command_timeout_seconds,
                     max_records=self.config.max_files + 1,
                     max_output_bytes=self.config.max_tree_output_bytes,
-                    cancellation=self.cancellation,
+                    cancellation=cancellation,
                 )
             else:
                 listing = TreeListingResult(
-                    result=self.runner.run(args, root, self.config.command_timeout_seconds),
+                    result=runner.run(args, root, self.config.command_timeout_seconds),
                     record_limit_exceeded=False,
                     byte_limit_exceeded=False,
                     cancelled=False,
@@ -1600,11 +1670,12 @@ class RepositoryScanner:
         self._command_provenance.append(
             CommandProvenance(
                 args=args,
-                tool_identity=self.runner.identity,
+                tool_identity=runner.identity,
                 exit_status=result.returncode,
                 timed_out=result.timed_out,
             )
         )
+        self._assert_execution_collaborators_sealed()
         if result.timed_out:
             raise RepositoryIntelligenceError("bounded tracked-tree enumeration timed out")
         if listing.cancelled:
@@ -2042,12 +2113,15 @@ class RepositoryScanner:
     def _apply_adapters(
         self, files: tuple[TrackedFile, ...]
     ) -> tuple[dict[str, list[EvidenceItem]], list[Finding], list[BoundaryCandidate], set[str]]:
+        self._assert_execution_collaborators_sealed()
+        adapters = self.adapters
         inventory: dict[str, list[EvidenceItem]] = {name: [] for name in AUDIT_CATEGORIES}
         findings: list[Finding] = []
         boundaries: list[BoundaryCandidate] = []
         supported: set[str] = set()
         context = AdapterContext(files=files)
-        for adapter in self.adapters:
+        for adapter in adapters:
+            self._assert_execution_collaborators_sealed()
             if self._is_cancelled():
                 findings.append(
                     _finding(
@@ -2068,6 +2142,7 @@ class RepositoryScanner:
                 adapter,
                 matched_context,
             )
+            self._assert_execution_collaborators_sealed()
             if status == "CANCELLED":
                 findings.append(self._cancelled_finding(f"adapter:{adapter.adapter_id}"))
                 break
@@ -2115,6 +2190,7 @@ class RepositoryScanner:
             )
             for item in boundaries
         )
+        self._assert_execution_collaborators_sealed()
         return inventory, findings, boundaries, supported
 
     @staticmethod
@@ -2805,6 +2881,10 @@ class RepositoryScanner:
         tracked_tree_digest: str | None = None,
         scanned_content_digest: str | None = None,
     ) -> RepositorySnapshot:
+        self._assert_execution_collaborators_sealed()
+        adapters = self.adapters
+        runner = self.runner
+        redactor = self.redactor
         findings = list(findings)
         statuses = dict(statuses)
         reasons = dict(reasons)
@@ -2847,13 +2927,13 @@ class RepositoryScanner:
                     "scanner_version": SCANNER_VERSION,
                     "adapter_set_digest": adapter_digest,
                     "implementation_digest": implementation_digest,
-                    "command_runner": self.runner.identity,
-                    "redactor_version": str(getattr(self.redactor, "version", "unknown")),
+                    "command_runner": runner.identity,
+                    "redactor_version": str(getattr(redactor, "version", "unknown")),
                     "tool_versions": [asdict(item) for item in self._tool_versions],
                 }
             ),
             tool_versions=self._tool_versions,
-            adapters=tuple(_metadata(adapter) for adapter in self.adapters),
+            adapters=tuple(_metadata(adapter) for adapter in adapters),
             command_provenance=tuple(self._command_provenance),
             inventory=inventory,
             findings=tuple(
@@ -2869,7 +2949,7 @@ class RepositoryScanner:
             ),
             disposition=disposition,
             redaction={
-                "version": str(getattr(self.redactor, "version", "unknown")),
+                "version": str(getattr(redactor, "version", "unknown")),
                 "status": "SANITIZED_BEFORE_PERSISTENCE",
                 "read_only_method": (
                     "allowlisted immutable Git object reads; project code not executed"
@@ -2878,11 +2958,12 @@ class RepositoryScanner:
             snapshot_digest="",
         )
         try:
-            sanitized = cast(dict[str, Any], self.redactor.sanitize(draft.as_dict()))
+            sanitized = cast(dict[str, Any], redactor.sanitize(draft.as_dict()))
         except (RedactionError, Exception) as exc:
             raise RepositorySecurityError(
                 "evidence redaction failed; artifact was not created"
             ) from exc
+        self._assert_execution_collaborators_sealed()
         if self._is_cancelled() and not any(item.code == "SCAN.CANCELLED" for item in findings):
             return self._finalize(
                 commit_sha=commit_sha,
@@ -2905,6 +2986,7 @@ class RepositoryScanner:
         return _snapshot_from_dict(sanitized)
 
     def scan(self, repository_root: Path | str, *, commit: str = "HEAD") -> RepositorySnapshot:
+        self._assert_execution_collaborators_sealed()
         self._validate_config()
         self._commands = 0
         self._command_provenance = []
@@ -2917,6 +2999,7 @@ class RepositoryScanner:
         # commit-stable provenance because equivalent refs (HEAD versus the exact SHA)
         # must yield byte-equivalent snapshots. Remaining commands are SHA-bound.
         self._command_provenance = self._command_provenance[2:]
+        self._assert_execution_collaborators_sealed()
         adapter_digest = canonical_digest([asdict(_metadata(item)) for item in self.adapters])
         config_digest = canonical_digest(asdict(self.config))
         try:

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.metadata
 import os
+import platform
 import posixpath
 import re
 import selectors
@@ -13,6 +15,8 @@ from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, cast
+
+import yaml
 
 from pmpe.contracts.canonical import canonical_digest
 from pmpe.repository.adapters import (
@@ -32,10 +36,18 @@ from pmpe.repository.models import (
     InventoryCategory,
     RepositorySnapshot,
     ScanConfig,
+    ToolVersion,
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/1.0.0"
+SCANNER_VERSION = "repository-scanner/1.1.0"
+IMPLEMENTATION_MODULES = (
+    "repository.adapters",
+    "repository.models",
+    "repository.redaction",
+    "repository.scanner",
+    "contracts.canonical",
+)
 _SHA = re.compile(r"^[0-9a-f]{40}$")
 
 
@@ -62,13 +74,14 @@ class TreeListingResult:
     result: CommandResult
     record_limit_exceeded: bool
     byte_limit_exceeded: bool
+    cancelled: bool
 
 
 class SubprocessCommandRunner:
     """Allowlisted local Git reader; it never invokes shells or project code."""
 
-    identity = "git-readonly-subprocess/1.0.0"
-    _allowed = {"rev-parse", "ls-tree", "cat-file"}
+    identity = "git-readonly-subprocess/1.1.0"
+    _allowed = {"rev-parse", "ls-tree", "cat-file", "version"}
 
     @staticmethod
     def _environment() -> dict[str, str]:
@@ -78,6 +91,14 @@ class SubprocessCommandRunner:
             "GIT_CONFIG_SYSTEM": os.devnull,
             "GIT_TERMINAL_PROMPT": "0",
             "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_CONFIG_COUNT": "3",
+            "GIT_CONFIG_KEY_0": "core.fsmonitor",
+            "GIT_CONFIG_VALUE_0": "false",
+            "GIT_CONFIG_KEY_1": "core.untrackedCache",
+            "GIT_CONFIG_VALUE_1": "false",
+            "GIT_CONFIG_KEY_2": "core.preloadIndex",
+            "GIT_CONFIG_VALUE_2": "false",
             "LC_ALL": "C",
         }
 
@@ -110,6 +131,7 @@ class SubprocessCommandRunner:
         *,
         max_records: int,
         max_output_bytes: int,
+        cancellation: Cancellation | None = None,
     ) -> TreeListingResult:
         """Stream NUL-delimited tree records and stop before unbounded buffering."""
 
@@ -132,9 +154,14 @@ class SubprocessCommandRunner:
         record_count = 0
         byte_limit = False
         timed_out = False
+        cancelled = False
         deadline = time.monotonic() + timeout
         try:
             while True:
+                if cancellation is not None and cancellation.cancelled():
+                    cancelled = True
+                    process.terminate()
+                    break
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     timed_out = True
@@ -186,7 +213,29 @@ class SubprocessCommandRunner:
             ),
             record_limit_exceeded=record_limit,
             byte_limit_exceeded=byte_limit,
+            cancelled=cancelled,
         )
+
+
+def _implementation_digest() -> str:
+    package_root = Path(__file__).resolve().parent
+    paths = {
+        "repository.adapters": package_root / "adapters.py",
+        "repository.models": package_root / "models.py",
+        "repository.redaction": package_root / "redaction.py",
+        "repository.scanner": package_root / "scanner.py",
+        "contracts.canonical": package_root.parent / "contracts" / "canonical.py",
+    }
+    try:
+        evidence = [
+            {"module": name, "source_digest": _sha256(paths[name].read_bytes())}
+            for name in IMPLEMENTATION_MODULES
+        ]
+    except OSError as exc:
+        raise RepositoryIntelligenceError(
+            "scanner implementation bytes are unavailable for provenance binding"
+        ) from exc
+    return canonical_digest(evidence)
 
 
 def _sha256(payload: bytes) -> str:
@@ -249,7 +298,7 @@ def _finding(
         explanation=explanation,
         evidence_refs=evidence_refs,
         detector_id="repository-scanner",
-        detector_version="1.0.0",
+        detector_version="1.1.0",
         blocking=blocking,
     )
 
@@ -285,11 +334,13 @@ def _snapshot_from_dict(value: dict[str, Any]) -> RepositorySnapshot:
         scanner_version=str(value["scanner_version"]),
         scan_configuration_digest=str(value["scan_configuration_digest"]),
         adapter_set_digest=str(value["adapter_set_digest"]),
+        implementation_digest=str(value["implementation_digest"]),
         tracked_tree_digest=str(value["tracked_tree_digest"]),
         scanned_content_digest=str(value["scanned_content_digest"]),
         scan_scope=str(value["scan_scope"]),
         included_paths=tuple(value["included_paths"]),
         tooling_digest=str(value["tooling_digest"]),
+        tool_versions=tuple(ToolVersion(**item) for item in value["tool_versions"]),
         adapters=tuple(AdapterMetadata(**item) for item in value["adapters"]),
         command_provenance=tuple(
             CommandProvenance(
@@ -334,6 +385,7 @@ class RepositoryScanner:
         self.cancellation = cancellation
         self._commands = 0
         self._command_provenance: list[CommandProvenance] = []
+        self._tool_versions: tuple[ToolVersion, ...] = ()
 
     def _run(
         self, args: tuple[str, ...], root: Path, *, essential: bool = False
@@ -375,12 +427,14 @@ class RepositoryScanner:
                     self.config.command_timeout_seconds,
                     max_records=self.config.max_files + 1,
                     max_output_bytes=self.config.max_tree_output_bytes,
+                    cancellation=self.cancellation,
                 )
             else:
                 listing = TreeListingResult(
                     result=self.runner.run(args, root, self.config.command_timeout_seconds),
                     record_limit_exceeded=False,
                     byte_limit_exceeded=False,
+                    cancelled=False,
                 )
         except (FileNotFoundError, OSError) as exc:
             raise RepositoryIntelligenceError("read-only Git command is unavailable") from exc
@@ -395,6 +449,8 @@ class RepositoryScanner:
         )
         if result.timed_out:
             raise RepositoryIntelligenceError("bounded tracked-tree enumeration timed out")
+        if listing.cancelled:
+            return listing
         if result.returncode != 0 and not (
             listing.record_limit_exceeded or listing.byte_limit_exceeded
         ):
@@ -421,6 +477,36 @@ class RepositoryScanner:
                 raise RepositorySecurityError(
                     "configured scan paths must be contained in the repository"
                 )
+
+    def _collect_tool_versions(self, root: Path) -> tuple[ToolVersion, ...]:
+        try:
+            git_result = self.runner.run(
+                ("git", "version"), root, self.config.command_timeout_seconds
+            )
+            if git_result.timed_out or git_result.returncode != 0:
+                raise RepositoryIntelligenceError("Git version command failed")
+            git_version = _text(git_result.stdout).strip()
+            canonicalizer_version = importlib.metadata.version("rfc8785")
+        except (
+            FileNotFoundError,
+            OSError,
+            UnicodeDecodeError,
+            importlib.metadata.PackageNotFoundError,
+        ) as exc:
+            raise RepositoryIntelligenceError("scanner tool versions are unavailable") from exc
+        if not git_version.startswith("git version "):
+            raise RepositoryIntelligenceError("Git version output is malformed")
+        return tuple(
+            sorted(
+                (
+                    ToolVersion("git", git_version.removeprefix("git version ")),
+                    ToolVersion("python", platform.python_version()),
+                    ToolVersion("pyyaml", str(yaml.__version__)),
+                    ToolVersion("rfc8785", canonicalizer_version),
+                ),
+                key=lambda item: item.tool,
+            )
+        )
 
     def _cancelled_snapshot(
         self,
@@ -528,6 +614,16 @@ class RepositoryScanner:
             )
             return [], findings, tracked_tree_digest, canonical_digest([])
         listing = bounded_listing.result
+        if bounded_listing.cancelled:
+            findings.append(
+                _finding(
+                    "SCAN.CANCELLED",
+                    "repository_topology",
+                    "The scan was cancelled during bounded tracked-tree enumeration.",
+                    ("repository:tracked-tree",),
+                    blocking=True,
+                )
+            )
         if bounded_listing.byte_limit_exceeded:
             findings.append(
                 _finding(
@@ -603,6 +699,17 @@ class RepositoryScanner:
         total = 0
         total_exhausted = False
         for mode, object_type, object_id, path, size in entries:
+            if self.cancellation is not None and self.cancellation.cancelled():
+                findings.append(
+                    _finding(
+                        "SCAN.CANCELLED",
+                        "repository_topology",
+                        "The scan was cancelled before every tracked blob was inspected.",
+                        (path,),
+                        blocking=True,
+                    )
+                )
+                break
             if len(PurePosixPath(path).parts) > self.config.max_path_depth:
                 findings.append(
                     _finding(
@@ -706,9 +813,22 @@ class RepositoryScanner:
         supported: set[str] = set()
         context = AdapterContext(files=files)
         for adapter in self.adapters:
+            if self.cancellation is not None and self.cancellation.cancelled():
+                findings.append(
+                    _finding(
+                        "SCAN.CANCELLED",
+                        "repository_topology",
+                        "The scan was cancelled during adapter evaluation.",
+                        (f"adapter:{adapter.adapter_id}",),
+                        blocking=True,
+                    )
+                )
+                break
             supported.update(adapter.supported_categories)
             try:
-                result = adapter.evaluator(context)
+                result = adapter.evaluator(
+                    AdapterContext(files=context.matching(adapter.file_patterns))
+                )
             except Exception:
                 findings.append(
                     _finding(
@@ -745,7 +865,16 @@ class RepositoryScanner:
     def _cross_cutting_findings(
         self, files: tuple[TrackedFile, ...], inventory: dict[str, list[EvidenceItem]]
     ) -> list[Finding]:
-        findings: list[Finding] = []
+        findings: list[Finding] = [
+            _finding(
+                "ARCHITECTURE.HISTORY_COUPLING_UNSUPPORTED",
+                "architecture_boundaries",
+                "High-change and temporal-coupling analysis is unsupported by an exact-tree "
+                "snapshot without governed history inputs; no hotspot was inferred.",
+                ("repository:exact-tree",),
+                severity="MEDIUM",
+            )
+        ]
         expected_test_kinds = {
             "unit": "UNIT_TEST_FILE_SIGNAL",
             "integration": "INTEGRATION_TEST_FILE_SIGNAL",
@@ -986,6 +1115,7 @@ class RepositoryScanner:
         tracked_tree_digest: str | None = None,
         scanned_content_digest: str | None = None,
     ) -> RepositorySnapshot:
+        implementation_digest = _implementation_digest()
         inventory = {
             name: InventoryCategory(
                 status=statuses.get(name, "SUPPORTED"),
@@ -1008,6 +1138,7 @@ class RepositoryScanner:
             scanner_version=SCANNER_VERSION,
             scan_configuration_digest=config_digest,
             adapter_set_digest=adapter_digest,
+            implementation_digest=implementation_digest,
             tracked_tree_digest=tracked_tree_digest or canonical_digest([]),
             scanned_content_digest=scanned_content_digest or canonical_digest([]),
             scan_scope=("INCLUDED_PATHS" if self.config.include_paths else "FULL_REPOSITORY"),
@@ -1016,10 +1147,13 @@ class RepositoryScanner:
                 {
                     "scanner_version": SCANNER_VERSION,
                     "adapter_set_digest": adapter_digest,
+                    "implementation_digest": implementation_digest,
                     "command_runner": self.runner.identity,
                     "redactor_version": str(getattr(self.redactor, "version", "unknown")),
+                    "tool_versions": [asdict(item) for item in self._tool_versions],
                 }
             ),
+            tool_versions=self._tool_versions,
             adapters=tuple(_metadata(adapter) for adapter in self.adapters),
             command_provenance=tuple(self._command_provenance),
             inventory=inventory,
@@ -1045,7 +1179,7 @@ class RepositoryScanner:
             snapshot_digest="",
         )
         try:
-            sanitized = cast(dict[str, Any], self.redactor.sanitize(asdict(draft)))
+            sanitized = cast(dict[str, Any], self.redactor.sanitize(draft.as_dict()))
         except (RedactionError, Exception) as exc:
             raise RepositorySecurityError(
                 "evidence redaction failed; artifact was not created"
@@ -1066,6 +1200,7 @@ class RepositoryScanner:
         # commit-stable provenance because equivalent refs (HEAD versus the exact SHA)
         # must yield byte-equivalent snapshots. Remaining commands are SHA-bound.
         self._command_provenance = self._command_provenance[2:]
+        self._tool_versions = self._collect_tool_versions(root)
         adapter_digest = canonical_digest([asdict(_metadata(item)) for item in self.adapters])
         config_digest = canonical_digest(asdict(self.config))
         if self.cancellation is not None and self.cancellation.cancelled():
@@ -1088,7 +1223,8 @@ class RepositoryScanner:
                     severity="MEDIUM",
                 )
             )
-        findings.extend(self._cross_cutting_findings(tuple(files), inventory))
+        if not any(item.code == "SCAN.CANCELLED" for item in findings):
+            findings.extend(self._cross_cutting_findings(tuple(files), inventory))
         statuses = {
             name: (
                 "OBSERVED"
@@ -1131,6 +1267,7 @@ class RepositoryScanner:
             "MANIFEST.MALFORMED",
             "WORKFLOW.MALFORMED",
             "SCAN.SCOPED_PARTIAL",
+            "SCAN.CANCELLED",
         }
         partial = any(item.code in partial_codes for item in findings)
         if partial:

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -49,7 +49,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.1.0"
+SCANNER_VERSION = "repository-scanner/2.2.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -1653,12 +1653,24 @@ class RepositoryScanner:
             ".dockerignore",
             ".typed",
         }
+        # A non-generic item from a sealed adapter proves that the file's role is
+        # already understood.  Do not then contradict that evidence merely because
+        # the file uses a domain-specific suffix (for example .proto, .graphql,
+        # Dockerfile.dev, or .env.production).  Repository-topology's TRACKED_FILE
+        # item is intentionally excluded because it says nothing about file type.
+        classified_paths = {
+            item.path
+            for category, category_items in inventory.items()
+            if category != "repository_topology"
+            for item in category_items
+        }
         unknown = [
             file.path
             for file in files
             if PurePosixPath(file.path).suffix
             and PurePosixPath(file.path).suffix.lower() not in known_suffixes
             and not file.binary
+            and file.path not in classified_paths
         ]
         unsupported_source_suffixes = {
             ".sh",

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -1,0 +1,871 @@
+"""Read-only exact-Git-object repository scanner."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import posixpath
+import re
+import subprocess
+from collections.abc import Sequence
+from dataclasses import asdict
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol, cast
+
+from pmpe.contracts.canonical import canonical_digest
+from pmpe.repository.adapters import (
+    AdapterContext,
+    RepositoryAdapter,
+    TrackedFile,
+    default_adapters,
+)
+from pmpe.repository.models import (
+    AUDIT_CATEGORIES,
+    AdapterMetadata,
+    BoundaryCandidate,
+    CommandProvenance,
+    CommandResult,
+    EvidenceItem,
+    Finding,
+    InventoryCategory,
+    RepositorySnapshot,
+    ScanConfig,
+)
+from pmpe.repository.redaction import EvidenceRedactor, RedactionError
+
+SCANNER_VERSION = "repository-scanner/1.0.0"
+_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+class RepositoryIntelligenceError(RuntimeError):
+    """Safe fail-closed repository-intelligence failure."""
+
+
+class RepositorySecurityError(RepositoryIntelligenceError):
+    """A containment or evidence-safety guarantee could not be established."""
+
+
+class CommandRunner(Protocol):
+    identity: str
+
+    def run(self, args: tuple[str, ...], cwd: Path, timeout: int) -> CommandResult: ...
+
+
+class Cancellation(Protocol):
+    def cancelled(self) -> bool: ...
+
+
+class SubprocessCommandRunner:
+    """Allowlisted local Git reader; it never invokes shells or project code."""
+
+    identity = "git-readonly-subprocess/1.0.0"
+    _allowed = {"rev-parse", "ls-tree", "cat-file"}
+
+    def run(self, args: tuple[str, ...], cwd: Path, timeout: int) -> CommandResult:
+        if len(args) < 2 or args[0] != "git" or args[1] not in self._allowed:
+            raise RepositorySecurityError("command is outside the read-only Git allowlist")
+        safe_environment = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "LC_ALL": "C",
+        }
+        try:
+            result = subprocess.run(
+                args,
+                cwd=cwd,
+                capture_output=True,
+                check=False,
+                timeout=timeout,
+                env=safe_environment,
+            )
+        except subprocess.TimeoutExpired:
+            return CommandResult(args=args, returncode=124, stdout=b"", stderr=b"", timed_out=True)
+        return CommandResult(
+            args=args,
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+
+def _sha256(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _text(value: str | bytes) -> str:
+    return value.decode("utf-8", errors="strict") if isinstance(value, bytes) else value
+
+
+def _safe_relative_path(value: str) -> bool:
+    path = PurePosixPath(value)
+    return not path.is_absolute() and ".." not in path.parts and value not in {"", "."}
+
+
+def _symlink_escapes(path: str, target: bytes | None) -> bool:
+    if target is None:
+        return True
+    try:
+        value = target.decode("utf-8")
+    except UnicodeDecodeError:
+        return True
+    if PurePosixPath(value).is_absolute():
+        return True
+    joined = posixpath.normpath(posixpath.join(posixpath.dirname(path), value))
+    return joined == ".." or joined.startswith("../")
+
+
+def _finding(
+    code: str,
+    category: str,
+    explanation: str,
+    evidence_refs: tuple[str, ...],
+    *,
+    blocking: bool = False,
+    severity: str = "HIGH",
+) -> Finding:
+    return Finding(
+        code=code,
+        category=category,
+        severity=severity,
+        confidence="HIGH",
+        explanation=explanation,
+        evidence_refs=evidence_refs,
+        detector_id="repository-scanner",
+        detector_version="1.0.0",
+        blocking=blocking,
+    )
+
+
+def _metadata(adapter: RepositoryAdapter) -> AdapterMetadata:
+    return AdapterMetadata(
+        adapter_id=adapter.adapter_id,
+        version=adapter.version,
+        file_patterns=adapter.file_patterns,
+        supported_categories=adapter.supported_categories,
+        failure_behavior=adapter.failure_behavior,
+        detection_logic=adapter.detection_logic,
+        evidence_emitted=adapter.evidence_emitted,
+        confidence_semantics=adapter.confidence_semantics,
+    )
+
+
+def _snapshot_from_dict(value: dict[str, Any]) -> RepositorySnapshot:
+    inventory = {
+        name: InventoryCategory(
+            status=str(category["status"]),
+            items=tuple(EvidenceItem(**item) for item in category["items"]),
+            reason=str(category["reason"]),
+        )
+        for name, category in cast(dict[str, dict[str, Any]], value["inventory"]).items()
+    }
+    return RepositorySnapshot(
+        repository=str(value["repository"]),
+        commit_sha=str(value["commit_sha"]),
+        tree_sha=str(value["tree_sha"]),
+        default_branch=cast(str | None, value["default_branch"]),
+        scanner_version=str(value["scanner_version"]),
+        scan_configuration_digest=str(value["scan_configuration_digest"]),
+        adapter_set_digest=str(value["adapter_set_digest"]),
+        tracked_tree_digest=str(value["tracked_tree_digest"]),
+        tooling_digest=str(value["tooling_digest"]),
+        adapters=tuple(AdapterMetadata(**item) for item in value["adapters"]),
+        command_provenance=tuple(
+            CommandProvenance(
+                args=tuple(item["args"]),
+                tool_identity=str(item["tool_identity"]),
+                exit_status=int(item["exit_status"]),
+                timed_out=bool(item["timed_out"]),
+            )
+            for item in value["command_provenance"]
+        ),
+        inventory=inventory,
+        findings=tuple(Finding(**item) for item in value["findings"]),
+        boundary_candidates=tuple(
+            BoundaryCandidate(**item) for item in value["boundary_candidates"]
+        ),
+        unsupported_categories=tuple(value["unsupported_categories"]),
+        disposition=str(value["disposition"]),
+        redaction=cast(dict[str, Any], value["redaction"]),
+        snapshot_digest=str(value["snapshot_digest"]),
+        artifact_kind=str(value["artifact_kind"]),
+    )
+
+
+class RepositoryScanner:
+    """Create a deterministic artifact from immutable tracked Git objects only."""
+
+    def __init__(
+        self,
+        *,
+        config: ScanConfig,
+        adapters: Sequence[RepositoryAdapter] | None = None,
+        command_runner: CommandRunner | None = None,
+        redactor: Any | None = None,
+        cancellation: Cancellation | None = None,
+    ) -> None:
+        self.config = config
+        self.adapters = tuple(
+            sorted(adapters or default_adapters(), key=lambda item: item.adapter_id)
+        )
+        self.runner = command_runner or SubprocessCommandRunner()
+        self.redactor = redactor or EvidenceRedactor()
+        self.cancellation = cancellation
+        self._commands = 0
+        self._command_provenance: list[CommandProvenance] = []
+
+    def _run(
+        self, args: tuple[str, ...], root: Path, *, essential: bool = False
+    ) -> CommandResult | None:
+        if self._commands >= self.config.max_commands:
+            if essential:
+                raise RepositoryIntelligenceError("read-only Git command budget was exhausted")
+            return None
+        self._commands += 1
+        try:
+            result = self.runner.run(args, root, self.config.command_timeout_seconds)
+        except (FileNotFoundError, OSError) as exc:
+            raise RepositoryIntelligenceError("read-only Git command is unavailable") from exc
+        self._command_provenance.append(
+            CommandProvenance(
+                args=args,
+                tool_identity=self.runner.identity,
+                exit_status=result.returncode,
+                timed_out=result.timed_out,
+            )
+        )
+        if result.timed_out:
+            raise RepositoryIntelligenceError("read-only Git command timed out")
+        if result.returncode != 0:
+            if essential:
+                raise RepositoryIntelligenceError("path is not an accessible Git repository")
+            raise RepositoryIntelligenceError("an immutable Git object could not be read")
+        return result
+
+    def _validate_config(self) -> None:
+        if not self.config.repository.strip():
+            raise RepositoryIntelligenceError("repository identity is required")
+        positive = (
+            self.config.max_files,
+            self.config.max_directories,
+            self.config.max_total_bytes,
+            self.config.max_file_bytes,
+            self.config.max_commands,
+            self.config.command_timeout_seconds,
+            self.config.max_path_depth,
+        )
+        if any(value <= 0 for value in positive):
+            raise RepositoryIntelligenceError("scan budgets must be positive")
+        for path in self.config.include_paths:
+            if not _safe_relative_path(path):
+                raise RepositorySecurityError(
+                    "configured scan paths must be contained in the repository"
+                )
+
+    def _cancelled_snapshot(
+        self,
+        root: Path,
+        commit_sha: str,
+        tree_sha: str,
+        config_digest: str,
+        adapter_digest: str,
+    ) -> RepositorySnapshot:
+        finding = _finding(
+            "SCAN.CANCELLED",
+            "repository_topology",
+            "The scan was cancelled before repository content was read.",
+            ("repository:scan",),
+            blocking=True,
+        )
+        return self._finalize(
+            commit_sha=commit_sha,
+            tree_sha=tree_sha,
+            config_digest=config_digest,
+            adapter_digest=adapter_digest,
+            inventory_items={},
+            findings=[finding],
+            boundaries=[],
+            statuses=dict.fromkeys(AUDIT_CATEGORIES, "BLOCKED"),
+            reasons=dict.fromkeys(AUDIT_CATEGORIES, "scan cancelled"),
+            disposition="BLOCKED",
+        )
+
+    def _resolve_identity(self, requested: Path) -> tuple[Path, str, str]:
+        root_result = self._run(("git", "rev-parse", "--show-toplevel"), requested, essential=True)
+        assert root_result is not None
+        try:
+            root = Path(_text(root_result.stdout).strip()).resolve(strict=True)
+        except (UnicodeDecodeError, OSError) as exc:
+            raise RepositoryIntelligenceError("Git repository root is malformed") from exc
+        if root != requested.resolve() and root not in requested.resolve().parents:
+            raise RepositorySecurityError(
+                "resolved Git repository root is outside the requested path"
+            )
+        commit_result = self._run(
+            (
+                "git",
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                f"{self._requested_commit}^{{commit}}",
+            ),
+            root,
+            essential=True,
+        )
+        assert commit_result is not None
+        try:
+            commit_sha = _text(commit_result.stdout).strip()
+        except UnicodeDecodeError as exc:
+            raise RepositoryIntelligenceError("Git commit identity is malformed") from exc
+        if not _SHA.fullmatch(commit_sha):
+            raise RepositoryIntelligenceError("Git commit identity is malformed")
+        tree_result = self._run(
+            (
+                "git",
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                f"{commit_sha}^{{tree}}",
+            ),
+            root,
+        )
+        if tree_result is None:
+            return root, commit_sha, "0" * 40
+        try:
+            tree_sha = _text(tree_result.stdout).strip()
+        except UnicodeDecodeError as exc:
+            raise RepositoryIntelligenceError("Git tree identity is malformed") from exc
+        if not _SHA.fullmatch(tree_sha):
+            raise RepositoryIntelligenceError("Git tree identity is malformed")
+        return root, commit_sha, tree_sha
+
+    def _list_files(
+        self, root: Path, commit_sha: str, tree_sha: str
+    ) -> tuple[list[TrackedFile], list[Finding], str]:
+        findings: list[Finding] = []
+        if tree_sha == "0" * 40:
+            findings.append(
+                _finding(
+                    "BUDGET.COMMAND_COUNT",
+                    "repository_topology",
+                    "The command budget ended before the tracked tree could be enumerated.",
+                    ("repository:scan-budget",),
+                )
+            )
+            return [], findings, canonical_digest([])
+        listing = self._run(("git", "ls-tree", "-r", "-z", "-l", "--full-tree", commit_sha), root)
+        if listing is None:
+            findings.append(
+                _finding(
+                    "BUDGET.COMMAND_COUNT",
+                    "repository_topology",
+                    "The command budget ended before the tracked tree could be enumerated.",
+                    ("repository:scan-budget",),
+                )
+            )
+            return [], findings, canonical_digest([])
+        raw = listing.stdout if isinstance(listing.stdout, bytes) else listing.stdout.encode()
+        entries: list[tuple[str, str, str, str, int]] = []
+        for record in raw.split(b"\0"):
+            if not record:
+                continue
+            try:
+                metadata, raw_path = record.split(b"\t", 1)
+                mode, object_type, object_id, raw_size = metadata.decode("ascii").split()
+                path = raw_path.decode("utf-8")
+                size = int(raw_size) if raw_size != "-" else 0
+            except (ValueError, UnicodeDecodeError) as exc:
+                raise RepositoryIntelligenceError("tracked-tree output is malformed") from exc
+            if object_type not in {"blob", "commit"} or not _SHA.fullmatch(object_id):
+                raise RepositoryIntelligenceError("tracked-tree output is malformed")
+            if object_type == "commit" and mode != "160000":
+                raise RepositoryIntelligenceError("tracked-tree output is malformed")
+            if not _safe_relative_path(path):
+                raise RepositoryIntelligenceError("tracked-tree output is malformed")
+            if self.config.include_paths and not any(
+                path == prefix or path.startswith(prefix.rstrip("/") + "/")
+                for prefix in self.config.include_paths
+            ):
+                continue
+            entries.append((mode, object_type, object_id, path, size))
+        entries.sort(key=lambda item: item[3])
+        tracked_tree_digest = canonical_digest(
+            [
+                {
+                    "mode": mode,
+                    "object_type": object_type,
+                    "object_id": object_id,
+                    "path": path,
+                    "size": size,
+                }
+                for mode, object_type, object_id, path, size in entries
+            ]
+        )
+        if len(entries) > self.config.max_files:
+            findings.append(
+                _finding(
+                    "BUDGET.FILE_COUNT",
+                    "repository_topology",
+                    "The tracked file-count budget was exceeded; results are explicitly partial.",
+                    ("repository:tracked-tree",),
+                )
+            )
+            entries = entries[: self.config.max_files]
+        directories = sorted(
+            {
+                "/".join(PurePosixPath(path).parts[:depth])
+                for _, _, _, path, _ in entries
+                for depth in range(1, len(PurePosixPath(path).parts))
+            }
+        )
+        if len(directories) > self.config.max_directories:
+            allowed_directories = set(directories[: self.config.max_directories])
+            findings.append(
+                _finding(
+                    "BUDGET.DIRECTORY_COUNT",
+                    "repository_topology",
+                    "The tracked directory-count budget was exceeded; results are explicitly "
+                    "partial.",
+                    ("repository:tracked-tree",),
+                )
+            )
+            entries = [
+                entry
+                for entry in entries
+                if all(
+                    "/".join(PurePosixPath(entry[3]).parts[:depth]) in allowed_directories
+                    for depth in range(1, len(PurePosixPath(entry[3]).parts))
+                )
+            ]
+        files: list[TrackedFile] = []
+        total = 0
+        total_exhausted = False
+        for mode, object_type, object_id, path, size in entries:
+            if len(PurePosixPath(path).parts) > self.config.max_path_depth:
+                findings.append(
+                    _finding(
+                        "BUDGET.PATH_DEPTH",
+                        "repository_topology",
+                        "A tracked path exceeds the configured traversal depth.",
+                        (path,),
+                    )
+                )
+                continue
+            if total + size > self.config.max_total_bytes:
+                if not total_exhausted:
+                    findings.append(
+                        _finding(
+                            "BUDGET.TOTAL_BYTES",
+                            "repository_topology",
+                            "The aggregate byte budget was exceeded; results are explicitly "
+                            "partial.",
+                            (path,),
+                        )
+                    )
+                    total_exhausted = True
+                continue
+            total += size
+            if object_type == "commit":
+                files.append(
+                    TrackedFile(
+                        path=path,
+                        mode=mode,
+                        object_id=object_id,
+                        digest=f"git-object:{object_id}",
+                        content=None,
+                        binary=False,
+                    )
+                )
+                continue
+            oversized = size > self.config.max_file_bytes
+            if oversized:
+                findings.append(
+                    _finding(
+                        "BUDGET.FILE_BYTES",
+                        "repository_topology",
+                        "A tracked file exceeds the per-file byte budget.",
+                        (path,),
+                    )
+                )
+                files.append(
+                    TrackedFile(
+                        path=path,
+                        mode=mode,
+                        object_id=object_id,
+                        digest=f"git-blob:{object_id}",
+                        content=None,
+                        binary=False,
+                        oversized=True,
+                    )
+                )
+                continue
+            result = self._run(("git", "cat-file", "blob", f"{commit_sha}:{path}"), root)
+            if result is None:
+                findings.append(
+                    _finding(
+                        "BUDGET.COMMAND_COUNT",
+                        "repository_topology",
+                        "The command budget ended before every tracked blob could be inspected.",
+                        (path,),
+                    )
+                )
+                break
+            content = result.stdout if isinstance(result.stdout, bytes) else result.stdout.encode()
+            files.append(
+                TrackedFile(
+                    path=path,
+                    mode=mode,
+                    object_id=object_id,
+                    digest=_sha256(content),
+                    content=content,
+                    binary=b"\0" in content,
+                )
+            )
+        return files, findings, tracked_tree_digest
+
+    def _apply_adapters(
+        self, files: tuple[TrackedFile, ...]
+    ) -> tuple[dict[str, list[EvidenceItem]], list[Finding], list[BoundaryCandidate], set[str]]:
+        inventory: dict[str, list[EvidenceItem]] = {name: [] for name in AUDIT_CATEGORIES}
+        findings: list[Finding] = []
+        boundaries: list[BoundaryCandidate] = []
+        supported: set[str] = set()
+        context = AdapterContext(files=files)
+        for adapter in self.adapters:
+            supported.update(adapter.supported_categories)
+            try:
+                result = adapter.evaluator(context)
+            except Exception:
+                findings.append(
+                    _finding(
+                        "ADAPTER.FAILURE",
+                        adapter.supported_categories[0],
+                        f"Adapter {adapter.adapter_id} failed; its categories remain visibly "
+                        "partial.",
+                        (f"adapter:{adapter.adapter_id}",),
+                        blocking=False,
+                    )
+                )
+                continue
+            for category, item in result.items:
+                if category in inventory:
+                    inventory[category].append(item)
+            findings.extend(result.findings)
+            boundaries.extend(result.boundaries)
+        inventory["architecture_boundaries"].extend(
+            EvidenceItem(
+                kind=f"BOUNDARY_{item.kind}",
+                path=item.evidence_paths[0],
+                file_digest=next(
+                    (file.digest for file in files if file.path == item.evidence_paths[0]),
+                    "sha256:" + "0" * 64,
+                ),
+                detector_id=item.detector_id,
+                detector_version=item.detector_version,
+                confidence=item.confidence,
+            )
+            for item in boundaries
+        )
+        return inventory, findings, boundaries, supported
+
+    def _cross_cutting_findings(
+        self, files: tuple[TrackedFile, ...], inventory: dict[str, list[EvidenceItem]]
+    ) -> list[Finding]:
+        findings: list[Finding] = []
+        if not inventory["tests_quality"]:
+            findings.append(
+                _finding(
+                    "QUALITY.TEST_CATEGORY_ABSENT",
+                    "tests_quality",
+                    "No deterministic tracked evidence of a test category was observed.",
+                    ("repository:tracked-tree",),
+                    severity="MEDIUM",
+                )
+            )
+        absence_rules = (
+            (
+                "security_privacy",
+                "SECURITY.CONTROL_EVIDENCE_ABSENT",
+                "No tracked security-control configuration was observed.",
+            ),
+            (
+                "observability_operations",
+                "OPERATIONS.OBSERVABILITY_EVIDENCE_ABSENT",
+                "No tracked logs, metrics, traces, alerts, SLO, or health-check evidence "
+                "was observed.",
+            ),
+            (
+                "documentation_governance",
+                "GOVERNANCE.DOCUMENTATION_EVIDENCE_ABSENT",
+                "No tracked repository governance document was observed.",
+            ),
+        )
+        for category, code, explanation in absence_rules:
+            if not inventory[category]:
+                findings.append(
+                    _finding(
+                        code,
+                        "debt_risk",
+                        explanation,
+                        ("repository:tracked-tree",),
+                        severity="MEDIUM",
+                    )
+                )
+        if not any(
+            item.kind == "ROLLBACK_MECHANISM" for item in inventory["delivery_environments"]
+        ):
+            findings.append(
+                _finding(
+                    "DELIVERY.ROLLBACK_EVIDENCE_ABSENT",
+                    "debt_risk",
+                    "No tracked rollback mechanism was observed; this is an evidence gap, "
+                    "not proof that operational rollback is impossible.",
+                    ("category:delivery_environments",),
+                    severity="MEDIUM",
+                )
+            )
+        python_versions: set[str] = set()
+        for file in files:
+            if file.content is None or file.binary:
+                continue
+            if file.path == ".python-version":
+                python_versions.add(file.content.decode("utf-8", errors="ignore").strip())
+            if "dockerfile" in PurePosixPath(file.path).name.lower():
+                match = re.search(rb"\bpython:([0-9]+(?:\.[0-9]+)?)", file.content)
+                if match:
+                    python_versions.add(match.group(1).decode())
+        if len(python_versions) > 1:
+            findings.append(
+                _finding(
+                    "RUNTIME.VERSION_DRIFT_SIGNAL",
+                    "debt_risk",
+                    "Different tracked Python runtime declarations were observed; this is a "
+                    "drift signal.",
+                    tuple(sorted(python_versions)),
+                    severity="MEDIUM",
+                )
+            )
+        known_suffixes = {
+            ".md",
+            ".txt",
+            ".py",
+            ".pyi",
+            ".json",
+            ".yaml",
+            ".yml",
+            ".toml",
+            ".lock",
+            ".js",
+            ".jsx",
+            ".ts",
+            ".tsx",
+            ".sql",
+            ".sh",
+            ".ini",
+            ".cfg",
+            ".dockerignore",
+        }
+        unknown = [
+            file.path
+            for file in files
+            if PurePosixPath(file.path).suffix
+            and PurePosixPath(file.path).suffix.lower() not in known_suffixes
+            and not file.binary
+        ]
+        if unknown and not inventory["languages_build_ecosystems"]:
+            findings.append(
+                _finding(
+                    "STACK.UNSUPPORTED",
+                    "languages_build_ecosystems",
+                    "Tracked source belongs to an unsupported ecosystem; no stack was inferred.",
+                    tuple(sorted(unknown)),
+                    blocking=True,
+                )
+            )
+        for file in files:
+            if file.mode == "120000" and _symlink_escapes(file.path, file.content):
+                findings.append(
+                    _finding(
+                        "SECURITY.SYMLINK_ESCAPE",
+                        "security_privacy",
+                        "A tracked symlink resolves outside the repository root and was not "
+                        "followed.",
+                        (file.path,),
+                        blocking=True,
+                        severity="CRITICAL",
+                    )
+                )
+        return findings
+
+    def _finalize(
+        self,
+        *,
+        commit_sha: str,
+        tree_sha: str,
+        config_digest: str,
+        adapter_digest: str,
+        inventory_items: dict[str, list[EvidenceItem]],
+        findings: list[Finding],
+        boundaries: list[BoundaryCandidate],
+        statuses: dict[str, str],
+        reasons: dict[str, str],
+        disposition: str,
+        tracked_tree_digest: str | None = None,
+    ) -> RepositorySnapshot:
+        inventory = {
+            name: InventoryCategory(
+                status=statuses.get(name, "SUPPORTED"),
+                items=tuple(
+                    sorted(
+                        inventory_items.get(name, []),
+                        key=lambda item: (item.path, item.kind, item.detector_id),
+                    )
+                ),
+                reason=reasons.get(name, ""),
+            )
+            for name in AUDIT_CATEGORIES
+        }
+        draft = RepositorySnapshot(
+            repository=self.config.repository,
+            commit_sha=commit_sha,
+            tree_sha=tree_sha,
+            default_branch=self.config.default_branch,
+            scanner_version=SCANNER_VERSION,
+            scan_configuration_digest=config_digest,
+            adapter_set_digest=adapter_digest,
+            tracked_tree_digest=tracked_tree_digest or canonical_digest([]),
+            tooling_digest=canonical_digest(
+                {
+                    "scanner_version": SCANNER_VERSION,
+                    "adapter_set_digest": adapter_digest,
+                    "command_runner": self.runner.identity,
+                    "redactor_version": str(getattr(self.redactor, "version", "unknown")),
+                }
+            ),
+            adapters=tuple(_metadata(adapter) for adapter in self.adapters),
+            command_provenance=tuple(self._command_provenance),
+            inventory=inventory,
+            findings=tuple(
+                sorted(findings, key=lambda item: (item.code, item.evidence_refs, item.detector_id))
+            ),
+            boundary_candidates=tuple(
+                sorted(boundaries, key=lambda item: (item.kind, item.name, item.evidence_paths))
+            ),
+            unsupported_categories=tuple(
+                name
+                for name in AUDIT_CATEGORIES
+                if statuses.get(name) in {"UNSUPPORTED", "BLOCKED"}
+            ),
+            disposition=disposition,
+            redaction={
+                "version": str(getattr(self.redactor, "version", "unknown")),
+                "status": "SANITIZED_BEFORE_PERSISTENCE",
+                "read_only_method": (
+                    "allowlisted immutable Git object reads; project code not executed"
+                ),
+            },
+            snapshot_digest="",
+        )
+        try:
+            sanitized = cast(dict[str, Any], self.redactor.sanitize(asdict(draft)))
+        except (RedactionError, Exception) as exc:
+            raise RepositorySecurityError(
+                "evidence redaction failed; artifact was not created"
+            ) from exc
+        sanitized["snapshot_digest"] = canonical_digest(
+            {key: value for key, value in sanitized.items() if key != "snapshot_digest"}
+        )
+        return _snapshot_from_dict(sanitized)
+
+    def scan(self, repository_root: Path | str, *, commit: str = "HEAD") -> RepositorySnapshot:
+        self._validate_config()
+        self._commands = 0
+        self._command_provenance = []
+        self._requested_commit = commit
+        requested = Path(repository_root).resolve()
+        root, commit_sha, tree_sha = self._resolve_identity(requested)
+        # Root/ref resolution establishes the immutable identity but is excluded from
+        # commit-stable provenance because equivalent refs (HEAD versus the exact SHA)
+        # must yield byte-equivalent snapshots. Remaining commands are SHA-bound.
+        self._command_provenance = self._command_provenance[2:]
+        adapter_digest = canonical_digest([asdict(_metadata(item)) for item in self.adapters])
+        config_digest = canonical_digest(asdict(self.config))
+        if self.cancellation is not None and self.cancellation.cancelled():
+            return self._cancelled_snapshot(
+                root, commit_sha, tree_sha, config_digest, adapter_digest
+            )
+        files, budget_findings, tree_digest = self._list_files(root, commit_sha, tree_sha)
+        inventory, adapter_findings, boundaries, supported = self._apply_adapters(tuple(files))
+        findings = budget_findings + adapter_findings
+        findings.extend(self._cross_cutting_findings(tuple(files), inventory))
+        statuses = {
+            name: (
+                "OBSERVED"
+                if inventory[name]
+                else "NOT_OBSERVED"
+                if name in supported
+                else "UNSUPPORTED"
+            )
+            for name in AUDIT_CATEGORIES
+        }
+        reasons = {
+            name: "No versioned adapter supports this category."
+            for name in AUDIT_CATEGORIES
+            if name not in supported
+        }
+        statuses["active_divergent_work"] = "UNSUPPORTED"
+        reasons["active_divergent_work"] = (
+            "Mutable branch, worktree, PR, issue, and governance facts belong only in "
+            "GovernanceObservation."
+        )
+        if any(item.code == "STACK.UNSUPPORTED" for item in findings):
+            statuses["languages_build_ecosystems"] = "UNSUPPORTED"
+            reasons["languages_build_ecosystems"] = (
+                "The tracked ecosystem has no deterministic adapter."
+            )
+        unsupported_required = any(
+            status in {"UNSUPPORTED", "BLOCKED"} and name != "active_divergent_work"
+            for name, status in statuses.items()
+        )
+        blocking = any(item.blocking for item in findings) or unsupported_required
+        partial_codes = {
+            "ADAPTER.FAILURE",
+            "BUDGET.FILE_COUNT",
+            "BUDGET.DIRECTORY_COUNT",
+            "BUDGET.TOTAL_BYTES",
+            "BUDGET.FILE_BYTES",
+            "BUDGET.PATH_DEPTH",
+            "BUDGET.COMMAND_COUNT",
+            "MANIFEST.MALFORMED",
+            "WORKFLOW.MALFORMED",
+        }
+        partial = any(item.code in partial_codes for item in findings)
+        if partial:
+            for name in AUDIT_CATEGORIES:
+                if name != "active_divergent_work" and statuses[name] != "UNSUPPORTED":
+                    statuses[name] = "PARTIAL"
+                    reasons[name] = "A bounded scan or adapter failure made this category partial."
+        disposition = "BLOCKED" if blocking else "PARTIAL" if partial else "COMPLETE"
+        return self._finalize(
+            commit_sha=commit_sha,
+            tree_sha=tree_sha,
+            config_digest=config_digest,
+            adapter_digest=adapter_digest,
+            tracked_tree_digest=tree_digest,
+            inventory_items=inventory,
+            findings=findings,
+            boundaries=boundaries,
+            statuses=statuses,
+            reasons=reasons,
+            disposition=disposition,
+        )
+
+
+def scan_repository(
+    repository_root: Path | str,
+    *,
+    commit: str = "HEAD",
+    config: ScanConfig,
+) -> RepositorySnapshot:
+    return RepositoryScanner(config=config).scan(repository_root, commit=commit)

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -51,7 +51,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.11.0"
+SCANNER_VERSION = "repository-scanner/2.12.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -118,7 +118,9 @@ _RUNTIME_DEPENDENCY_MODULES = MappingProxyType(
 )
 _STDLIB_IMPLEMENTATION_MODULES = (
     "configparser",
+    "datetime",
     "fnmatch",
+    "hashlib",
     "json",
     "json.decoder",
     "json.encoder",
@@ -130,6 +132,15 @@ _STDLIB_IMPLEMENTATION_MODULES = (
     "tomllib",
     "tomllib._parser",
     "tomllib._re",
+    "urllib.parse",
+    "uuid",
+)
+_NATIVE_IMPLEMENTATION_MODULES = (
+    "_datetime",
+    "_hashlib",
+    "_json",
+    "_sre",
+    "math",
 )
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
 
@@ -564,8 +575,10 @@ def _stable_code_constant(value: Any) -> Any:
         }
     if value is Ellipsis:
         return {"singleton": "ELLIPSIS"}
-    if value is None or isinstance(value, (bool, int, str)):
+    if value is None or isinstance(value, (bool, str)):
         return value
+    if isinstance(value, int):
+        return {"integer": str(value)}
     if isinstance(value, (float, complex)):
         return {"numeric_type": type(value).__name__, "value": repr(value)}
     return {"unsupported_constant_type": f"{type(value).__module__}.{type(value).__qualname__}"}
@@ -654,8 +667,10 @@ def _runtime_value_evidence(value: Any, *, depth: int = 0) -> Any:
         raise RepositoryIntelligenceError("runtime implementation state exceeds depth limit")
     if isinstance(value, CodeType):
         return {"code": _code_object_evidence(value)}
-    if value is None or isinstance(value, (bool, int, str)):
+    if value is None or isinstance(value, (bool, str)):
         return value
+    if isinstance(value, int):
+        return {"integer": str(value)}
     if isinstance(value, bytes):
         return {"bytes": value.hex()}
     if isinstance(value, (float, complex)):
@@ -725,6 +740,91 @@ def _runtime_module_namespace_digest(module: Any) -> str:
                     "value": _runtime_value_evidence(target),
                 }
             )
+    return canonical_digest(symbols)
+
+
+def _runtime_dependency_module_digest(module: Any) -> str:
+    """Bind a dependency module without recursively traversing arbitrary objects."""
+
+    symbols: list[dict[str, Any]] = []
+    module_name = str(getattr(module, "__name__", "unknown"))
+    for name, target in sorted(vars(module).items()):
+        if name.startswith("__"):
+            continue
+        if inspect.isfunction(target):
+            symbols.append(
+                {
+                    "symbol": name,
+                    "kind": "function",
+                    "code": _runtime_code_evidence(target),
+                }
+            )
+            continue
+        if inspect.isclass(target):
+            methods: list[dict[str, Any]] = []
+            for method_name, member in sorted(vars(target).items()):
+                implementations: tuple[Any, ...]
+                if isinstance(member, (classmethod, staticmethod)):
+                    implementations = (member.__func__,)
+                elif isinstance(member, property):
+                    implementations = tuple(
+                        implementation
+                        for implementation in (member.fget, member.fset, member.fdel)
+                        if implementation is not None
+                    )
+                else:
+                    implementations = (member,)
+                for implementation in implementations:
+                    if inspect.isfunction(implementation):
+                        methods.append(
+                            {
+                                "method": method_name,
+                                "code": _runtime_code_evidence(implementation),
+                            }
+                        )
+            symbols.append(
+                {
+                    "symbol": name,
+                    "kind": "class",
+                    "module": str(getattr(target, "__module__", "unknown")),
+                    "qualname": str(getattr(target, "__qualname__", name)),
+                    "methods": methods,
+                }
+            )
+            continue
+        if inspect.isbuiltin(target):
+            symbols.append(
+                {
+                    "symbol": name,
+                    "kind": "builtin",
+                    "module": str(getattr(target, "__module__", module_name)),
+                    "qualname": str(getattr(target, "__qualname__", name)),
+                }
+            )
+            continue
+        wrapped = getattr(target, "__wrapped__", None)
+        if callable(target) and inspect.isfunction(wrapped):
+            symbols.append(
+                {
+                    "symbol": name,
+                    "kind": "wrapped-callable",
+                    "type": f"{type(target).__module__}.{type(target).__qualname__}",
+                    "code": _runtime_code_evidence(wrapped),
+                }
+            )
+            continue
+        if isinstance(target, (type(None), bool, int, float, complex, str, bytes, re.Pattern)):
+            symbols.append(
+                {
+                    "symbol": name,
+                    "kind": "constant",
+                    "value": _runtime_value_evidence(target),
+                }
+            )
+    if not symbols:
+        raise RepositoryIntelligenceError(
+            f"{module_name} runtime namespace is unavailable for provenance binding"
+        )
     return canonical_digest(symbols)
 
 
@@ -864,7 +964,25 @@ def _runtime_dependency_evidence() -> list[dict[str, str]]:
                 "label": f"python-stdlib.{module_name}",
                 "module": module_name,
                 "source_digest": source_digest,
-                "runtime_code_digest": _runtime_module_namespace_digest(module),
+                "runtime_code_digest": _runtime_dependency_module_digest(module),
+            }
+        )
+    for module_name in _NATIVE_IMPLEMENTATION_MODULES:
+        module = importlib.import_module(module_name)
+        module_file = getattr(module, "__file__", None)
+        binary_path = Path(module_file) if isinstance(module_file, str) else Path(sys.executable)
+        try:
+            binary_digest = _sha256(binary_path.read_bytes())
+        except OSError as exc:
+            raise RepositoryIntelligenceError(
+                f"{module_name} native bytes are unavailable for provenance binding"
+            ) from exc
+        evidence.append(
+            {
+                "label": f"python-native.{module_name}",
+                "module": module_name,
+                "source_digest": binary_digest,
+                "runtime_code_digest": _runtime_dependency_module_digest(module),
             }
         )
     return evidence

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -46,7 +46,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/1.6.0"
+SCANNER_VERSION = "repository-scanner/1.7.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -617,9 +617,16 @@ class RepositoryScanner:
         cancellation: Cancellation | None = None,
     ) -> None:
         self.config = config
-        self.adapters = tuple(
-            sorted(adapters or default_adapters(), key=lambda item: item.adapter_id)
-        )
+        registered_adapters = default_adapters()
+        requested_adapters = tuple(adapters) if adapters is not None else registered_adapters
+        registered_by_id = {item.adapter_id: item for item in registered_adapters}
+        if len(requested_adapters) != len(registered_adapters) or any(
+            registered_by_id.get(item.adapter_id) is not item for item in requested_adapters
+        ):
+            raise RepositorySecurityError(
+                "repository scans only execute the sealed built-in adapter registry"
+            )
+        self.adapters = tuple(sorted(requested_adapters, key=lambda item: item.adapter_id))
         adapter_ids = [item.adapter_id for item in self.adapters]
         if len(set(adapter_ids)) != len(adapter_ids) or any(
             not item.adapter_id
@@ -1478,34 +1485,34 @@ class RepositoryScanner:
                     blocking=True,
                 )
             )
+        unsupported_manifest_names = {
+            "BUILD",
+            "BUILD.bazel",
+            "CMakeLists.txt",
+            "Cargo.toml",
+            "Gemfile",
+            "GNUmakefile",
+            "Jenkinsfile",
+            "MODULE.bazel",
+            "Makefile",
+            "Pipfile",
+            "Pipfile.lock",
+            "Procfile",
+            "Rakefile",
+            "SConstruct",
+            "Tiltfile",
+            "Vagrantfile",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+            "build.gradle",
+            "go.mod",
+            "justfile",
+            "pom.xml",
+        }
         unsupported_manifests = sorted(
             file.path
             for file in files
-            if PurePosixPath(file.path).name
-            in {
-                "BUILD",
-                "BUILD.bazel",
-                "CMakeLists.txt",
-                "Cargo.toml",
-                "Gemfile",
-                "GNUmakefile",
-                "Jenkinsfile",
-                "MODULE.bazel",
-                "Makefile",
-                "Pipfile",
-                "Pipfile.lock",
-                "Procfile",
-                "Rakefile",
-                "SConstruct",
-                "Tiltfile",
-                "Vagrantfile",
-                "WORKSPACE",
-                "WORKSPACE.bazel",
-                "build.gradle",
-                "go.mod",
-                "justfile",
-                "pom.xml",
-            }
+            if PurePosixPath(file.path).name in unsupported_manifest_names
         )
         if unsupported_manifests:
             findings.append(
@@ -1515,6 +1522,27 @@ class RepositoryScanner:
                     "A tracked ecosystem manifest has no versioned adapter; its stack was not "
                     "guessed.",
                     tuple(unsupported_manifests),
+                    blocking=True,
+                )
+            )
+        extensionless_programs = sorted(
+            file.path
+            for file in files
+            if not PurePosixPath(file.path).suffix
+            and PurePosixPath(file.path).name not in {*unsupported_manifest_names, "Dockerfile"}
+            and (
+                file.mode == "100755"
+                or (file.content is not None and file.content.startswith(b"#!"))
+            )
+        )
+        if extensionless_programs:
+            findings.append(
+                _finding(
+                    "STACK.UNSUPPORTED_EXTENSIONLESS_PROGRAM",
+                    "languages_build_ecosystems",
+                    "Tracked extensionless executable or shebang content has no deterministic "
+                    "stack adapter; it was not executed or guessed.",
+                    tuple(extensionless_programs),
                     blocking=True,
                 )
             )

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -15,12 +15,13 @@ import selectors
 import signal
 import subprocess
 import sys
+import threading
 import time
 from collections.abc import Callable, Sequence
 from contextlib import suppress
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any, Protocol, cast
+from typing import Any, Protocol, cast, final
 
 import yaml
 
@@ -47,7 +48,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/1.9.0"
+SCANNER_VERSION = "repository-scanner/2.0.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -74,6 +75,32 @@ class CommandRunner(Protocol):
 
 class Cancellation(Protocol):
     def cancelled(self) -> bool: ...
+
+
+@final
+class CancellationSignal:
+    """Sealed cancellation capability with no caller-executed callback."""
+
+    __slots__ = ("_cancel_after_checks", "_checks", "_event", "_lock")
+
+    def __init__(self, *, cancel_after_checks: int | None = None) -> None:
+        if cancel_after_checks is not None and cancel_after_checks < 1:
+            raise ValueError("cancellation check limit must be positive")
+        self._cancel_after_checks = cancel_after_checks
+        self._checks = 0
+        self._event = threading.Event()
+        self._lock = threading.Lock()
+
+    def cancel(self) -> None:
+        self._event.set()
+
+    def cancelled(self) -> bool:
+        with self._lock:
+            self._checks += 1
+            threshold_reached = (
+                self._cancel_after_checks is not None and self._checks >= self._cancel_after_checks
+            )
+        return self._event.is_set() or threshold_reached
 
 
 _PROCESS_GROUP_GUARD = "import signal\nwhile True:\n signal.pause()"
@@ -156,6 +183,7 @@ class SubprocessCommandRunner:
     """Allowlisted local Git reader; it never invokes shells or project code."""
 
     identity = "git-readonly-subprocess/1.7.0"
+    __slots__ = ()
     _allowed = {"rev-parse", "ls-tree", "cat-file", "version"}
 
     @staticmethod
@@ -192,6 +220,8 @@ class SubprocessCommandRunner:
         *,
         cancellation: Cancellation | None = None,
     ) -> CommandResult:
+        if cancellation is not None and type(cancellation) is not CancellationSignal:
+            raise RepositorySecurityError("Git cancellation requires the sealed signal")
         if len(args) < 2 or args[0] != "git" or args[1] not in self._allowed:
             raise RepositorySecurityError("command is outside the read-only Git allowlist")
         process, guard = _spawn_guarded_git(args, cwd, self._environment())
@@ -251,6 +281,8 @@ class SubprocessCommandRunner:
     ) -> TreeListingResult:
         """Stream NUL-delimited tree records and stop before unbounded buffering."""
 
+        if cancellation is not None and type(cancellation) is not CancellationSignal:
+            raise RepositorySecurityError("Git cancellation requires the sealed signal")
         if len(args) < 2 or args[0:2] != ("git", "ls-tree"):
             raise RepositorySecurityError("bounded tree reader only accepts git ls-tree")
         process, guard = _spawn_guarded_git(args, cwd, self._environment())
@@ -609,7 +641,16 @@ def _snapshot_from_dict(value: dict[str, Any]) -> RepositorySnapshot:
         included_paths=tuple(value["included_paths"]),
         tooling_digest=str(value["tooling_digest"]),
         tool_versions=tuple(ToolVersion(**item) for item in value["tool_versions"]),
-        adapters=tuple(AdapterMetadata(**item) for item in value["adapters"]),
+        adapters=tuple(
+            AdapterMetadata(
+                **{
+                    **item,
+                    "file_patterns": tuple(item["file_patterns"]),
+                    "supported_categories": tuple(item["supported_categories"]),
+                }
+            )
+            for item in value["adapters"]
+        ),
         command_provenance=tuple(
             CommandProvenance(
                 args=tuple(item["args"]),
@@ -620,9 +661,13 @@ def _snapshot_from_dict(value: dict[str, Any]) -> RepositorySnapshot:
             for item in value["command_provenance"]
         ),
         inventory=inventory,
-        findings=tuple(Finding(**item) for item in value["findings"]),
+        findings=tuple(
+            Finding(**{**item, "evidence_refs": tuple(item["evidence_refs"])})
+            for item in value["findings"]
+        ),
         boundary_candidates=tuple(
-            BoundaryCandidate(**item) for item in value["boundary_candidates"]
+            BoundaryCandidate(**{**item, "evidence_paths": tuple(item["evidence_paths"])})
+            for item in value["boundary_candidates"]
         ),
         unsupported_categories=tuple(value["unsupported_categories"]),
         disposition=str(value["disposition"]),
@@ -666,6 +711,12 @@ class RepositoryScanner:
             for item in self.adapters
         ):
             raise RepositoryIntelligenceError("repository adapter declaration is invalid")
+        if command_runner is not None and type(command_runner) is not SubprocessCommandRunner:
+            raise RepositorySecurityError("repository scans require the sealed Git reader")
+        if redactor is not None and type(redactor) is not EvidenceRedactor:
+            raise RepositorySecurityError("repository scans require the sealed redactor")
+        if cancellation is not None and type(cancellation) is not CancellationSignal:
+            raise RepositorySecurityError("repository scans require the sealed cancellation signal")
         self.runner = command_runner or SubprocessCommandRunner()
         # Exact-SHA snapshots never capture host environment values; excluding them
         # from the default redaction context preserves cross-host determinism.
@@ -1347,9 +1398,23 @@ class RepositoryScanner:
                                 (str(category), EvidenceItem(**item))
                                 for category, item in raw_result["items"]
                             ),
-                            findings=tuple(Finding(**item) for item in raw_result["findings"]),
+                            findings=tuple(
+                                Finding(
+                                    **{
+                                        **item,
+                                        "evidence_refs": tuple(item["evidence_refs"]),
+                                    }
+                                )
+                                for item in raw_result["findings"]
+                            ),
                             boundaries=tuple(
-                                BoundaryCandidate(**item) for item in raw_result["boundaries"]
+                                BoundaryCandidate(
+                                    **{
+                                        **item,
+                                        "evidence_paths": tuple(item["evidence_paths"]),
+                                    }
+                                )
+                                for item in raw_result["boundaries"]
                             ),
                         )
                     except (KeyError, TypeError, ValueError):

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -49,7 +49,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.5.0"
+SCANNER_VERSION = "repository-scanner/2.6.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -1545,6 +1545,121 @@ class RepositoryScanner:
             (
                 "delivery_environments",
                 "deployment-evidence mechanisms",
+                (),
+            ),
+            (
+                "delivery_environments",
+                "release workflows",
+                (),
+            ),
+            (
+                "delivery_environments",
+                "preview environments",
+                (),
+            ),
+            (
+                "delivery_environments",
+                "container definitions",
+                (),
+            ),
+            (
+                "delivery_environments",
+                "infrastructure-as-code",
+                (),
+            ),
+            (
+                "delivery_environments",
+                "deployment definitions",
+                (),
+            ),
+            (
+                "delivery_environments",
+                "environment configuration shapes",
+                (),
+            ),
+            (
+                "delivery_environments",
+                "rollback mechanisms",
+                (),
+            ),
+            (
+                "security_privacy",
+                "dependency audits",
+                (),
+            ),
+            (
+                "security_privacy",
+                "static application security testing",
+                (),
+            ),
+            (
+                "security_privacy",
+                "secret scanning",
+                (),
+            ),
+            (
+                "security_privacy",
+                "permissions",
+                (),
+            ),
+            (
+                "security_privacy",
+                "credential boundaries",
+                (),
+            ),
+            (
+                "security_privacy",
+                "data retention and privacy controls",
+                (),
+            ),
+            (
+                "security_privacy",
+                "security configuration",
+                (),
+            ),
+            (
+                "observability_operations",
+                "logs",
+                (),
+            ),
+            (
+                "observability_operations",
+                "metrics",
+                (),
+            ),
+            (
+                "observability_operations",
+                "traces",
+                (),
+            ),
+            (
+                "observability_operations",
+                "alerting",
+                (),
+            ),
+            (
+                "observability_operations",
+                "service-level objectives",
+                (),
+            ),
+            (
+                "observability_operations",
+                "health checks",
+                (),
+            ),
+            (
+                "observability_operations",
+                "incident and rollback evidence",
+                (),
+            ),
+            (
+                "observability_operations",
+                "telemetry schemas",
+                (),
+            ),
+            (
+                "observability_operations",
+                "production feedback paths",
                 (),
             ),
         )

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -165,6 +165,7 @@ def _snapshot_from_dict(value: dict[str, Any]) -> RepositorySnapshot:
         commit_sha=str(value["commit_sha"]),
         tree_sha=str(value["tree_sha"]),
         default_branch=cast(str | None, value["default_branch"]),
+        default_branch_source=str(value["default_branch_source"]),
         scanner_version=str(value["scanner_version"]),
         scan_configuration_digest=str(value["scan_configuration_digest"]),
         adapter_set_digest=str(value["adapter_set_digest"]),
@@ -652,19 +653,26 @@ class RepositoryScanner:
             ".py",
             ".pyi",
             ".json",
+            ".jsonl",
             ".yaml",
             ".yml",
             ".toml",
             ".lock",
             ".js",
+            ".mjs",
+            ".cjs",
             ".jsx",
             ".ts",
             ".tsx",
+            ".css",
+            ".html",
+            ".svg",
             ".sql",
             ".sh",
             ".ini",
             ".cfg",
             ".dockerignore",
+            ".typed",
         }
         unknown = [
             file.path
@@ -673,16 +681,67 @@ class RepositoryScanner:
             and PurePosixPath(file.path).suffix.lower() not in known_suffixes
             and not file.binary
         ]
-        if unknown and not inventory["languages_build_ecosystems"]:
+        if unknown:
             findings.append(
                 _finding(
-                    "STACK.UNSUPPORTED",
+                    "STACK.UNSUPPORTED_FILE_TYPE",
                     "languages_build_ecosystems",
-                    "Tracked source belongs to an unsupported ecosystem; no stack was inferred.",
+                    "A tracked file type has no deterministic stack adapter; no ecosystem was "
+                    "inferred for it.",
                     tuple(sorted(unknown)),
                     blocking=True,
                 )
             )
+        unsupported_manifests = sorted(
+            file.path
+            for file in files
+            if PurePosixPath(file.path).name
+            in {"Cargo.toml", "go.mod", "pom.xml", "build.gradle", "Gemfile"}
+        )
+        if unsupported_manifests:
+            findings.append(
+                _finding(
+                    "STACK.UNSUPPORTED_ECOSYSTEM",
+                    "languages_build_ecosystems",
+                    "A tracked ecosystem manifest has no versioned adapter; its stack was not "
+                    "guessed.",
+                    tuple(unsupported_manifests),
+                    blocking=True,
+                )
+            )
+        by_name: dict[str, list[str]] = {}
+        for file in files:
+            name = PurePosixPath(file.path).name
+            if name.endswith((".schema.json", ".config.json", ".config.yaml", ".config.yml")):
+                by_name.setdefault(name, []).append(file.path)
+        for paths in sorted(by_name.values()):
+            if len(paths) > 1:
+                findings.append(
+                    _finding(
+                        "CONFIG.DUPLICATE_PATH_SIGNAL",
+                        "debt_risk",
+                        "The same configuration basename appears in multiple tracked locations; "
+                        "this is a duplication signal, not proof of drift.",
+                        tuple(sorted(paths)),
+                        severity="MEDIUM",
+                    )
+                )
+        for file in files:
+            if not file.path.startswith(".github/workflows/") or not file.content:
+                continue
+            if re.search(
+                rb"\bpip\s+install\s+(?:[^\n]*\s)?(?:ruff|mypy|bandit|build)\s*(?:\n|$)",
+                file.content,
+            ):
+                findings.append(
+                    _finding(
+                        "TOOL.UNPINNED_INSTALL_SIGNAL",
+                        "debt_risk",
+                        "A CI tool install appears unbounded; exact resolver behavior may drift.",
+                        (file.path,),
+                        severity="MEDIUM",
+                    )
+                )
         for file in files:
             if file.mode == "120000" and _symlink_escapes(file.path, file.content):
                 findings.append(
@@ -731,6 +790,7 @@ class RepositoryScanner:
             commit_sha=commit_sha,
             tree_sha=tree_sha,
             default_branch=self.config.default_branch,
+            default_branch_source="SCAN_CONFIGURATION_NOT_OBSERVED",
             scanner_version=SCANNER_VERSION,
             scan_configuration_digest=config_digest,
             adapter_set_digest=adapter_digest,
@@ -819,7 +879,7 @@ class RepositoryScanner:
             "Mutable branch, worktree, PR, issue, and governance facts belong only in "
             "GovernanceObservation."
         )
-        if any(item.code == "STACK.UNSUPPORTED" for item in findings):
+        if any(item.code.startswith("STACK.UNSUPPORTED") for item in findings):
             statuses["languages_build_ecosystems"] = "UNSUPPORTED"
             reasons["languages_build_ecosystems"] = (
                 "The tracked ecosystem has no deterministic adapter."

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -49,7 +49,17 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.6.0"
+SCANNER_VERSION = "repository-scanner/2.7.0"
+_MAX_SCAN_BUDGETS = {
+    "max_files": 100_000,
+    "max_directories": 50_000,
+    "max_total_bytes": 2_000_000_000,
+    "max_file_bytes": 50_000_000,
+    "max_tree_output_bytes": 128_000_000,
+    "max_commands": 250_000,
+    "command_timeout_seconds": 120,
+    "max_path_depth": 256,
+}
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -901,6 +911,18 @@ class RepositoryScanner:
         )
         if any(value <= 0 for value in positive):
             raise RepositoryIntelligenceError("scan budgets must be positive")
+        configured_budgets = {
+            "max_files": self.config.max_files,
+            "max_directories": self.config.max_directories,
+            "max_total_bytes": self.config.max_total_bytes,
+            "max_file_bytes": self.config.max_file_bytes,
+            "max_tree_output_bytes": self.config.max_tree_output_bytes,
+            "max_commands": self.config.max_commands,
+            "command_timeout_seconds": self.config.command_timeout_seconds,
+            "max_path_depth": self.config.max_path_depth,
+        }
+        if any(value > _MAX_SCAN_BUDGETS[name] for name, value in configured_budgets.items()):
+            raise RepositoryIntelligenceError("scan budget exceeds a hard safety ceiling")
         for path in self.config.include_paths:
             if not _safe_relative_path(path):
                 raise RepositorySecurityError(

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -6,9 +6,11 @@ import hashlib
 import os
 import posixpath
 import re
+import selectors
 import subprocess
+import time
 from collections.abc import Sequence
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, cast
 
@@ -55,22 +57,33 @@ class Cancellation(Protocol):
     def cancelled(self) -> bool: ...
 
 
+@dataclass(frozen=True)
+class TreeListingResult:
+    result: CommandResult
+    record_limit_exceeded: bool
+    byte_limit_exceeded: bool
+
+
 class SubprocessCommandRunner:
     """Allowlisted local Git reader; it never invokes shells or project code."""
 
     identity = "git-readonly-subprocess/1.0.0"
     _allowed = {"rev-parse", "ls-tree", "cat-file"}
 
-    def run(self, args: tuple[str, ...], cwd: Path, timeout: int) -> CommandResult:
-        if len(args) < 2 or args[0] != "git" or args[1] not in self._allowed:
-            raise RepositorySecurityError("command is outside the read-only Git allowlist")
-        safe_environment = {
+    @staticmethod
+    def _environment() -> dict[str, str]:
+        return {
             "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
             "GIT_CONFIG_GLOBAL": os.devnull,
             "GIT_CONFIG_SYSTEM": os.devnull,
             "GIT_TERMINAL_PROMPT": "0",
+            "GIT_OPTIONAL_LOCKS": "0",
             "LC_ALL": "C",
         }
+
+    def run(self, args: tuple[str, ...], cwd: Path, timeout: int) -> CommandResult:
+        if len(args) < 2 or args[0] != "git" or args[1] not in self._allowed:
+            raise RepositorySecurityError("command is outside the read-only Git allowlist")
         try:
             result = subprocess.run(
                 args,
@@ -78,7 +91,7 @@ class SubprocessCommandRunner:
                 capture_output=True,
                 check=False,
                 timeout=timeout,
-                env=safe_environment,
+                env=self._environment(),
             )
         except subprocess.TimeoutExpired:
             return CommandResult(args=args, returncode=124, stdout=b"", stderr=b"", timed_out=True)
@@ -87,6 +100,92 @@ class SubprocessCommandRunner:
             returncode=result.returncode,
             stdout=result.stdout,
             stderr=result.stderr,
+        )
+
+    def list_tree(
+        self,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        max_records: int,
+        max_output_bytes: int,
+    ) -> TreeListingResult:
+        """Stream NUL-delimited tree records and stop before unbounded buffering."""
+
+        if len(args) < 2 or args[0:2] != ("git", "ls-tree"):
+            raise RepositorySecurityError("bounded tree reader only accepts git ls-tree")
+        process = subprocess.Popen(
+            args,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            env=self._environment(),
+        )
+        if process.stdout is None:
+            process.kill()
+            raise RepositoryIntelligenceError("bounded tree reader did not expose output")
+        selector = selectors.DefaultSelector()
+        selector.register(process.stdout, selectors.EVENT_READ)
+        payload = bytearray()
+        record_limit = False
+        record_count = 0
+        byte_limit = False
+        timed_out = False
+        deadline = time.monotonic() + timeout
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    timed_out = True
+                    process.kill()
+                    break
+                events = selector.select(remaining)
+                if not events:
+                    timed_out = True
+                    process.kill()
+                    break
+                chunk = os.read(process.stdout.fileno(), 65_536)
+                if not chunk:
+                    break
+                payload.extend(chunk)
+                record_count += chunk.count(0)
+                if len(payload) > max_output_bytes:
+                    byte_limit = True
+                    process.terminate()
+                    break
+                if record_count >= max_records:
+                    record_limit = True
+                    process.terminate()
+                    break
+        finally:
+            selector.close()
+            process.stdout.close()
+        try:
+            returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            process.kill()
+            returncode = process.wait()
+            timed_out = True
+        complete_records = bytes(payload[:max_output_bytes]).split(b"\0")
+        if complete_records and complete_records[-1]:
+            complete_records = complete_records[:-1]
+        complete_records = complete_records[:max_records]
+        bounded_payload = b"\0".join(complete_records)
+        if complete_records:
+            bounded_payload += b"\0"
+        return TreeListingResult(
+            result=CommandResult(
+                args=args,
+                # A deliberate budget stop is represented by the finding flags, not
+                # by the platform-dependent SIGTERM status in canonical provenance.
+                returncode=0 if record_limit or byte_limit else returncode,
+                stdout=bounded_payload,
+                stderr=b"",
+                timed_out=timed_out,
+            ),
+            record_limit_exceeded=record_limit,
+            byte_limit_exceeded=byte_limit,
         )
 
 
@@ -101,6 +200,23 @@ def _text(value: str | bytes) -> str:
 def _safe_relative_path(value: str) -> bool:
     path = PurePosixPath(value)
     return not path.is_absolute() and ".." not in path.parts and value not in {"", "."}
+
+
+def resolve_repository_root(repository_root: Path | str) -> Path:
+    """Resolve a Git root with the same non-locking read-only policy as scans."""
+
+    requested = Path(repository_root).resolve()
+    runner = SubprocessCommandRunner()
+    result = runner.run(("git", "rev-parse", "--show-toplevel"), requested, 20)
+    if result.timed_out or result.returncode != 0:
+        raise RepositoryIntelligenceError("path is not an accessible Git repository")
+    try:
+        root = Path(_text(result.stdout).strip()).resolve(strict=True)
+    except (UnicodeDecodeError, OSError) as exc:
+        raise RepositoryIntelligenceError("Git repository root is malformed") from exc
+    if root != requested and root not in requested.parents:
+        raise RepositorySecurityError("resolved Git repository root is outside the requested path")
+    return root
 
 
 def _symlink_escapes(path: str, target: bytes | None) -> bool:
@@ -170,6 +286,9 @@ def _snapshot_from_dict(value: dict[str, Any]) -> RepositorySnapshot:
         scan_configuration_digest=str(value["scan_configuration_digest"]),
         adapter_set_digest=str(value["adapter_set_digest"]),
         tracked_tree_digest=str(value["tracked_tree_digest"]),
+        scanned_content_digest=str(value["scanned_content_digest"]),
+        scan_scope=str(value["scan_scope"]),
+        included_paths=tuple(value["included_paths"]),
         tooling_digest=str(value["tooling_digest"]),
         adapters=tuple(AdapterMetadata(**item) for item in value["adapters"]),
         command_provenance=tuple(
@@ -244,6 +363,44 @@ class RepositoryScanner:
             raise RepositoryIntelligenceError("an immutable Git object could not be read")
         return result
 
+    def _list_tree(self, args: tuple[str, ...], root: Path) -> TreeListingResult | None:
+        if self._commands >= self.config.max_commands:
+            return None
+        self._commands += 1
+        try:
+            if isinstance(self.runner, SubprocessCommandRunner):
+                listing = self.runner.list_tree(
+                    args,
+                    root,
+                    self.config.command_timeout_seconds,
+                    max_records=self.config.max_files + 1,
+                    max_output_bytes=self.config.max_tree_output_bytes,
+                )
+            else:
+                listing = TreeListingResult(
+                    result=self.runner.run(args, root, self.config.command_timeout_seconds),
+                    record_limit_exceeded=False,
+                    byte_limit_exceeded=False,
+                )
+        except (FileNotFoundError, OSError) as exc:
+            raise RepositoryIntelligenceError("read-only Git command is unavailable") from exc
+        result = listing.result
+        self._command_provenance.append(
+            CommandProvenance(
+                args=args,
+                tool_identity=self.runner.identity,
+                exit_status=result.returncode,
+                timed_out=result.timed_out,
+            )
+        )
+        if result.timed_out:
+            raise RepositoryIntelligenceError("bounded tracked-tree enumeration timed out")
+        if result.returncode != 0 and not (
+            listing.record_limit_exceeded or listing.byte_limit_exceeded
+        ):
+            raise RepositoryIntelligenceError("the immutable Git tree could not be read")
+        return listing
+
     def _validate_config(self) -> None:
         if not self.config.repository.strip():
             raise RepositoryIntelligenceError("repository identity is required")
@@ -252,6 +409,7 @@ class RepositoryScanner:
             self.config.max_directories,
             self.config.max_total_bytes,
             self.config.max_file_bytes,
+            self.config.max_tree_output_bytes,
             self.config.max_commands,
             self.config.command_timeout_seconds,
             self.config.max_path_depth,
@@ -343,8 +501,9 @@ class RepositoryScanner:
 
     def _list_files(
         self, root: Path, commit_sha: str, tree_sha: str
-    ) -> tuple[list[TrackedFile], list[Finding], str]:
+    ) -> tuple[list[TrackedFile], list[Finding], str, str]:
         findings: list[Finding] = []
+        tracked_tree_digest = canonical_digest({"git_object_format": "sha1", "tree_sha": tree_sha})
         if tree_sha == "0" * 40:
             findings.append(
                 _finding(
@@ -354,9 +513,11 @@ class RepositoryScanner:
                     ("repository:scan-budget",),
                 )
             )
-            return [], findings, canonical_digest([])
-        listing = self._run(("git", "ls-tree", "-r", "-z", "-l", "--full-tree", commit_sha), root)
-        if listing is None:
+            return [], findings, tracked_tree_digest, canonical_digest([])
+        bounded_listing = self._list_tree(
+            ("git", "ls-tree", "-r", "-z", "-l", "--full-tree", commit_sha), root
+        )
+        if bounded_listing is None:
             findings.append(
                 _finding(
                     "BUDGET.COMMAND_COUNT",
@@ -365,7 +526,18 @@ class RepositoryScanner:
                     ("repository:scan-budget",),
                 )
             )
-            return [], findings, canonical_digest([])
+            return [], findings, tracked_tree_digest, canonical_digest([])
+        listing = bounded_listing.result
+        if bounded_listing.byte_limit_exceeded:
+            findings.append(
+                _finding(
+                    "BUDGET.TREE_OUTPUT_BYTES",
+                    "repository_topology",
+                    "Tracked-tree enumeration exceeded its byte budget; results are explicitly "
+                    "partial.",
+                    ("repository:tracked-tree",),
+                )
+            )
         raw = listing.stdout if isinstance(listing.stdout, bytes) else listing.stdout.encode()
         entries: list[tuple[str, str, str, str, int]] = []
         for record in raw.split(b"\0"):
@@ -391,19 +563,7 @@ class RepositoryScanner:
                 continue
             entries.append((mode, object_type, object_id, path, size))
         entries.sort(key=lambda item: item[3])
-        tracked_tree_digest = canonical_digest(
-            [
-                {
-                    "mode": mode,
-                    "object_type": object_type,
-                    "object_id": object_id,
-                    "path": path,
-                    "size": size,
-                }
-                for mode, object_type, object_id, path, size in entries
-            ]
-        )
-        if len(entries) > self.config.max_files:
+        if bounded_listing.record_limit_exceeded or len(entries) > self.config.max_files:
             findings.append(
                 _finding(
                     "BUDGET.FILE_COUNT",
@@ -523,7 +683,19 @@ class RepositoryScanner:
                     binary=b"\0" in content,
                 )
             )
-        return files, findings, tracked_tree_digest
+        scanned_content_digest = canonical_digest(
+            [
+                {
+                    "path": file.path,
+                    "mode": file.mode,
+                    "object_id": file.object_id,
+                    "file_digest": file.digest,
+                    "oversized": file.oversized,
+                }
+                for file in files
+            ]
+        )
+        return files, findings, tracked_tree_digest, scanned_content_digest
 
     def _apply_adapters(
         self, files: tuple[TrackedFile, ...]
@@ -574,12 +746,26 @@ class RepositoryScanner:
         self, files: tuple[TrackedFile, ...], inventory: dict[str, list[EvidenceItem]]
     ) -> list[Finding]:
         findings: list[Finding] = []
-        if not inventory["tests_quality"]:
+        expected_test_kinds = {
+            "unit": "UNIT_TEST_FILE_SIGNAL",
+            "integration": "INTEGRATION_TEST_FILE_SIGNAL",
+            "e2e": "E2E_TEST_FILE_SIGNAL",
+            "contract": "CONTRACT_TEST_FILE_SIGNAL",
+            "security": "SECURITY_TEST_FILE_SIGNAL",
+            "performance": "PERFORMANCE_TEST_FILE_SIGNAL",
+            "mutation": "MUTATION_TEST_FILE_SIGNAL",
+        }
+        observed_test_kinds = {item.kind for item in inventory["tests_quality"]}
+        missing_test_categories = tuple(
+            name for name, kind in expected_test_kinds.items() if kind not in observed_test_kinds
+        )
+        if missing_test_categories:
             findings.append(
                 _finding(
                     "QUALITY.TEST_CATEGORY_ABSENT",
                     "tests_quality",
-                    "No deterministic tracked evidence of a test category was observed.",
+                    "No deterministic tracked configuration or conventional file signal was "
+                    f"observed for these test categories: {', '.join(missing_test_categories)}.",
                     ("repository:tracked-tree",),
                     severity="MEDIUM",
                 )
@@ -626,17 +812,17 @@ class RepositoryScanner:
                     severity="MEDIUM",
                 )
             )
-        python_versions: set[str] = set()
+        python_versions: dict[str, str] = {}
         for file in files:
             if file.content is None or file.binary:
                 continue
             if file.path == ".python-version":
-                python_versions.add(file.content.decode("utf-8", errors="ignore").strip())
+                python_versions[file.path] = file.content.decode("utf-8", errors="ignore").strip()
             if "dockerfile" in PurePosixPath(file.path).name.lower():
                 match = re.search(rb"\bpython:([0-9]+(?:\.[0-9]+)?)", file.content)
                 if match:
-                    python_versions.add(match.group(1).decode())
-        if len(python_versions) > 1:
+                    python_versions[file.path] = match.group(1).decode()
+        if len(set(python_versions.values())) > 1:
             findings.append(
                 _finding(
                     "RUNTIME.VERSION_DRIFT_SIGNAL",
@@ -681,14 +867,41 @@ class RepositoryScanner:
             and PurePosixPath(file.path).suffix.lower() not in known_suffixes
             and not file.binary
         ]
-        if unknown:
+        unsupported_source_suffixes = {
+            ".sh",
+            ".bash",
+            ".zsh",
+            ".rb",
+            ".go",
+            ".rs",
+            ".java",
+            ".kt",
+            ".php",
+            ".swift",
+            ".c",
+            ".cc",
+            ".cpp",
+            ".cs",
+        }
+        unsupported_sources = sorted(
+            {
+                *unknown,
+                *(
+                    file.path
+                    for file in files
+                    if PurePosixPath(file.path).suffix.lower() in unsupported_source_suffixes
+                    and not file.binary
+                ),
+            }
+        )
+        if unsupported_sources:
             findings.append(
                 _finding(
                     "STACK.UNSUPPORTED_FILE_TYPE",
                     "languages_build_ecosystems",
                     "A tracked file type has no deterministic stack adapter; no ecosystem was "
                     "inferred for it.",
-                    tuple(sorted(unknown)),
+                    tuple(unsupported_sources),
                     blocking=True,
                 )
             )
@@ -771,6 +984,7 @@ class RepositoryScanner:
         reasons: dict[str, str],
         disposition: str,
         tracked_tree_digest: str | None = None,
+        scanned_content_digest: str | None = None,
     ) -> RepositorySnapshot:
         inventory = {
             name: InventoryCategory(
@@ -795,6 +1009,9 @@ class RepositoryScanner:
             scan_configuration_digest=config_digest,
             adapter_set_digest=adapter_digest,
             tracked_tree_digest=tracked_tree_digest or canonical_digest([]),
+            scanned_content_digest=scanned_content_digest or canonical_digest([]),
+            scan_scope=("INCLUDED_PATHS" if self.config.include_paths else "FULL_REPOSITORY"),
+            included_paths=tuple(sorted(self.config.include_paths)),
             tooling_digest=canonical_digest(
                 {
                     "scanner_version": SCANNER_VERSION,
@@ -855,9 +1072,22 @@ class RepositoryScanner:
             return self._cancelled_snapshot(
                 root, commit_sha, tree_sha, config_digest, adapter_digest
             )
-        files, budget_findings, tree_digest = self._list_files(root, commit_sha, tree_sha)
+        files, budget_findings, tree_digest, scanned_digest = self._list_files(
+            root, commit_sha, tree_sha
+        )
         inventory, adapter_findings, boundaries, supported = self._apply_adapters(tuple(files))
         findings = budget_findings + adapter_findings
+        if self.config.include_paths:
+            findings.append(
+                _finding(
+                    "SCAN.SCOPED_PARTIAL",
+                    "repository_topology",
+                    "Only explicitly included paths were inspected; the artifact is not a "
+                    "whole-repository inventory.",
+                    tuple(sorted(self.config.include_paths)),
+                    severity="MEDIUM",
+                )
+            )
         findings.extend(self._cross_cutting_findings(tuple(files), inventory))
         statuses = {
             name: (
@@ -895,10 +1125,12 @@ class RepositoryScanner:
             "BUDGET.DIRECTORY_COUNT",
             "BUDGET.TOTAL_BYTES",
             "BUDGET.FILE_BYTES",
+            "BUDGET.TREE_OUTPUT_BYTES",
             "BUDGET.PATH_DEPTH",
             "BUDGET.COMMAND_COUNT",
             "MANIFEST.MALFORMED",
             "WORKFLOW.MALFORMED",
+            "SCAN.SCOPED_PARTIAL",
         }
         partial = any(item.code in partial_codes for item in findings)
         if partial:
@@ -913,6 +1145,7 @@ class RepositoryScanner:
             config_digest=config_digest,
             adapter_digest=adapter_digest,
             tracked_tree_digest=tree_digest,
+            scanned_content_digest=scanned_digest,
             inventory_items=inventory,
             findings=findings,
             boundaries=boundaries,

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -51,7 +51,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.10.0"
+SCANNER_VERSION = "repository-scanner/2.11.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -115,6 +115,21 @@ _RUNTIME_DEPENDENCY_MODULES = MappingProxyType(
         ),
         "rfc8785": ("rfc8785", "rfc8785._impl"),
     }
+)
+_STDLIB_IMPLEMENTATION_MODULES = (
+    "configparser",
+    "fnmatch",
+    "json",
+    "json.decoder",
+    "json.encoder",
+    "json.scanner",
+    "pathlib",
+    "posixpath",
+    "re",
+    "shlex",
+    "tomllib",
+    "tomllib._parser",
+    "tomllib._re",
 )
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
 
@@ -648,7 +663,10 @@ def _runtime_value_evidence(value: Any, *, depth: int = 0) -> Any:
     if isinstance(value, PurePosixPath):
         return {"path": value.as_posix()}
     if isinstance(value, re.Pattern):
-        return {"pattern": value.pattern, "flags": value.flags}
+        return {
+            "pattern": _runtime_value_evidence(value.pattern, depth=depth + 1),
+            "flags": value.flags,
+        }
     if isinstance(value, Mapping):
         return {
             "mapping": [
@@ -828,6 +846,25 @@ def _runtime_dependency_evidence() -> list[dict[str, str]]:
                 "module": package_name,
                 "source_digest": canonical_digest(source_evidence),
                 "runtime_code_digest": canonical_digest(loaded_modules),
+            }
+        )
+    for module_name in _STDLIB_IMPLEMENTATION_MODULES:
+        module = importlib.import_module(module_name)
+        try:
+            source_path_value = inspect.getsourcefile(module)
+            if source_path_value is None:
+                raise OSError("stdlib implementation source path is unavailable")
+            source_digest = _sha256(Path(source_path_value).read_bytes())
+        except (OSError, TypeError) as exc:
+            raise RepositoryIntelligenceError(
+                f"{module_name} stdlib bytes are unavailable for provenance binding"
+            ) from exc
+        evidence.append(
+            {
+                "label": f"python-stdlib.{module_name}",
+                "module": module_name,
+                "source_digest": source_digest,
+                "runtime_code_digest": _runtime_module_namespace_digest(module),
             }
         )
     return evidence

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -52,7 +52,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.13.0"
+SCANNER_VERSION = "repository-scanner/2.14.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -129,6 +129,10 @@ _STDLIB_IMPLEMENTATION_MODULES = (
     "pathlib",
     "posixpath",
     "re",
+    "re._casefix",
+    "re._compiler",
+    "re._constants",
+    "re._parser",
     "shlex",
     "tomllib",
     "tomllib._parser",
@@ -145,6 +149,7 @@ _NATIVE_IMPLEMENTATION_MODULES = (
 )
 _RUNTIME_DEPENDENCY_GLOBALS = MappingProxyType(
     {
+        "json": ("_default_decoder", "_default_encoder"),
         "urllib.parse": (
             "_ALWAYS_SAFE",
             "_ALWAYS_SAFE_BYTES",
@@ -854,6 +859,64 @@ def _is_runtime_semantic_constant(
     return False
 
 
+def _runtime_configured_instance_evidence(value: Any, *, module_name: str) -> dict[str, Any]:
+    """Bind the deterministic configuration of a sealed parser/encoder instance."""
+
+    try:
+        state = vars(value)
+    except TypeError as exc:
+        raise RepositoryIntelligenceError(
+            f"{module_name} configured runtime state is unavailable for provenance binding"
+        ) from exc
+    if not state or len(state) > 1_024:
+        raise RepositoryIntelligenceError(
+            f"{module_name} configured runtime state is empty or unbounded"
+        )
+    members: list[dict[str, Any]] = []
+    for name, member in sorted(state.items()):
+        if _is_runtime_semantic_constant(member, module_name=module_name):
+            members.append(
+                {
+                    "member": name,
+                    "kind": "constant",
+                    "value": _runtime_value_evidence(member),
+                }
+            )
+            continue
+        implementation = member.__func__ if inspect.ismethod(member) else member
+        if inspect.isfunction(implementation):
+            members.append(
+                {
+                    "member": name,
+                    "kind": "function",
+                    "code": _runtime_code_evidence(implementation),
+                }
+            )
+            continue
+        if inspect.isclass(member) or inspect.isbuiltin(member) or callable(member):
+            callable_evidence: dict[str, Any] = {
+                "member": name,
+                "kind": "callable",
+                "module": str(getattr(member, "__module__", type(member).__module__)),
+                "qualname": str(getattr(member, "__qualname__", type(member).__qualname__)),
+                "type": f"{type(member).__module__}.{type(member).__qualname__}",
+            }
+            bound_state = getattr(member, "__self__", None)
+            if bound_state is not None and _is_runtime_semantic_constant(
+                bound_state, module_name=module_name
+            ):
+                callable_evidence["bound_state"] = _runtime_value_evidence(bound_state)
+            members.append(callable_evidence)
+            continue
+        raise RepositoryIntelligenceError(
+            f"{module_name}.{name} runtime state is unsupported for provenance binding"
+        )
+    return {
+        "type": f"{type(value).__module__}.{type(value).__qualname__}",
+        "members": members,
+    }
+
+
 def _runtime_dependency_module_digest(module: Any) -> str:
     """Bind a dependency module without recursively traversing arbitrary objects."""
 
@@ -938,9 +1001,23 @@ def _runtime_dependency_module_digest(module: Any) -> str:
                 }
             )
             continue
-        if (
-            name in explicit_globals or name.lstrip("_").isupper()
-        ) and _is_runtime_semantic_constant(target, module_name=module_name):
+        if name in explicit_globals:
+            value = (
+                _runtime_value_evidence(target)
+                if _is_runtime_semantic_constant(target, module_name=module_name)
+                else _runtime_configured_instance_evidence(target, module_name=module_name)
+            )
+            symbols.append(
+                {
+                    "symbol": name,
+                    "kind": "configured-global",
+                    "value": value,
+                }
+            )
+            continue
+        if name.lstrip("_").isupper() and _is_runtime_semantic_constant(
+            target, module_name=module_name
+        ):
             symbols.append(
                 {
                     "symbol": name,

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -13,6 +13,7 @@ import posixpath
 import re
 import selectors
 import signal
+import stat
 import subprocess
 import sys
 import threading
@@ -48,7 +49,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/2.0.0"
+SCANNER_VERSION = "repository-scanner/2.1.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -65,6 +66,27 @@ class RepositoryIntelligenceError(RuntimeError):
 
 class RepositorySecurityError(RepositoryIntelligenceError):
     """A containment or evidence-safety guarantee could not be established."""
+
+
+class RepositoryScanCancelledError(RepositoryIntelligenceError):
+    """A scan stopped before an exact-SHA snapshot could be safely emitted."""
+
+    def __init__(self, evidence_ref: str) -> None:
+        self.finding = Finding(
+            code="SCAN.CANCELLED",
+            category="repository_topology",
+            severity="HIGH",
+            confidence="HIGH",
+            explanation=(
+                "The scan was cancelled before immutable repository identity could be "
+                "established; no RepositorySnapshot was emitted."
+            ),
+            evidence_refs=(evidence_ref,),
+            detector_id="repository-scanner",
+            detector_version="1.1.0",
+            blocking=True,
+        )
+        super().__init__(f"{self.finding.code}: {self.finding.explanation}")
 
 
 class CommandRunner(Protocol):
@@ -104,12 +126,37 @@ class CancellationSignal:
 
 
 _PROCESS_GROUP_GUARD = "import signal\nwhile True:\n signal.pause()"
+_TRUSTED_GIT_CANDIDATES = (Path("/usr/bin/git"), Path("/bin/git"))
+
+
+def _trusted_git_executable() -> str:
+    """Resolve Git only from root-owned, non-writable operating-system paths."""
+
+    for candidate in _TRUSTED_GIT_CANDIDATES:
+        try:
+            resolved = candidate.resolve(strict=True)
+            metadata = resolved.stat()
+        except OSError:
+            continue
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != 0
+            or metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        ):
+            continue
+        return str(resolved)
+    raise FileNotFoundError("a trusted operating-system Git executable is unavailable")
 
 
 def _spawn_guarded_git(
     args: tuple[str, ...], cwd: Path, environment: dict[str, str]
 ) -> tuple[subprocess.Popen[bytes], subprocess.Popen[bytes]]:
     """Launch Git behind an inert group leader whose PID cannot be reused early."""
+
+    if not args or args[0] != "git":
+        raise RepositorySecurityError("guarded Git execution requires the logical Git command")
+    executable = _trusted_git_executable()
+    sealed_args = (executable, *args[1:])
 
     guard_environment = {"PATH": environment.get("PATH", "/usr/bin:/bin"), "LC_ALL": "C"}
     guard = subprocess.Popen(
@@ -123,7 +170,7 @@ def _spawn_guarded_git(
     )
     try:
         process = subprocess.Popen(
-            args,
+            sealed_args,
             cwd=cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -154,7 +201,7 @@ def _stop_guarded_process_group(
         raise RepositorySecurityError("bounded Git descendant termination could not be proven")
 
 
-class _ScanCancelledError(RepositoryIntelligenceError):
+class _ScanCancelledError(RepositoryScanCancelledError):
     """An in-flight bounded scan operation was cancelled."""
 
 
@@ -182,14 +229,14 @@ class TreeListingResult:
 class SubprocessCommandRunner:
     """Allowlisted local Git reader; it never invokes shells or project code."""
 
-    identity = "git-readonly-subprocess/1.7.0"
+    identity = "git-readonly-subprocess/1.8.0"
     __slots__ = ()
     _allowed = {"rev-parse", "ls-tree", "cat-file", "version"}
 
     @staticmethod
     def _environment() -> dict[str, str]:
         return {
-            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "PATH": "/usr/bin:/bin",
             "GIT_CONFIG_GLOBAL": os.devnull,
             "GIT_CONFIG_SYSTEM": os.devnull,
             "GIT_TERMINAL_PROMPT": "0",
@@ -769,7 +816,7 @@ class RepositoryScanner:
                     args,
                     root,
                     self.config.command_timeout_seconds,
-                    cancellation=self.cancellation if self._identity_resolved else None,
+                    cancellation=self.cancellation,
                 )
             else:
                 result = self.runner.run(args, root, self.config.command_timeout_seconds)
@@ -785,8 +832,10 @@ class RepositoryScanner:
         )
         if result.timed_out:
             raise RepositoryIntelligenceError("read-only Git command timed out")
-        if result.returncode == 126 and self._identity_resolved:
-            raise _ScanCancelledError("read-only Git command was cancelled")
+        if result.returncode == 126:
+            raise _ScanCancelledError(
+                "repository:identity" if not self._identity_resolved else "repository:scan"
+            )
         if result.returncode != 0:
             if essential:
                 raise RepositoryIntelligenceError("path is not an accessible Git repository")
@@ -1974,7 +2023,10 @@ class RepositoryScanner:
         partial = any(item.code in partial_codes for item in findings)
         if partial:
             for name in AUDIT_CATEGORIES:
-                if name != "active_divergent_work" and statuses[name] != "UNSUPPORTED":
+                if name != "active_divergent_work" and statuses[name] not in {
+                    "UNSUPPORTED",
+                    "BLOCKED",
+                }:
                     statuses[name] = "PARTIAL"
                     reasons[name] = "A bounded scan or adapter failure made this category partial."
         disposition = "BLOCKED" if blocking else "PARTIAL" if partial else "COMPLETE"

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -14,8 +14,9 @@ import re
 import selectors
 import signal
 import subprocess
+import sys
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from contextlib import suppress
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
@@ -46,7 +47,7 @@ from pmpe.repository.models import (
 )
 from pmpe.repository.redaction import EvidenceRedactor, RedactionError
 
-SCANNER_VERSION = "repository-scanner/1.7.0"
+SCANNER_VERSION = "repository-scanner/1.8.0"
 IMPLEMENTATION_MODULES = (
     "repository.adapters",
     "repository.models",
@@ -75,8 +76,63 @@ class Cancellation(Protocol):
     def cancelled(self) -> bool: ...
 
 
+_PROCESS_GROUP_GUARD = "import signal\nwhile True:\n signal.pause()"
+
+
+def _spawn_guarded_git(
+    args: tuple[str, ...], cwd: Path, environment: dict[str, str]
+) -> tuple[subprocess.Popen[bytes], subprocess.Popen[bytes]]:
+    """Launch Git behind an inert group leader whose PID cannot be reused early."""
+
+    guard_environment = {"PATH": environment.get("PATH", "/usr/bin:/bin"), "LC_ALL": "C"}
+    guard = subprocess.Popen(
+        (sys.executable, "-I", "-S", "-c", _PROCESS_GROUP_GUARD),
+        cwd=cwd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=guard_environment,
+        process_group=0,
+    )
+    try:
+        process = subprocess.Popen(
+            args,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            env=environment,
+            process_group=guard.pid,
+        )
+    except BaseException:
+        with suppress(ProcessLookupError, OSError):
+            os.killpg(guard.pid, signal.SIGKILL)
+        with suppress(subprocess.TimeoutExpired):
+            guard.wait(timeout=1.0)
+        raise
+    return process, guard
+
+
+def _stop_guarded_process_group(
+    process: subprocess.Popen[bytes], guard: subprocess.Popen[bytes]
+) -> None:
+    """Fence a retained group identity, then reap the command and its guard."""
+
+    group_proven = _signal_process_group(guard, signal.SIGKILL)
+    try:
+        process.wait(timeout=1.0)
+        guard.wait(timeout=1.0)
+    except subprocess.TimeoutExpired as exc:
+        raise RepositorySecurityError("bounded Git process group could not be reaped") from exc
+    if not group_proven:
+        raise RepositorySecurityError("bounded Git descendant termination could not be proven")
+
+
 class _ScanCancelledError(RepositoryIntelligenceError):
     """An in-flight bounded scan operation was cancelled."""
+
+
+class _ScanCommandBudgetError(RepositoryIntelligenceError):
+    """A required scan command could not run within the declared budget."""
 
 
 def _cancellation_requested(cancellation: Cancellation | None) -> bool:
@@ -99,7 +155,7 @@ class TreeListingResult:
 class SubprocessCommandRunner:
     """Allowlisted local Git reader; it never invokes shells or project code."""
 
-    identity = "git-readonly-subprocess/1.6.0"
+    identity = "git-readonly-subprocess/1.7.0"
     _allowed = {"rev-parse", "ls-tree", "cat-file", "version"}
 
     @staticmethod
@@ -138,19 +194,9 @@ class SubprocessCommandRunner:
     ) -> CommandResult:
         if len(args) < 2 or args[0] != "git" or args[1] not in self._allowed:
             raise RepositorySecurityError("command is outside the read-only Git allowlist")
-        try:
-            process = subprocess.Popen(
-                args,
-                cwd=cwd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
-                env=self._environment(),
-                start_new_session=True,
-            )
-        except OSError:
-            raise
+        process, guard = _spawn_guarded_git(args, cwd, self._environment())
         if process.stdout is None:
-            _stop_subprocess_group(process)
+            _stop_guarded_process_group(process, guard)
             raise RepositoryIntelligenceError("bounded Git command output is unavailable")
         selector = selectors.DefaultSelector()
         selector.register(process.stdout, selectors.EVENT_READ)
@@ -176,30 +222,18 @@ class SubprocessCommandRunner:
                     if len(payload) > 8_000_000:
                         timed_out = True
                         break
-                elif process.poll() is not None:
-                    break
         except BaseException:
-            _stop_subprocess_group(process)
+            _stop_guarded_process_group(process, guard)
             raise
         finally:
             selector.close()
             process.stdout.close()
-        if cancelled or timed_out:
-            _stop_subprocess_group(process)
-        else:
-            try:
-                process.wait(timeout=0.25)
-            except subprocess.TimeoutExpired:
-                timed_out = True
-                _stop_subprocess_group(process)
-            else:
-                if not _signal_process_group(process, signal.SIGKILL):
-                    raise RepositorySecurityError(
-                        "bounded Git descendant termination could not be proven"
-                    )
+        _stop_guarded_process_group(process, guard)
+        returncode = process.returncode
+        assert returncode is not None
         return CommandResult(
             args=args,
-            returncode=126 if cancelled else 124 if timed_out else process.returncode,
+            returncode=126 if cancelled else 124 if timed_out else returncode,
             stdout=bytes(payload),
             stderr=b"",
             timed_out=timed_out,
@@ -219,16 +253,9 @@ class SubprocessCommandRunner:
 
         if len(args) < 2 or args[0:2] != ("git", "ls-tree"):
             raise RepositorySecurityError("bounded tree reader only accepts git ls-tree")
-        process = subprocess.Popen(
-            args,
-            cwd=cwd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            env=self._environment(),
-            start_new_session=True,
-        )
+        process, guard = _spawn_guarded_git(args, cwd, self._environment())
         if process.stdout is None:
-            process.kill()
+            _stop_guarded_process_group(process, guard)
             raise RepositoryIntelligenceError("bounded tree reader did not expose output")
         selector = selectors.DefaultSelector()
         selector.register(process.stdout, selectors.EVENT_READ)
@@ -263,26 +290,14 @@ class SubprocessCommandRunner:
                     record_limit = True
                     break
         except BaseException:
-            _stop_subprocess_group(process)
+            _stop_guarded_process_group(process, guard)
             raise
         finally:
             selector.close()
             process.stdout.close()
-        if cancelled or record_limit or byte_limit or timed_out:
-            _stop_subprocess_group(process)
-            returncode = process.returncode
-        else:
-            try:
-                returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
-            except subprocess.TimeoutExpired:
-                timed_out = True
-                _stop_subprocess_group(process)
-                returncode = process.returncode
-            else:
-                if not _signal_process_group(process, signal.SIGKILL):
-                    raise RepositorySecurityError(
-                        "bounded Git descendant termination could not be proven"
-                    )
+        _stop_guarded_process_group(process, guard)
+        returncode = process.returncode
+        assert returncode is not None
         complete_records = bytes(payload[:max_output_bytes]).split(b"\0")
         if complete_records and complete_records[-1]:
             complete_records = complete_records[:-1]
@@ -340,19 +355,32 @@ def _signal_process_group(process: subprocess.Popen[bytes], action: signal.Signa
         return False
 
 
-def _stop_subprocess_group(process: subprocess.Popen[bytes]) -> None:
-    """Terminate and reap a bounded process group, including surviving descendants."""
+def _wait_for_exit_without_reaping(process: subprocess.Popen[bytes], timeout: float) -> bool:
+    """Observe child exit while retaining its PID until the process group is fenced."""
 
-    _signal_process_group(process, signal.SIGTERM)
-    with suppress(subprocess.TimeoutExpired):
-        process.wait(timeout=0.25)
-    group_proven = _signal_process_group(process, signal.SIGKILL)
-    try:
-        process.wait(timeout=1.0)
-    except subprocess.TimeoutExpired as exc:
-        raise RepositorySecurityError("bounded Git process could not be reaped") from exc
-    if not group_proven:
-        raise RepositorySecurityError("bounded Git descendant termination could not be proven")
+    if not all(hasattr(os, name) for name in ("P_PID", "WEXITED", "WNOHANG", "WNOWAIT")):
+        raise RepositorySecurityError("PID-safe bounded process observation is unsupported")
+    waitid = cast(
+        Callable[[int, int, int], object | None],
+        vars(os)["waitid"],
+    )
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            result = waitid(
+                os.P_PID,
+                process.pid,
+                os.WEXITED | os.WNOHANG | os.WNOWAIT,
+            )
+        except ChildProcessError as exc:
+            raise RepositorySecurityError(
+                "bounded process was reaped before its process group was fenced"
+            ) from exc
+        if result is not None:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.01)
 
 
 def _valid_object_id(value: str, object_format: str) -> bool:
@@ -423,8 +451,10 @@ def _implementation_digest(
 def _adapter_worker(connection: Any, adapter: RepositoryAdapter, context: AdapterContext) -> None:
     """Evaluate one adapter in a killable, environment-isolated process."""
 
+    isolated = False
     try:
         os.setsid()
+        isolated = True
         os.environ.clear()
         os.environ.update({"PATH": "/usr/bin:/bin", "LC_ALL": "C"})
         result = adapter.evaluator(context)
@@ -447,27 +477,25 @@ def _adapter_worker(connection: Any, adapter: RepositoryAdapter, context: Adapte
             )
     finally:
         connection.close()
+        if isolated:
+            while True:
+                signal.pause()
 
 
 def _stop_isolated_process(process: Any) -> None:
     """Terminate a forked evaluator and its descendants even if its parent exited."""
 
     try:
-        os.killpg(process.pid, signal.SIGTERM)
-    except ProcessLookupError:
-        pass
-    except (PermissionError, OSError):
-        if process.is_alive():
-            process.terminate()
-    process.join(timeout=0.25)
-    try:
         os.killpg(process.pid, signal.SIGKILL)
         group_proven = True
     except ProcessLookupError:
-        group_proven = True
+        group_proven = _wait_for_exit_without_reaping(process, 0.0)
+        if not group_proven:
+            with suppress(ProcessLookupError, OSError):
+                process.kill()
     except (PermissionError, OSError):
         group_proven = False
-        if process.is_alive():
+        with suppress(ProcessLookupError, OSError):
             process.kill()
     process.join(timeout=1.0)
     if process.is_alive():
@@ -639,7 +667,9 @@ class RepositoryScanner:
         ):
             raise RepositoryIntelligenceError("repository adapter declaration is invalid")
         self.runner = command_runner or SubprocessCommandRunner()
-        self.redactor = redactor or EvidenceRedactor()
+        # Exact-SHA snapshots never capture host environment values; excluding them
+        # from the default redaction context preserves cross-host determinism.
+        self.redactor = redactor or EvidenceRedactor(environment={})
         self.cancellation = cancellation
         extension_targets: list[tuple[str, Any]] = [
             ("command_runner", self.runner),
@@ -777,21 +807,11 @@ class RepositoryScanner:
 
     def _collect_tool_versions(self, root: Path) -> tuple[ToolVersion, ...]:
         try:
-            if isinstance(self.runner, SubprocessCommandRunner):
-                git_result = self.runner.run(
-                    ("git", "version"),
-                    root,
-                    self.config.command_timeout_seconds,
-                    cancellation=self.cancellation,
+            git_result = self._run(("git", "version"), root)
+            if git_result is None:
+                raise _ScanCommandBudgetError(
+                    "Git version could not be observed within the command budget"
                 )
-            else:
-                git_result = self.runner.run(
-                    ("git", "version"), root, self.config.command_timeout_seconds
-                )
-            if git_result.returncode == 126:
-                raise _ScanCancelledError("Git version observation was cancelled")
-            if git_result.timed_out or git_result.returncode != 0:
-                raise RepositoryIntelligenceError("Git version command failed")
             git_version = _text(git_result.stdout).strip()
             canonicalizer_version = importlib.metadata.version("rfc8785")
         except (
@@ -813,6 +833,35 @@ class RepositoryScanner:
                 ),
                 key=lambda item: item.tool,
             )
+        )
+
+    def _command_budget_snapshot(
+        self,
+        commit_sha: str,
+        tree_sha: str,
+        git_object_format: str,
+        config_digest: str,
+        adapter_digest: str,
+    ) -> RepositorySnapshot:
+        finding = _finding(
+            "BUDGET.COMMAND_COUNT",
+            "repository_topology",
+            "The command budget ended before required scanner tooling could be observed.",
+            ("repository:scan-budget",),
+            blocking=True,
+        )
+        return self._finalize(
+            commit_sha=commit_sha,
+            tree_sha=tree_sha,
+            git_object_format=git_object_format,
+            config_digest=config_digest,
+            adapter_digest=adapter_digest,
+            inventory_items={},
+            findings=[finding],
+            boundaries=[],
+            statuses=dict.fromkeys(AUDIT_CATEGORIES, "BLOCKED"),
+            reasons=dict.fromkeys(AUDIT_CATEGORIES, "scan command budget exhausted"),
+            disposition="BLOCKED",
         )
 
     def _cancelled_snapshot(
@@ -1306,8 +1355,6 @@ class RepositoryScanner:
                     except (KeyError, TypeError, ValueError):
                         return "ERROR", None
                     return "RESULT", result
-                if not process.is_alive():
-                    return "ERROR", None
         finally:
             receiver.close()
             _stop_isolated_process(process)
@@ -1495,8 +1542,6 @@ class RepositoryScanner:
             "Jenkinsfile",
             "MODULE.bazel",
             "Makefile",
-            "Pipfile",
-            "Pipfile.lock",
             "Procfile",
             "Rakefile",
             "SConstruct",
@@ -1733,6 +1778,14 @@ class RepositoryScanner:
                 root, tree_sha, object_format
             )
             inventory, adapter_findings, boundaries, supported = self._apply_adapters(tuple(files))
+        except _ScanCommandBudgetError:
+            return self._command_budget_snapshot(
+                commit_sha,
+                tree_sha,
+                object_format,
+                config_digest,
+                adapter_digest,
+            )
         except _ScanCancelledError:
             return self._cancelled_snapshot(
                 root, commit_sha, tree_sha, object_format, config_digest, adapter_digest

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import _thread
 import datetime as datetime_module
 import hashlib
 import importlib
-import importlib.metadata
+import importlib.metadata as importlib_metadata
 import inspect
 import json
 import multiprocessing
@@ -55,7 +56,7 @@ from pmpe.repository.redaction import (
     assert_distinct_identities_preserved,
 )
 
-SCANNER_VERSION = "repository-scanner/2.18.0"
+SCANNER_VERSION = "repository-scanner/2.19.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -125,11 +126,14 @@ _STDLIB_IMPLEMENTATION_MODULES = (
     "datetime",
     "fnmatch",
     "hashlib",
+    "importlib.metadata",
     "json",
     "json.decoder",
     "json.encoder",
     "json.scanner",
+    "os",
     "pathlib",
+    "platform",
     "posixpath",
     "re",
     "re._casefix",
@@ -149,6 +153,7 @@ _NATIVE_IMPLEMENTATION_MODULES = (
     "_json",
     "_sre",
     "math",
+    "time",
 )
 _RUNTIME_DEPENDENCY_GLOBALS = MappingProxyType(
     {
@@ -224,38 +229,82 @@ class Cancellation(Protocol):
 
 @final
 class CancellationSignal:
-    """Scalar-only cancellation capability with no nested executable state."""
+    """Cancellation capability with an atomic terminal-state handoff."""
 
-    __slots__ = ("_cancel_after_checks", "_cancelled", "_checks")
+    __slots__ = ("_cancel_after_checks", "_checks", "_lock", "_state")
+
+    _ACTIVE = 0
+    _CANCELLED = 1
+    _COMPLETED = 2
 
     def __init__(self, *, cancel_after_checks: int | None = None) -> None:
         if cancel_after_checks is not None and cancel_after_checks < 1:
             raise ValueError("cancellation check limit must be positive")
         self._cancel_after_checks = cancel_after_checks
-        self._cancelled = False
         self._checks = 0
+        self._lock = _thread.allocate_lock()
+        self._state = self._ACTIVE
 
     def _integrity_is_valid(self) -> bool:
         return (
             (self._cancel_after_checks is None or type(self._cancel_after_checks) is int)
-            and type(self._cancelled) is bool
             and type(self._checks) is int
             and self._checks >= 0
+            and type(self._lock) is _thread.LockType
+            and type(self._state) is int
+            and self._state in {self._ACTIVE, self._CANCELLED, self._COMPLETED}
         )
 
     def cancel(self) -> None:
         if not self._integrity_is_valid():
             raise RepositorySecurityError("cancellation signal integrity is invalid")
-        self._cancelled = True
+        lock = self._lock
+        with lock:
+            if not self._integrity_is_valid():
+                raise RepositorySecurityError("cancellation signal integrity is invalid")
+            if self._state == self._ACTIVE:
+                self._state = self._CANCELLED
 
     def cancelled(self) -> bool:
         if not self._integrity_is_valid():
             raise RepositorySecurityError("cancellation signal integrity is invalid")
-        self._checks += 1
-        threshold_reached = (
-            self._cancel_after_checks is not None and self._checks >= self._cancel_after_checks
-        )
-        return self._cancelled or threshold_reached
+        lock = self._lock
+        with lock:
+            if not self._integrity_is_valid():
+                raise RepositorySecurityError("cancellation signal integrity is invalid")
+            if self._state == self._COMPLETED:
+                return False
+            self._checks += 1
+            if (
+                self._state == self._ACTIVE
+                and self._cancel_after_checks is not None
+                and self._checks >= self._cancel_after_checks
+            ):
+                self._state = self._CANCELLED
+            return self._state == self._CANCELLED
+
+    def claim_completion(self) -> bool:
+        """Atomically let either cancellation or artifact admission win."""
+
+        if not self._integrity_is_valid():
+            raise RepositorySecurityError("cancellation signal integrity is invalid")
+        lock = self._lock
+        with lock:
+            if not self._integrity_is_valid():
+                raise RepositorySecurityError("cancellation signal integrity is invalid")
+            if self._state == self._COMPLETED:
+                return True
+            self._checks += 1
+            if (
+                self._state == self._ACTIVE
+                and self._cancel_after_checks is not None
+                and self._checks >= self._cancel_after_checks
+            ):
+                self._state = self._CANCELLED
+            if self._state == self._CANCELLED:
+                return False
+            self._state = self._COMPLETED
+            return True
 
 
 _PROCESS_GROUP_GUARD = "import signal\nwhile True:\n signal.pause()"
@@ -1261,6 +1310,7 @@ def _runtime_dependency_evidence() -> list[dict[str, str]]:
 def _implementation_digest(
     extension_evidence: Sequence[dict[str, str]] = (),
 ) -> str:
+    _assert_scanner_import_bindings_sealed(verify_state=True)
     evidence = _implementation_module_evidence(
         _IMPLEMENTATION_PATHS,
         _IMPORTED_SOURCE_DIGESTS,
@@ -1496,6 +1546,38 @@ _SEALED_ADAPTER_IMPORT_STATE_DIGEST = _module_import_binding_state_digest(
 _SEALED_ADAPTER_IMPORT_PROCESS_IDENTITIES = _module_import_binding_identities(
     "repository.adapters", _SEALED_ADAPTER_IMPORT_NAMES
 )
+_SEALED_SCANNER_IMPORT_NAMES = tuple(
+    sorted(name for name, target in globals().items() if type(target) is ModuleType)
+)
+_SEALED_SCANNER_IMPORT_STATE_NAMES = ("importlib_metadata", "platform")
+_SEALED_SCANNER_IMPORT_STATE_DIGEST = _module_import_binding_state_digest(
+    "repository.scanner", _SEALED_SCANNER_IMPORT_STATE_NAMES
+)
+_SEALED_SCANNER_IMPORT_PROCESS_IDENTITIES = tuple(
+    (name, id(globals()[name])) for name in _SEALED_SCANNER_IMPORT_NAMES
+)
+
+
+def _assert_scanner_import_bindings_sealed(*, verify_state: bool = False) -> None:
+    """Reject replaced or mutated output-affecting imported modules before use."""
+
+    current_identities = tuple(
+        (
+            name,
+            id(target) if type(target) is ModuleType else -1,
+        )
+        for name in _SEALED_SCANNER_IMPORT_NAMES
+        for target in (globals().get(name),)
+    )
+    if current_identities != _SEALED_SCANNER_IMPORT_PROCESS_IDENTITIES:
+        raise RepositorySecurityError("scanner imported-module bindings changed")
+    if verify_state and (
+        _module_import_binding_state_digest(
+            "repository.scanner", _SEALED_SCANNER_IMPORT_STATE_NAMES
+        )
+        != _SEALED_SCANNER_IMPORT_STATE_DIGEST
+    ):
+        raise RepositorySecurityError("scanner imported-module state changed")
 
 
 def _snapshot_identity_groups(
@@ -1505,6 +1587,7 @@ def _snapshot_identity_groups(
 
     groups: dict[str, list[tuple[str, str]]] = {
         "snapshot paths": [],
+        "evidence locations": [],
         "boundary names": [],
     }
     try:
@@ -1525,6 +1608,9 @@ def _snapshot_identity_groups(
                 strict=True,
             ):
                 groups["snapshot paths"].append((str(raw_item["path"]), str(safe_item["path"])))
+                groups["evidence locations"].append(
+                    (str(raw_item["location"]), str(safe_item["location"]))
+                )
         for raw_finding, safe_finding in zip(
             cast(list[dict[str, Any]], original["findings"]),
             cast(list[dict[str, Any]], sanitized["findings"]),
@@ -1627,6 +1713,7 @@ class RepositoryScanner:
         redactor: Any | None = None,
         cancellation: Cancellation | None = None,
     ) -> None:
+        _assert_scanner_import_bindings_sealed()
         self.config = config
         registered_adapters = _SEALED_BUILTIN_ADAPTERS
         if (
@@ -1676,6 +1763,9 @@ class RepositoryScanner:
         # from the default redaction context preserves cross-host determinism.
         self._redactor = EvidenceRedactor(environment={})
         self._cancellation = cancellation
+        self._sealed_cancellation_lock = (
+            cancellation._lock if type(cancellation) is CancellationSignal else None
+        )
         extension_targets: list[tuple[str, Any]] = [
             ("command_runner", self.runner),
             ("redactor", self.redactor),
@@ -1702,6 +1792,7 @@ class RepositoryScanner:
             self.runner,
             self.redactor,
             self.cancellation,
+            self._sealed_cancellation_lock,
             self._extension_implementation_evidence,
             self._sealed_adapter_runtime_guards,
         )
@@ -1728,11 +1819,13 @@ class RepositoryScanner:
         return self._cancellation
 
     def _assert_execution_collaborators_sealed(self) -> None:
+        _assert_scanner_import_bindings_sealed()
         current = (
             self.adapters,
             self.runner,
             self.redactor,
             self.cancellation,
+            (self.cancellation._lock if type(self.cancellation) is CancellationSignal else None),
             self._extension_implementation_evidence,
             self._sealed_adapter_runtime_guards,
         )
@@ -1786,6 +1879,15 @@ class RepositoryScanner:
             return self.cancellation.cancelled()
         except Exception:
             return True
+
+    def _claim_completion(self) -> bool:
+        self._assert_execution_collaborators_sealed()
+        if self.cancellation is None:
+            return True
+        try:
+            return self.cancellation.claim_completion()
+        except Exception:
+            return False
 
     @staticmethod
     def _cancelled_finding(evidence_ref: str) -> Finding:
@@ -1921,6 +2023,7 @@ class RepositoryScanner:
                 )
 
     def _collect_tool_versions(self, root: Path) -> tuple[ToolVersion, ...]:
+        _assert_scanner_import_bindings_sealed()
         try:
             git_result = self._run(("git", "version"), root)
             if git_result is None:
@@ -1928,12 +2031,12 @@ class RepositoryScanner:
                     "Git version could not be observed within the command budget"
                 )
             git_version = _text(git_result.stdout).strip()
-            canonicalizer_version = importlib.metadata.version("rfc8785")
+            canonicalizer_version = importlib_metadata.version("rfc8785")
         except (
             FileNotFoundError,
             OSError,
             UnicodeDecodeError,
-            importlib.metadata.PackageNotFoundError,
+            importlib_metadata.PackageNotFoundError,
         ) as exc:
             raise RepositoryIntelligenceError("scanner tool versions are unavailable") from exc
         if not git_version.startswith("git version "):
@@ -3216,6 +3319,25 @@ class RepositoryScanner:
         sanitized["snapshot_digest"] = canonical_digest(
             {key: value for key, value in sanitized.items() if key != "snapshot_digest"}
         )
+        if (
+            not any(item.code == "SCAN.CANCELLED" for item in findings)
+            and not self._claim_completion()
+        ):
+            return self._finalize(
+                commit_sha=commit_sha,
+                tree_sha=tree_sha,
+                git_object_format=git_object_format,
+                config_digest=config_digest,
+                adapter_digest=adapter_digest,
+                inventory_items=inventory_items,
+                findings=[*findings, self._cancelled_finding("repository:artifact-admission")],
+                boundaries=boundaries,
+                statuses=dict.fromkeys(AUDIT_CATEGORIES, "BLOCKED"),
+                reasons=dict.fromkeys(AUDIT_CATEGORIES, "scan cancelled"),
+                disposition="BLOCKED",
+                tracked_tree_digest=tracked_tree_digest,
+                scanned_content_digest=scanned_content_digest,
+            )
         return _snapshot_from_dict(sanitized)
 
     def scan(self, repository_root: Path | str, *, commit: str = "HEAD") -> RepositorySnapshot:

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -11,6 +11,13 @@ import importlib.metadata as importlib_metadata
 import inspect
 import json
 import multiprocessing
+import multiprocessing.connection as multiprocessing_connection
+import multiprocessing.context as multiprocessing_context
+import multiprocessing.popen_fork as multiprocessing_popen_fork
+import multiprocessing.process as multiprocessing_process
+import multiprocessing.reduction as multiprocessing_reduction
+import multiprocessing.synchronize as multiprocessing_synchronize
+import multiprocessing.util as multiprocessing_util
 import os
 import platform
 import posixpath
@@ -50,6 +57,7 @@ from pmpe.repository.models import (
     RepositorySnapshot,
     ScanConfig,
     ToolVersion,
+    _assert_repository_model_bindings_sealed,
 )
 from pmpe.repository.redaction import (
     EvidenceRedactor,
@@ -57,7 +65,7 @@ from pmpe.repository.redaction import (
     assert_distinct_identities_preserved,
 )
 
-SCANNER_VERSION = "repository-scanner/2.21.0"
+SCANNER_VERSION = "repository-scanner/2.22.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -100,6 +108,16 @@ _RUNTIME_DEPENDENCY_PATHS = MappingProxyType(
 )
 _RUNTIME_DEPENDENCY_MODULES = MappingProxyType(
     {
+        "multiprocessing": (
+            "multiprocessing",
+            "multiprocessing.connection",
+            "multiprocessing.context",
+            "multiprocessing.popen_fork",
+            "multiprocessing.process",
+            "multiprocessing.reduction",
+            "multiprocessing.synchronize",
+            "multiprocessing.util",
+        ),
         "yaml": (
             "yaml",
             "yaml.composer",
@@ -724,7 +742,11 @@ def _runtime_code_evidence(target: Any) -> list[dict[str, Any]]:
     if inspect.isclass(target):
         evidence: list[dict[str, Any]] = []
         for name, member in sorted(vars(target).items()):
-            if name.startswith("__") and name.endswith("__"):
+            if (
+                name.startswith("__")
+                and name.endswith("__")
+                and not (name == "__init__" and inspect.isfunction(member))
+            ):
                 continue
             if isinstance(member, (staticmethod, classmethod)):
                 member = member.__func__
@@ -1312,6 +1334,10 @@ def _implementation_digest(
     extension_evidence: Sequence[dict[str, str]] = (),
 ) -> str:
     _assert_scanner_import_bindings_sealed(verify_state=True)
+    try:
+        _assert_repository_model_bindings_sealed()
+    except ValueError as exc:
+        raise RepositorySecurityError("repository model digest bindings changed") from exc
     evidence = _implementation_module_evidence(
         _IMPLEMENTATION_PATHS,
         _IMPORTED_SOURCE_DIGESTS,
@@ -1677,6 +1703,16 @@ def _external_global_binding_state_digest(names: tuple[str, ...]) -> str:
 
 
 _MULTIPROCESSING_CONTEXT_MEMBER_NAMES = ("Event", "Pipe", "Process")
+_MULTIPROCESSING_IMPLEMENTATION_MODULES = (
+    multiprocessing,
+    multiprocessing_connection,
+    multiprocessing_context,
+    multiprocessing_popen_fork,
+    multiprocessing_process,
+    multiprocessing_reduction,
+    multiprocessing_synchronize,
+    multiprocessing_util,
+)
 _SEALED_MULTIPROCESSING_CONTEXT = multiprocessing.get_context("fork")
 
 
@@ -1689,20 +1725,64 @@ def _multiprocessing_context_member_identities(context: Any) -> tuple[tuple[str,
 
 
 def _multiprocessing_context_state_digest(context: Any) -> str:
-    context_type = type(context)
     return canonical_digest(
-        [
-            {
-                "member": name,
-                "state": _module_attribute_value_evidence(
-                    "multiprocessing-context",
-                    name,
-                    inspect.getattr_static(context_type, name),
-                ),
-            }
-            for name in _MULTIPROCESSING_CONTEXT_MEMBER_NAMES
-        ]
+        {
+            "context_members": [
+                {
+                    "member": name,
+                    "state": _module_attribute_value_evidence(
+                        "multiprocessing-context",
+                        name,
+                        inspect.getattr_static(type(context), name),
+                    ),
+                }
+                for name in _MULTIPROCESSING_CONTEXT_MEMBER_NAMES
+            ],
+            "implementation_modules": [
+                {
+                    "module": module.__name__,
+                    "runtime_digest": _runtime_module_namespace_digest(module),
+                }
+                for module in _MULTIPROCESSING_IMPLEMENTATION_MODULES
+            ],
+        }
     )
+
+
+def _multiprocessing_module_identities() -> tuple[tuple[str, int], ...]:
+    return tuple(
+        (module.__name__, id(module)) for module in _MULTIPROCESSING_IMPLEMENTATION_MODULES
+    )
+
+
+def _multiprocessing_primitive_identities() -> tuple[tuple[str, int], ...]:
+    return (
+        ("connection.Pipe", id(multiprocessing_connection.Pipe)),
+        ("context.ForkProcess", id(multiprocessing_context.ForkProcess)),
+        ("synchronize.Event", id(multiprocessing_synchronize.Event)),
+    )
+
+
+_SEALED_MULTIPROCESSING_MODULE_PROCESS_IDENTITIES = _multiprocessing_module_identities()
+_SEALED_MULTIPROCESSING_PRIMITIVE_PROCESS_IDENTITIES = _multiprocessing_primitive_identities()
+
+
+def _multiprocessing_context_instance_identities(
+    context: Any,
+) -> tuple[tuple[str, int], ...]:
+    """Bind context-instance shadows without inspecting hostile values."""
+
+    instance_state = vars(context)
+    return tuple(
+        (name, id(instance_state[name]))
+        for name in _MULTIPROCESSING_CONTEXT_MEMBER_NAMES
+        if name in instance_state
+    )
+
+
+_SEALED_MULTIPROCESSING_CONTEXT_INSTANCE_IDENTITIES = _multiprocessing_context_instance_identities(
+    _SEALED_MULTIPROCESSING_CONTEXT
+)
 
 
 _SEALED_MULTIPROCESSING_CONTEXT_PROCESS_IDENTITIES = (
@@ -1728,6 +1808,14 @@ def _assert_multiprocessing_context_sealed(*, verify_state: bool = True) -> None
     )
     if current_identities != _SEALED_MULTIPROCESSING_CONTEXT_PROCESS_IDENTITIES:
         raise RepositorySecurityError("multiprocessing context or members changed")
+    if (
+        _multiprocessing_module_identities() != _SEALED_MULTIPROCESSING_MODULE_PROCESS_IDENTITIES
+        or _multiprocessing_primitive_identities()
+        != _SEALED_MULTIPROCESSING_PRIMITIVE_PROCESS_IDENTITIES
+        or _multiprocessing_context_instance_identities(current_context)
+        != _SEALED_MULTIPROCESSING_CONTEXT_INSTANCE_IDENTITIES
+    ):
+        raise RepositorySecurityError("multiprocessing runtime or context instance changed")
     if verify_state and (
         _multiprocessing_context_state_digest(current_context)
         != _SEALED_MULTIPROCESSING_CONTEXT_STATE_DIGEST
@@ -1735,9 +1823,19 @@ def _assert_multiprocessing_context_sealed(*, verify_state: bool = True) -> None
         raise RepositorySecurityError("multiprocessing context member state changed")
 
 
-def _sealed_multiprocessing_context() -> Any:
+def _sealed_fork_pipe(*, duplex: bool) -> tuple[Any, Any]:
     _assert_multiprocessing_context_sealed()
-    return _SEALED_MULTIPROCESSING_CONTEXT
+    return multiprocessing_connection.Pipe(duplex=duplex)
+
+
+def _sealed_fork_event() -> Any:
+    _assert_multiprocessing_context_sealed()
+    return multiprocessing_synchronize.Event(ctx=_SEALED_MULTIPROCESSING_CONTEXT)
+
+
+def _sealed_fork_process(**kwargs: Any) -> Any:
+    _assert_multiprocessing_context_sealed()
+    return multiprocessing_context.ForkProcess(**kwargs)
 
 
 _SEALED_SCANNER_MODULE_ATTRIBUTE_NAMES = _direct_module_attribute_names(
@@ -2793,9 +2891,8 @@ class RepositoryScanner:
         expected_adapter_identity, expected_evaluator_identity, expected_state_digest = (
             sealed_guards[adapter.adapter_id]
         )
-        process_context = _sealed_multiprocessing_context()
-        receiver, sender = process_context.Pipe(duplex=False)
-        process = process_context.Process(
+        receiver, sender = _sealed_fork_pipe(duplex=False)
+        process = _sealed_fork_process(
             target=_adapter_worker,
             args=(
                 sender,

--- a/tests/e2e/test_repository_intelligence_cli.py
+++ b/tests/e2e/test_repository_intelligence_cli.py
@@ -39,8 +39,10 @@ def test_repository_scan_cli_writes_artifacts_outside_scanned_repo(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     repo = _repo(tmp_path)
-    out = tmp_path / "evidence" / "snapshot.json"
-    observation = tmp_path / "evidence" / "governance.json"
+    output_parent = tmp_path / "evidence"
+    output_parent.mkdir()
+    out = output_parent / "snapshot.json"
+    observation = output_parent / "governance.json"
     before = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
     code = main(
         [
@@ -72,6 +74,26 @@ def test_repository_scan_cli_writes_artifacts_outside_scanned_repo(
     output = json.loads(capsys.readouterr().out)
     assert output["snapshot_digest"].startswith("sha256:")
     assert output["governance_observation_id"] == "OBS-CLI-001"
+
+
+def test_repository_scan_cli_refuses_to_create_unpinned_output_parents(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    missing_parent = tmp_path / "untrusted-parent"
+    code = main(
+        [
+            "repository",
+            "scan",
+            "--repo",
+            str(repo),
+            "--repository",
+            "example/cli-fixture",
+            "--snapshot-out",
+            str(missing_parent / "snapshot.json"),
+        ]
+    )
+    assert code != 0
+    assert not missing_parent.exists()
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == ""
 
 
 def test_repository_scan_cli_refuses_to_write_inside_scanned_repository(

--- a/tests/e2e/test_repository_intelligence_cli.py
+++ b/tests/e2e/test_repository_intelligence_cli.py
@@ -1,0 +1,92 @@
+"""Issue #64 public CLI contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from pmpe.cli import main
+
+pytestmark = pytest.mark.e2e
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repository"
+    repo.mkdir()
+    _git(repo, "init", "-q", "--initial-branch=main")
+    _git(repo, "config", "user.email", "fixture@localhost")
+    _git(repo, "config", "user.name", "Fixture")
+    (repo / "pyproject.toml").write_text("[project]\nname='cli-fixture'\nversion='1'\n")
+    (repo / "README.md").write_text("# CLI fixture\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "fixture")
+    return repo
+
+
+def test_repository_scan_cli_writes_artifacts_outside_scanned_repo(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _repo(tmp_path)
+    out = tmp_path / "evidence" / "snapshot.json"
+    observation = tmp_path / "evidence" / "governance.json"
+    before = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    code = main(
+        [
+            "repository",
+            "scan",
+            "--repo",
+            str(repo),
+            "--repository",
+            "example/cli-fixture",
+            "--commit",
+            "HEAD",
+            "--default-branch",
+            "main",
+            "--snapshot-out",
+            str(out),
+            "--governance-out",
+            str(observation),
+            "--observed-at",
+            "2026-08-01T00:00:00Z",
+            "--observation-id",
+            "OBS-CLI-001",
+        ]
+    )
+    after = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    assert code == 0
+    assert before == after == ""
+    assert json.loads(out.read_text())["artifact_kind"] == "REPOSITORY_SNAPSHOT"
+    assert json.loads(observation.read_text())["artifact_kind"] == "GOVERNANCE_OBSERVATION"
+    output = json.loads(capsys.readouterr().out)
+    assert output["snapshot_digest"].startswith("sha256:")
+    assert output["governance_observation_id"] == "OBS-CLI-001"
+
+
+def test_repository_scan_cli_refuses_to_write_inside_scanned_repository(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    code = main(
+        [
+            "repository",
+            "scan",
+            "--repo",
+            str(repo),
+            "--repository",
+            "example/cli-fixture",
+            "--snapshot-out",
+            str(repo / "snapshot.json"),
+        ]
+    )
+    assert code != 0
+    assert not (repo / "snapshot.json").exists()

--- a/tests/e2e/test_repository_intelligence_cli.py
+++ b/tests/e2e/test_repository_intelligence_cli.py
@@ -63,7 +63,7 @@ def test_repository_scan_cli_writes_artifacts_outside_scanned_repo(
         ]
     )
     after = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
-    assert code == 0
+    assert code == 3
     assert before == after == ""
     assert json.loads(out.read_text())["artifact_kind"] == "REPOSITORY_SNAPSHOT"
     assert json.loads(observation.read_text())["artifact_kind"] == "GOVERNANCE_OBSERVATION"
@@ -108,6 +108,27 @@ def test_repository_scan_cli_uses_actual_git_root_for_output_containment(
             "--repository",
             "example/cli-fixture",
             "--snapshot-out",
+            str(output),
+        ]
+    )
+    assert code != 0
+    assert not output.exists()
+
+
+def test_repository_scan_cli_requires_distinct_artifact_outputs(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    output = tmp_path / "evidence" / "artifact.json"
+    code = main(
+        [
+            "repository",
+            "scan",
+            "--repo",
+            str(repo),
+            "--repository",
+            "example/cli-fixture",
+            "--snapshot-out",
+            str(output),
+            "--governance-out",
             str(output),
         ]
     )

--- a/tests/e2e/test_repository_intelligence_cli.py
+++ b/tests/e2e/test_repository_intelligence_cli.py
@@ -90,3 +90,26 @@ def test_repository_scan_cli_refuses_to_write_inside_scanned_repository(
     )
     assert code != 0
     assert not (repo / "snapshot.json").exists()
+
+
+def test_repository_scan_cli_uses_actual_git_root_for_output_containment(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    nested = repo / "packages" / "component"
+    nested.mkdir(parents=True)
+    output = repo / "root-level-snapshot.json"
+    code = main(
+        [
+            "repository",
+            "scan",
+            "--repo",
+            str(nested),
+            "--repository",
+            "example/cli-fixture",
+            "--snapshot-out",
+            str(output),
+        ]
+    )
+    assert code != 0
+    assert not output.exists()

--- a/tests/e2e/test_repository_intelligence_cli.py
+++ b/tests/e2e/test_repository_intelligence_cli.py
@@ -134,3 +134,62 @@ def test_repository_scan_cli_requires_distinct_artifact_outputs(tmp_path: Path) 
     )
     assert code != 0
     assert not output.exists()
+
+
+def test_repository_scan_cli_refuses_sibling_worktree_output(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    sibling = tmp_path / "sibling-worktree"
+    _git(repo, "worktree", "add", "-q", "-b", "sibling", str(sibling))
+    output = sibling / "snapshot.json"
+    code = main(
+        [
+            "repository",
+            "scan",
+            "--repo",
+            str(repo),
+            "--repository",
+            "example/cli-fixture",
+            "--snapshot-out",
+            str(output),
+        ]
+    )
+    assert code != 0
+    assert not output.exists()
+
+
+def test_repository_scan_cli_refuses_external_git_metadata_output(tmp_path: Path) -> None:
+    repo = tmp_path / "separate-repository"
+    metadata = tmp_path / "separate-metadata.git"
+    repo.mkdir()
+    subprocess.run(
+        [
+            "git",
+            "init",
+            "-q",
+            "--initial-branch=main",
+            f"--separate-git-dir={metadata}",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    _git(repo, "config", "user.email", "fixture@localhost")
+    _git(repo, "config", "user.name", "Fixture")
+    (repo / "README.md").write_text("# Separate Git directory\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "fixture")
+    index = metadata / "index"
+    before_index = index.read_bytes()
+    code = main(
+        [
+            "repository",
+            "scan",
+            "--repo",
+            str(repo),
+            "--repository",
+            "example/separate-fixture",
+            "--snapshot-out",
+            str(index),
+        ]
+    )
+    assert code != 0
+    assert index.read_bytes() == before_index

--- a/tests/e2e/test_repository_intelligence_cli.py
+++ b/tests/e2e/test_repository_intelligence_cli.py
@@ -8,7 +8,9 @@ from pathlib import Path
 
 import pytest
 
-from pmpe.cli import main
+from pmpe.cli import main, repository_cmd
+from pmpe.repository import scan_repository
+from pmpe.repository.models import RepositorySnapshot, ScanConfig
 
 pytestmark = pytest.mark.e2e
 
@@ -193,3 +195,43 @@ def test_repository_scan_cli_refuses_external_git_metadata_output(tmp_path: Path
     )
     assert code != 0
     assert index.read_bytes() == before_index
+
+
+def test_repository_scan_cli_refuses_output_directory_symlink_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _repo(tmp_path)
+    output_parent = tmp_path / "evidence"
+    output_parent.mkdir()
+    moved_parent = tmp_path / "moved-evidence"
+    output = output_parent / "snapshot.json"
+
+    def scan_then_swap(
+        repository_root: Path | str,
+        *,
+        commit: str = "HEAD",
+        config: ScanConfig,
+    ) -> RepositorySnapshot:
+        snapshot = scan_repository(repository_root, commit=commit, config=config)
+        output_parent.rename(moved_parent)
+        output_parent.symlink_to(repo, target_is_directory=True)
+        return snapshot
+
+    monkeypatch.setattr(repository_cmd, "scan_repository", scan_then_swap)
+    code = main(
+        [
+            "repository",
+            "scan",
+            "--repo",
+            str(repo),
+            "--repository",
+            "example/cli-fixture",
+            "--snapshot-out",
+            str(output),
+        ]
+    )
+    assert code != 0
+    assert not (repo / "snapshot.json").exists()
+    assert not (moved_parent / "snapshot.json").exists()
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == ""

--- a/tests/e2e/test_repository_intelligence_cli.py
+++ b/tests/e2e/test_repository_intelligence_cli.py
@@ -235,3 +235,47 @@ def test_repository_scan_cli_refuses_output_directory_symlink_swap(
     assert not (repo / "snapshot.json").exists()
     assert not (moved_parent / "snapshot.json").exists()
     assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == ""
+
+
+def test_repository_scan_cli_refuses_output_directory_adopted_as_worktree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _repo(tmp_path)
+    output_parent = tmp_path / "evidence"
+    output_parent.mkdir()
+    output = output_parent / "snapshot.json"
+
+    def scan_then_adopt(
+        repository_root: Path | str,
+        *,
+        commit: str = "HEAD",
+        config: ScanConfig,
+    ) -> RepositorySnapshot:
+        snapshot = scan_repository(repository_root, commit=commit, config=config)
+        reservations = tuple(output_parent.glob(".pmpe-intelligence-reservation.*"))
+        assert reservations
+        for reservation in reservations:
+            reservation.unlink()
+        subprocess.run(
+            ["git", "worktree", "add", "-q", "-b", "adopt-output", str(output_parent)],
+            cwd=repo,
+            check=True,
+        )
+        return snapshot
+
+    monkeypatch.setattr(repository_cmd, "scan_repository", scan_then_adopt)
+    code = main(
+        [
+            "repository",
+            "scan",
+            "--repo",
+            str(repo),
+            "--repository",
+            "example/cli-fixture",
+            "--snapshot-out",
+            str(output),
+        ]
+    )
+    assert code != 0
+    assert not output.exists()

--- a/tests/integration/test_repository_intelligence.py
+++ b/tests/integration/test_repository_intelligence.py
@@ -62,6 +62,7 @@ def test_public_api_emits_separate_canonical_artifacts_without_mutating_repo(
         repo,
         repository="example/integration",
         ref="main",
+        snapshot=snapshot,
         clock=FixedClock(),
         id_provider=FixedIds(),
     )
@@ -92,6 +93,7 @@ def test_dirty_state_is_only_in_governance_artifact(tmp_path: Path) -> None:
         repo,
         repository="example/integration",
         ref="main",
+        snapshot=snapshot,
         clock=FixedClock(),
         id_provider=FixedIds(),
     )

--- a/tests/integration/test_repository_intelligence.py
+++ b/tests/integration/test_repository_intelligence.py
@@ -40,16 +40,6 @@ def _repo(tmp_path: Path) -> Path:
     return repo
 
 
-class FixedClock:
-    def now(self) -> str:
-        return "2026-08-01T12:00:00Z"
-
-
-class FixedIds:
-    def new_id(self) -> str:
-        return "OBS-INTEGRATION-001"
-
-
 def test_public_api_emits_separate_canonical_artifacts_without_mutating_repo(
     tmp_path: Path,
 ) -> None:
@@ -63,8 +53,8 @@ def test_public_api_emits_separate_canonical_artifacts_without_mutating_repo(
         repository="example/integration",
         ref="main",
         snapshot=snapshot,
-        clock=FixedClock(),
-        id_provider=FixedIds(),
+        clock=api.RecordedUtcClock("2026-08-01T12:00:00Z"),
+        id_provider=api.RecordedObservationIds("OBS-INTEGRATION-001"),
     )
     after = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
 
@@ -94,8 +84,8 @@ def test_dirty_state_is_only_in_governance_artifact(tmp_path: Path) -> None:
         repository="example/integration",
         ref="main",
         snapshot=snapshot,
-        clock=FixedClock(),
-        id_provider=FixedIds(),
+        clock=api.RecordedUtcClock("2026-08-01T12:00:00Z"),
+        id_provider=api.RecordedObservationIds("OBS-INTEGRATION-001"),
     )
     assert "dirty" not in snapshot.canonical_bytes().decode()
     assert observation.local_state.worktree_dirty is True

--- a/tests/integration/test_repository_intelligence.py
+++ b/tests/integration/test_repository_intelligence.py
@@ -1,0 +1,100 @@
+"""Integrated exact-commit snapshot plus mutable-governance evidence."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _api() -> ModuleType:
+    try:
+        return importlib.import_module("pmpe.repository")
+    except ModuleNotFoundError:
+        pytest.fail("issue #64 repository-intelligence API is not implemented", pytrace=False)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repository"
+    repo.mkdir()
+    _git(repo, "init", "-q", "--initial-branch=main")
+    _git(repo, "config", "user.email", "fixture@localhost")
+    _git(repo, "config", "user.name", "Fixture")
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("def main() -> None:\n    pass\n")
+    (repo / "pyproject.toml").write_text("[project]\nname='fixture'\nversion='1'\n")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_app.py").write_text("def test_app():\n    assert True\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "fixture")
+    return repo
+
+
+class FixedClock:
+    def now(self) -> str:
+        return "2026-08-01T12:00:00Z"
+
+
+class FixedIds:
+    def new_id(self) -> str:
+        return "OBS-INTEGRATION-001"
+
+
+def test_public_api_emits_separate_canonical_artifacts_without_mutating_repo(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    repo = _repo(tmp_path)
+    before = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    config = api.ScanConfig(repository="example/integration", default_branch="main")
+    snapshot = api.scan_repository(repo, commit="HEAD", config=config)
+    observation = api.observe_governance(
+        repo,
+        repository="example/integration",
+        ref="main",
+        clock=FixedClock(),
+        id_provider=FixedIds(),
+    )
+    after = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+    assert before == after == ""
+    assert snapshot.commit_sha == _git(repo, "rev-parse", "HEAD")
+    assert snapshot.artifact_kind == "REPOSITORY_SNAPSHOT"
+    assert observation.artifact_kind == "GOVERNANCE_OBSERVATION"
+    assert snapshot.snapshot_digest != observation.observation_output_digest
+    assert json.loads(snapshot.canonical_bytes())["snapshot_digest"] == snapshot.snapshot_digest
+    assert (
+        json.loads(observation.canonical_bytes())["observation_output_digest"]
+        == observation.observation_output_digest
+    )
+
+
+def test_dirty_state_is_only_in_governance_artifact(tmp_path: Path) -> None:
+    api = _api()
+    repo = _repo(tmp_path)
+    (repo / "src" / "app.py").write_text("dirty\n")
+    snapshot = api.scan_repository(
+        repo,
+        commit="HEAD",
+        config=api.ScanConfig(repository="example/integration", default_branch="main"),
+    )
+    observation = api.observe_governance(
+        repo,
+        repository="example/integration",
+        ref="main",
+        clock=FixedClock(),
+        id_provider=FixedIds(),
+    )
+    assert "dirty" not in snapshot.canonical_bytes().decode()
+    assert observation.local_state.worktree_dirty is True
+    assert (repo / "src" / "app.py").read_text() == "dirty\n"

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -11,6 +11,7 @@ import subprocess
 import threading
 import time
 from dataclasses import asdict, replace
+from datetime import timedelta, timezone
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -384,6 +385,10 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
             lambda payload=b"", *args, **kwargs: original_sha256(payload, *args, **kwargs),
         )
         assert scanner._implementation_digest() != original
+    urllib_parse = importlib.import_module("urllib.parse")
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(urllib_parse, "uses_netloc", [*urllib_parse.uses_netloc, "custom"])
+        assert scanner._implementation_digest() != original
     for module_name, attribute in (
         ("configparser", "ConfigParser"),
         ("datetime", "datetime"),
@@ -425,6 +430,18 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
         )
 
 
+def test_dormant_cancellation_signal_does_not_change_exact_snapshot(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    baseline = api.RepositoryScanner(config=_config()).scan(repo, commit="HEAD")
+    cancellable = api.RepositoryScanner(
+        config=_config(),
+        cancellation=api.CancellationSignal(),
+    ).scan(repo, commit="HEAD")
+    assert cancellable.canonical_bytes() == baseline.canonical_bytes()
+    assert cancellable.implementation_digest == baseline.implementation_digest
+
+
 def test_governance_provenance_binds_every_material_repository_module() -> None:
     governance = importlib.import_module("pmpe.repository.governance")
     assert set(governance.GOVERNANCE_IMPLEMENTATION_MODULES) == {
@@ -438,6 +455,9 @@ def test_governance_provenance_binds_every_material_repository_module() -> None:
     rfc8785_module = importlib.import_module("rfc8785")
     with pytest.MonkeyPatch.context() as runtime_patch:
         runtime_patch.setattr(rfc8785_module, "dumps", lambda value: b"changed")
+        assert governance._governance_implementation_digest() != original
+    with pytest.MonkeyPatch.context() as runtime_patch:
+        runtime_patch.setattr(governance, "UTC", timezone(timedelta(hours=1)))
         assert governance._governance_implementation_digest() != original
 
 
@@ -2242,6 +2262,26 @@ def _observe(repo: Path, remote: Any = None) -> Any:
         id_provider=_fixed_ids(),
         remote_provider=_sealed_remote(remote) if remote is not None else None,
     ).observe(repo, ref="main")
+
+
+def test_dormant_cancellation_signal_does_not_change_governance_observation(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    baseline = api.GovernanceCollector(
+        repository="example/fixture",
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
+    ).observe(repo, ref="main")
+    cancellable = api.GovernanceCollector(
+        repository="example/fixture",
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
+        cancellation=api.CancellationSignal(),
+    ).observe(repo, ref="main")
+    assert cancellable.canonical_bytes() == baseline.canonical_bytes()
+    assert cancellable.collector_implementation_digest == baseline.collector_implementation_digest
 
 
 def test_governance_observation_records_dirty_index_worktree_and_untracked_state(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -120,6 +120,15 @@ def test_exact_sha_snapshot_is_byte_deterministic_and_has_no_timestamp(tmp_path:
     assert "pull_requests" not in first.as_dict()
 
 
+def test_equivalent_ref_and_exact_sha_produce_same_snapshot(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    commit_sha = _git(repo, "rev-parse", "HEAD")
+    from_ref = api.RepositoryScanner(config=_config()).scan(repo, commit="HEAD")
+    from_sha = api.RepositoryScanner(config=_config()).scan(repo, commit=commit_sha)
+    assert from_ref.canonical_bytes() == from_sha.canonical_bytes()
+
+
 def test_dirty_tracked_content_does_not_change_exact_commit_snapshot(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     before = _scan(repo)
@@ -289,6 +298,7 @@ def test_adapter_failure_is_visible_and_cannot_remove_categories(tmp_path: Path)
     ("config_change", "expected_code"),
     [
         ({"max_files": 2}, "BUDGET.FILE_COUNT"),
+        ({"max_directories": 1}, "BUDGET.DIRECTORY_COUNT"),
         ({"max_total_bytes": 16}, "BUDGET.TOTAL_BYTES"),
         ({"max_file_bytes": 8}, "BUDGET.FILE_BYTES"),
         ({"max_path_depth": 1}, "BUDGET.PATH_DEPTH"),
@@ -316,6 +326,15 @@ def test_binary_files_are_structural_evidence_but_never_decoded(tmp_path: Path) 
     assert any(
         item.kind == "BINARY_FILE" for item in snapshot.inventory["repository_topology"].items
     )
+
+
+def test_submodule_gitlink_is_inventory_only_and_never_executed(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    commit_sha = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "update-index", "--add", "--cacheinfo", f"160000,{commit_sha},vendor/example")
+    _git(repo, "commit", "-q", "-m", "gitlink")
+    snapshot = _scan(repo)
+    assert any(item.kind == "SUBMODULE" for item in snapshot.inventory["repository_topology"].items)
 
 
 def test_symlink_escape_is_refused_without_following_target(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -754,6 +754,30 @@ def test_shell_source_without_adapter_is_blocked_not_reported_absent(tmp_path: P
     assert any(item.code == "STACK.UNSUPPORTED_FILE_TYPE" for item in snapshot.findings)
 
 
+def test_adapter_classified_file_types_are_not_also_reported_unsupported(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "contracts/events.proto", 'syntax = "proto3";\n')
+    _write(repo, "contracts/query.graphql", "type Query { ready: Boolean! }\n")
+    _write(repo, "containers/Dockerfile.dev", "FROM scratch\n")
+    _write(repo, "config/.env.production", "DEPLOYMENT=production\n")
+    _commit(repo, "supported domain-specific files")
+    snapshot = _scan(repo)
+    unsupported_refs = {
+        ref
+        for finding in snapshot.findings
+        if finding.code == "STACK.UNSUPPORTED_FILE_TYPE"
+        for ref in finding.evidence_refs
+    }
+    assert unsupported_refs.isdisjoint(
+        {
+            "contracts/events.proto",
+            "contracts/query.graphql",
+            "containers/Dockerfile.dev",
+            "config/.env.production",
+        }
+    )
+
+
 @pytest.mark.parametrize(
     "manifest",
     ["Makefile", "WORKSPACE", "BUILD.bazel", "Jenkinsfile", "Rakefile", "Procfile"],
@@ -1382,7 +1406,7 @@ def test_worktree_lifecycle_flags_are_preserved_and_prunable_state_blocks(
                 stdout=(
                     f"worktree {repo}\0HEAD {head}\0detached\0locked maintenance\0"
                     "prunable gitdir-missing\0\0"
-                    f"worktree {repo.parent / 'bare.git'}\0HEAD {head}\0bare\0\0"
+                    f"worktree {repo.parent / 'bare.git'}\0bare\0\0"
                 ),
                 stderr="",
             )
@@ -1401,8 +1425,42 @@ def test_worktree_lifecycle_flags_are_preserved_and_prunable_state_blocks(
     assert bare.bare is True
     assert bare.detached is False
     assert bare.branch == "BARE"
+    assert bare.head_sha == ""
     assert observation.disposition == "BLOCKED"
     assert any(item.fact == "worktree_prunable:1" for item in observation.unknowns)
+
+
+def test_bare_worktree_with_fabricated_head_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    repo = _init_repo(tmp_path)
+    head = _git(repo, "rev-parse", "HEAD")
+    original = governance.GovernanceCommandRunner.run
+
+    def invalid_bare_worktree(
+        self: Any,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        cancellation: Any = None,
+    ) -> Any:
+        if args[1:3] == ("worktree", "list"):
+            return api.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=f"worktree {repo.parent / 'bare.git'}\0HEAD {head}\0bare\0\0",
+                stderr="",
+            )
+        return original(self, args, cwd, timeout, cancellation=cancellation)
+
+    monkeypatch.setattr(governance.GovernanceCommandRunner, "run", invalid_bare_worktree)
+    observation = _observe(repo)
+    assert observation.disposition == "BLOCKED"
+    assert observation.worktrees == ()
+    assert any(item.fact == "worktree_record:1" for item in observation.unknowns)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -344,6 +344,27 @@ def test_snapshot_binds_implementation_modules_and_runtime_tool_versions(tmp_pat
     }
 
 
+def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    original = scanner._implementation_digest()
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(scanner, "_valid_object_id", lambda _value, _format: True)
+        assert scanner._implementation_digest() != original
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(scanner, "_OBJECT_FORMAT_LENGTH", {"sha1": 1, "sha256": 1})
+        assert scanner._implementation_digest() != original
+
+    mismatched_sources = dict(scanner._IMPORTED_SOURCE_DIGESTS)
+    mismatched_sources["repository.scanner"] = "sha256:" + "0" * 64
+    with pytest.raises(scanner.RepositorySecurityError, match="changed after"):
+        scanner._implementation_module_evidence(
+            scanner._IMPLEMENTATION_PATHS,
+            mismatched_sources,
+        )
+
+
 def test_governance_provenance_binds_every_material_repository_module() -> None:
     governance = importlib.import_module("pmpe.repository.governance")
     assert set(governance.GOVERNANCE_IMPLEMENTATION_MODULES) == {
@@ -817,6 +838,12 @@ def test_non_github_ci_is_not_reported_as_ci_absent(tmp_path: Path) -> None:
     [
         (".gitlab-ci.yml", "variables:\n  FOO: bar\n"),
         ("azure-pipelines.yml", "steps: []\n"),
+        (
+            ".github/workflows/ci.yml",
+            "name: empty\non: [push]\njobs:\n  empty: {}\n",
+        ),
+        (".circleci/config.yml", "version: 2.1\njobs: []\n"),
+        ("bitbucket-pipelines.yml", "pipelines:\n  default:\n"),
     ],
 )
 def test_non_runnable_ci_scaffolds_do_not_suppress_missing_ci(
@@ -2571,6 +2598,19 @@ def test_governance_budget_hard_ceilings_cannot_be_disabled(
     collector = api.GovernanceCollector(**kwargs)
     with pytest.raises(api.RepositoryIntelligenceError, match="hard safety ceiling"):
         collector.observe(_init_repo(tmp_path), ref="main")
+
+
+def test_governance_runner_budget_must_match_recorded_collector_budget() -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    with pytest.raises(api.RepositorySecurityError, match="must match"):
+        api.GovernanceCollector(
+            repository="example/fixture",
+            clock=_fixed_clock(),
+            id_provider=_fixed_ids(),
+            command_runner=governance.GovernanceCommandRunner(max_output_bytes=4_096),
+            max_output_bytes=2_048,
+        )
 
 
 def test_scan_and_observation_never_create_branches_commits_or_remote_mutations(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -835,15 +835,16 @@ def test_integration_declarations_and_codeowners_are_evidence_backed(tmp_path: P
     assert any(item.kind == "OWNERSHIP_AREA" for item in snapshot.boundary_candidates)
 
 
-def test_non_github_ci_is_not_reported_as_ci_absent(tmp_path: Path) -> None:
+def test_non_github_ci_is_visible_but_remains_structurally_unproven(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path, mixed=False)
     _write(repo, ".gitlab-ci.yml", "test:\n  script: pytest\n")
     _commit(repo, "gitlab ci")
     snapshot = _scan(repo)
-    assert any(
-        item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
-    )
-    assert not any(item.code == "DELIVERY.CI_ABSENT" for item in snapshot.findings)
+    delivery = snapshot.inventory["delivery_environments"].items
+    assert any(item.kind == "CI_CONFIGURATION_SIGNAL" for item in delivery)
+    assert not any(item.kind == "CI_WORKFLOW" for item in delivery)
+    assert any(item.code == "WORKFLOW.STRUCTURE_UNPROVEN" for item in snapshot.findings)
+    assert any(item.code == "DELIVERY.CI_ABSENT" for item in snapshot.findings)
 
 
 @pytest.mark.parametrize(
@@ -936,6 +937,39 @@ def test_non_github_ci_is_not_reported_as_ci_absent(tmp_path: Path) -> None:
             ".github/workflows/ci.yml",
             "name: invalid action reference\non: [push]\njobs:\n  test:\n"
             "    runs-on: ubuntu-latest\n    steps:\n      - uses: arbitrary-string\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: invalid job id\non: [push]\njobs:\n  'bad id':\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: unsupported top key\non: [push]\nunsupported: true\njobs:\n  test:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: unsupported job key\non: [push]\njobs:\n  test:\n"
+            "    runs-on: ubuntu-latest\n    unsupported: true\n"
+            "    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: unsupported step key\non: [push]\njobs:\n  test:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n"
+            "        unsupported: true\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: invalid schedule\non:\n  schedule:\n    - cron: '99 99 * * *'\n"
+            "jobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: conflicting filters\non:\n  push:\n    branches: [main]\n"
+            "    branches-ignore: [legacy]\njobs:\n  test:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
         ),
         (".circleci/config.yml", "version: 2.1\njobs: []\n"),
         (

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -208,13 +208,33 @@ def test_adapter_metadata_is_versioned_and_declares_supported_categories(
         "stack.python",
         "stack.node-web",
         "stack.docker-compose",
-        "delivery.github-actions",
+        "delivery.ci",
         "interface.schema-api",
+        "integration.manifest-declarations",
         "repository.pmpe",
     }
     assert all(item.version and item.file_patterns for item in snapshot.adapters)
     assert all(item.supported_categories for item in snapshot.adapters)
     assert all(item.failure_behavior == "VISIBLE_PARTIAL_OR_BLOCKED" for item in snapshot.adapters)
+
+
+def test_snapshot_binds_implementation_modules_and_runtime_tool_versions(tmp_path: Path) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    snapshot = _scan(_init_repo(tmp_path))
+    assert set(scanner.IMPLEMENTATION_MODULES) == {
+        "repository.adapters",
+        "repository.models",
+        "repository.redaction",
+        "repository.scanner",
+        "contracts.canonical",
+    }
+    assert snapshot.implementation_digest == scanner._implementation_digest()
+    assert {item.tool for item in snapshot.tool_versions} == {
+        "git",
+        "python",
+        "pyyaml",
+        "rfc8785",
+    }
 
 
 def test_api_data_generated_client_migration_and_contract_sync_are_inventory_items(
@@ -223,6 +243,39 @@ def test_api_data_generated_client_migration_and_contract_sync_are_inventory_ite
     snapshot = _scan(_init_repo(tmp_path))
     kinds = {item.kind for item in snapshot.inventory["apis_data"].items}
     assert {"OPENAPI", "MIGRATION", "CODE_GENERATOR"} <= kinds
+
+
+def test_integration_declarations_and_codeowners_are_evidence_backed(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _write(
+        repo,
+        "packages/web/package.json",
+        json.dumps(
+            {
+                "name": "web",
+                "dependencies": {"example-sdk": "1.0.0"},
+                "scripts": {"test": "vitest"},
+            }
+        ),
+    )
+    _commit(repo, "integration declaration")
+    snapshot = _scan(repo)
+    assert any(
+        item.kind == "EXTERNAL_DEPENDENCY_DECLARATION"
+        for item in snapshot.inventory["integrations"].items
+    )
+    assert any(item.kind == "OWNERSHIP_AREA" for item in snapshot.boundary_candidates)
+
+
+def test_non_github_ci_is_not_reported_as_ci_absent(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, ".gitlab-ci.yml", "test:\n  script: pytest\n")
+    _commit(repo, "gitlab ci")
+    snapshot = _scan(repo)
+    assert any(
+        item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
+    )
+    assert not any(item.code == "DELIVERY.CI_ABSENT" for item in snapshot.findings)
 
 
 def test_tests_delivery_security_observability_and_governance_are_evidence_backed(
@@ -446,10 +499,20 @@ class _FakeRemote:
     tool_identity = "fake-github-readonly/1.0"
     api_version = "github-rest/2026-03-10"
 
-    def collect(self, repository: str, ref: str) -> dict[str, Any]:
+    def collect(
+        self,
+        repository: str,
+        ref: str,
+        **bounds: Any,
+    ) -> dict[str, Any]:
         assert repository == "example/fixture"
+        assert bounds["timeout_seconds"] > 0
+        assert bounds["max_output_bytes"] > 0
+        assert bounds["max_items"] > 0
         return {
             "complete": True,
+            "observed_at": "2026-08-01T00:00:00Z",
+            "coverage": ["remote_branches", "pull_requests", "issues", "governance"],
             "remote_branches": [{"name": "origin/feature", "sha": "a" * 40}],
             "pull_requests": [{"number": 7, "draft": True, "head": "a" * 40}],
             "issues": [{"number": 8, "state": "OPEN"}],
@@ -469,6 +532,8 @@ class _FakeRemote:
             "safe_url": "https://user:password@example.invalid/repo?token=secret-value",
             "authorization": "Basic dXNlcjpwYXNzd29yZA==",
             "x-api-key": "unstructured-bare-secret",
+            "note": "Authorization: Basic dXNlcjpwYXNzd29yZA==",
+            "comment": "glpat-0123456789abcdefghijkl",
         }
 
 
@@ -476,15 +541,22 @@ class _DeniedRemote:
     tool_identity = "fake-github-readonly/1.0"
     api_version = "github-rest/2026-03-10"
 
-    def collect(self, _repository: str, _ref: str) -> dict[str, Any]:
+    def collect(self, _repository: str, _ref: str, **_bounds: Any) -> dict[str, Any]:
         raise PermissionError("token ghp_0123456789abcdefghijklmnop denied")
 
 
 class _PartialRemote(_FakeRemote):
-    def collect(self, repository: str, ref: str) -> dict[str, Any]:
-        payload = super().collect(repository, ref)
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
         payload.pop("complete")
         payload["query_provenance"][0]["has_next_page"] = True
+        return payload
+
+
+class _StaleRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["observed_at"] = "2026-07-31T00:00:00Z"
         return payload
 
 
@@ -516,6 +588,8 @@ def test_governance_observation_records_dirty_index_worktree_and_untracked_state
     assert observation.observed_at == "2026-08-01T00:00:00Z"
     assert observation.observation_id == "OBS-000001"
     assert observation.artifact_kind == "GOVERNANCE_OBSERVATION"
+    assert observation.disposition == "PARTIAL"
+    assert any(item.fact == "remote_governance" for item in observation.unknowns)
 
 
 def test_branch_divergence_and_additional_worktrees_are_mutable_observations(
@@ -548,11 +622,18 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "password" not in payload
     assert "secret-value" not in payload
     assert "unstructured-bare-secret" not in payload
+    assert "glpat-0123456789abcdefghijkl" not in payload
     assert "[REDACTED]" in payload
 
 
 def test_unproven_remote_pagination_is_blocked_not_complete(tmp_path: Path) -> None:
     observation = _observe(_init_repo(tmp_path), _PartialRemote())
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "remote_metadata_completeness" for item in observation.unknowns)
+
+
+def test_stale_remote_metadata_is_blocked_not_complete(tmp_path: Path) -> None:
+    observation = _observe(_init_repo(tmp_path), _StaleRemote())
     assert observation.disposition == "BLOCKED"
     assert any(item.fact == "remote_metadata_completeness" for item in observation.unknowns)
 
@@ -598,6 +679,28 @@ def test_governance_observation_does_not_refresh_index_bytes_or_mtime(tmp_path: 
     _observe(repo)
     assert index.read_bytes() == before_bytes
     assert index.stat().st_mtime_ns == before_mtime
+
+
+def test_governance_observation_disables_repository_fsmonitor_hook(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    marker = tmp_path / "fsmonitor-must-not-run"
+    hook = tmp_path / "hostile-fsmonitor.sh"
+    hook.write_text(f"#!/bin/sh\ntouch {marker}\nexit 0\n")
+    hook.chmod(0o755)
+    _git(repo, "config", "core.fsmonitor", str(hook))
+    _observe(repo)
+    assert not marker.exists()
+
+
+def test_invalid_governance_ref_is_rejected_before_git_comparison(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    with pytest.raises(api.RepositorySecurityError, match="ref"):
+        api.GovernanceCollector(
+            repository="example/fixture",
+            clock=_FixedClock(),
+            id_provider=_FixedIds(),
+        ).observe(repo, ref="--output=outside")
 
 
 def test_scanner_does_not_execute_tracked_project_code(tmp_path: Path) -> None:
@@ -660,6 +763,82 @@ def test_cancellation_is_visible_and_never_silently_partial(tmp_path: Path) -> N
     )
     assert snapshot.disposition == "BLOCKED"
     assert any(item.code == "SCAN.CANCELLED" for item in snapshot.findings)
+
+
+def test_cancellation_terminates_bounded_enumeration_and_preserves_repository(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_index = (repo / ".git" / "index").read_bytes()
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+    class CancelDuringTree:
+        calls = 0
+
+        def cancelled(self) -> bool:
+            self.calls += 1
+            return self.calls > 1
+
+    snapshot = api.RepositoryScanner(config=_config(), cancellation=CancelDuringTree()).scan(
+        repo, commit="HEAD"
+    )
+    assert snapshot.disposition == "BLOCKED"
+    assert any(item.code == "SCAN.CANCELLED" and item.blocking for item in snapshot.findings)
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert (repo / ".git" / "index").read_bytes() == before_index
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+
+
+def test_governance_cancellation_terminates_bounded_command_and_preserves_repository(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_index = (repo / ".git" / "index").read_bytes()
+
+    class CancelInsideCommand:
+        calls = 0
+
+        def cancelled(self) -> bool:
+            self.calls += 1
+            return self.calls > 1
+
+    collector = api.GovernanceCollector(
+        repository="example/fixture",
+        clock=_FixedClock(),
+        id_provider=_FixedIds(),
+        cancellation=CancelInsideCommand(),
+    )
+    with pytest.raises(api.RepositoryIntelligenceError, match="failed"):
+        collector.observe(repo, ref="main")
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert (repo / ".git" / "index").read_bytes() == before_index
+
+
+def test_git_readers_disable_lazy_fetch_and_repository_defined_accelerators() -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    governance = importlib.import_module("pmpe.repository.governance")
+    scanner_environment = scanner.SubprocessCommandRunner._environment()
+    assert scanner_environment["GIT_NO_LAZY_FETCH"] == "1"
+    assert scanner_environment["GIT_CONFIG_VALUE_0"] == "false"
+    governance_runner = governance.GovernanceCommandRunner()
+    assert governance_runner.identity.endswith("1.1.0")
+
+
+def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) -> None:
+    snapshot = _scan(_init_repo(tmp_path))
+    observation = _observe(tmp_path / "fixture-repo")
+    with pytest.raises(TypeError):
+        snapshot.inventory["repository_topology"] = snapshot.inventory[  # type: ignore[index]
+            "repository_topology"
+        ]
+    with pytest.raises(TypeError):
+        observation.governance["branch_protection"] = "changed"  # type: ignore[index]
+    assert snapshot.snapshot_digest in snapshot.canonical_bytes().decode()
+    assert observation.observation_output_digest in observation.canonical_bytes().decode()
 
 
 def test_snapshot_and_observation_references_form_a_narrow_lifecycle_seam(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -13,7 +13,7 @@ import time
 from dataclasses import asdict, replace
 from datetime import datetime, timedelta, timezone, tzinfo
 from pathlib import Path
-from types import ModuleType
+from types import FunctionType, ModuleType
 from typing import Any
 
 import pytest
@@ -535,11 +535,56 @@ def test_implementation_digest_seals_returned_multiprocessing_context_members(
             scanner._implementation_digest()
         assert callback_ran is False
 
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setitem(vars(context), "Pipe", pipe_proxy)
+        with pytest.raises(
+            scanner.RepositorySecurityError, match="runtime or context instance changed"
+        ):
+            scanner._sealed_fork_pipe(duplex=False)
+        assert callback_ran is False
+
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(scanner.multiprocessing_connection, "Pipe", pipe_proxy)
+        with pytest.raises(scanner.RepositorySecurityError, match="runtime or context"):
+            scanner._sealed_fork_pipe(duplex=False)
+        assert callback_ran is False
+
     replacement_context = type(context)()
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(scanner, "_SEALED_MULTIPROCESSING_CONTEXT", replacement_context)
         with pytest.raises(scanner.RepositorySecurityError, match="context or members changed"):
             scanner._implementation_digest()
+
+
+def test_artifact_digest_verification_rejects_same_code_forged_globals(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    models = importlib.import_module("pmpe.repository.models")
+    snapshot = _scan(_init_repo(tmp_path))
+    callback_ran = False
+    original = models.canonical_digest
+    forged_globals = dict(original.__globals__)
+
+    def forged_json_bytes(_value: Any) -> bytes:
+        nonlocal callback_ran
+        callback_ran = True
+        return b"forged"
+
+    forged_globals["canonical_json_bytes"] = forged_json_bytes
+    forged = FunctionType(
+        original.__code__,
+        forged_globals,
+        name=original.__name__,
+        argdefs=original.__defaults__,
+        closure=original.__closure__,
+    )
+    monkeypatch.setattr(models, "canonical_digest", forged)
+    with pytest.raises(ValueError, match="artifact digest bindings changed"):
+        snapshot.digest_is_valid()
+    with pytest.raises(scanner.RepositorySecurityError, match="model digest bindings changed"):
+        scanner._implementation_digest()
+    assert callback_ran is False
 
 
 def test_imported_non_callable_globals_are_sealed_before_use(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -425,6 +425,7 @@ def test_entry_points_and_test_coverage_configuration_are_explicit_inventory(
         (
             "[project]\nname='api'\nversion='1'\n"
             "[project.scripts]\napi='api.cli:main'\n"
+            "[project.entry-points.'api.plugins']\nfixture='api.plugin:load'\n"
             "[tool.pytest.ini_options]\ntestpaths=['tests']\n"
             "[tool.coverage.run]\nbranch=true\n"
         ),
@@ -435,6 +436,7 @@ def test_entry_points_and_test_coverage_configuration_are_explicit_inventory(
         (
             "[metadata]\nname = worker\n[tool:pytest]\ntestpaths = tests\n"
             "[coverage:run]\nbranch = true\n"
+            "[options.entry_points]\nconsole_scripts =\n    worker = worker.cli:main\n"
         ),
     )
     _write(repo, "services/api/src/api/__main__.py", "raise SystemExit(0)\n")
@@ -478,6 +480,7 @@ def test_entry_points_and_test_coverage_configuration_are_explicit_inventory(
     assert ("apps/web/package.json", "DECLARED_RUN_ENTRY_POINT") in architecture
     assert ("services/api/pyproject.toml", "TEST_CONFIGURATION") in quality
     assert ("services/api/pyproject.toml", "COVERAGE_CONFIGURATION") in quality
+    assert ("services/worker/setup.cfg", "DECLARED_ENTRY_POINT") in architecture
     assert ("services/worker/setup.cfg", "TEST_CONFIGURATION") in quality
     assert ("services/worker/setup.cfg", "COVERAGE_CONFIGURATION") in quality
     assert ("apps/web/package.json", "DECLARED_TEST_COMMAND") in quality
@@ -487,6 +490,20 @@ def test_entry_points_and_test_coverage_configuration_are_explicit_inventory(
     assert ("apps/web/playwright.config.ts", "TEST_CONFIGURATION") in quality
     assert ("apps/web/vitest.config.ts", "TEST_CONFIGURATION") in quality
     assert (".coveragerc", "COVERAGE_CONFIGURATION") in quality
+
+
+def test_dynamic_python_entry_points_are_explicitly_unsupported(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "setup.py", "from setuptools import setup\nsetup(name='fixture')\n")
+    _commit(repo, "dynamic Python packaging")
+    snapshot = _scan(repo)
+    assert snapshot.disposition == "BLOCKED"
+    assert any(
+        item.code == "ARCHITECTURE.DYNAMIC_ENTRY_POINTS_UNSUPPORTED"
+        and item.evidence_refs == ("setup.py",)
+        and item.blocking
+        for item in snapshot.findings
+    )
 
 
 def test_every_recognized_nested_python_manifest_creates_a_package_boundary(
@@ -1365,6 +1382,7 @@ def test_worktree_lifecycle_flags_are_preserved_and_prunable_state_blocks(
                 stdout=(
                     f"worktree {repo}\0HEAD {head}\0detached\0locked maintenance\0"
                     "prunable gitdir-missing\0\0"
+                    f"worktree {repo.parent / 'bare.git'}\0HEAD {head}\0bare\0\0"
                 ),
                 stderr="",
             )
@@ -1372,15 +1390,62 @@ def test_worktree_lifecycle_flags_are_preserved_and_prunable_state_blocks(
 
     monkeypatch.setattr(governance.GovernanceCommandRunner, "run", lifecycle_worktree)
     observation = _observe(repo)
-    worktree = observation.worktrees[0]
+    worktree = next(item for item in observation.worktrees if item.path == str(repo))
     assert worktree.detached is True
     assert worktree.bare is False
     assert worktree.locked is True
     assert worktree.locked_reason == "maintenance"
     assert worktree.prunable is True
     assert worktree.prunable_reason == "gitdir-missing"
+    bare = next(item for item in observation.worktrees if item.path.endswith("bare.git"))
+    assert bare.bare is True
+    assert bare.detached is False
+    assert bare.branch == "BARE"
     assert observation.disposition == "BLOCKED"
     assert any(item.fact == "worktree_prunable:1" for item in observation.unknowns)
+
+
+@pytest.mark.parametrize(
+    "lifecycle_fields",
+    [
+        "detached unexpected",
+        "branch refs/heads/main\0detached",
+        "branch refs/heads/main\0bare",
+    ],
+)
+def test_malformed_or_contradictory_worktree_lifecycle_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    lifecycle_fields: str,
+) -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    repo = _init_repo(tmp_path)
+    head = _git(repo, "rev-parse", "HEAD")
+    original = governance.GovernanceCommandRunner.run
+
+    def malformed_lifecycle(
+        self: Any,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        cancellation: Any = None,
+    ) -> Any:
+        if args[1:3] == ("worktree", "list"):
+            return api.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=f"worktree {repo}\0HEAD {head}\0{lifecycle_fields}\0\0",
+                stderr="",
+            )
+        return original(self, args, cwd, timeout, cancellation=cancellation)
+
+    monkeypatch.setattr(governance.GovernanceCommandRunner, "run", malformed_lifecycle)
+    observation = _observe(repo)
+    assert observation.disposition == "BLOCKED"
+    assert observation.worktrees == ()
+    assert any(item.fact == "worktree_record:1" for item in observation.unknowns)
 
 
 def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -885,6 +885,58 @@ def test_non_github_ci_is_not_reported_as_ci_absent(tmp_path: Path) -> None:
             "name: empty runner labels\non: [push]\njobs:\n  test:\n"
             "    runs-on: []\n    steps:\n      - run: pytest\n",
         ),
+        (
+            ".github/workflows/ci.yml",
+            "name: unknown event\non: imaginary_event\njobs:\n  test:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: mixed event list\non: [push, imaginary_event]\njobs:\n  test:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: invalid event filter\non:\n  push:\n    branches: main\njobs:\n  test:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: invalid activity type\non:\n  pull_request:\n"
+            "    types: [invented]\njobs:\n  test:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: invalid runner mapping\non: [push]\njobs:\n  test:\n"
+            "    runs-on: {pool: production}\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: invalid reusable workflow\non: [push]\njobs:\n  test:\n"
+            "    uses: arbitrary-string\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: escaping reusable workflow\non: [push]\njobs:\n  test:\n"
+            "    uses: ./.github/workflows/../secret.yml\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: conflicting reusable job\non: [push]\njobs:\n  test:\n"
+            "    uses: ./.github/workflows/build.yml\n    runs-on: ubuntu-latest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: mixed valid invalid jobs\non: [push]\njobs:\n  valid:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n"
+            "  invalid:\n    runs-on:\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: invalid action reference\non: [push]\njobs:\n  test:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - uses: arbitrary-string\n",
+        ),
         (".circleci/config.yml", "version: 2.1\njobs: []\n"),
         (
             ".circleci/config.yml",
@@ -918,6 +970,30 @@ def test_non_runnable_ci_scaffolds_do_not_suppress_missing_ci(
         item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
     )
     assert any(item.code == "DELIVERY.CI_ABSENT" for item in snapshot.findings)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "on:\n  push:\n    branches: [main]\n  schedule:\n    - cron: '23 3 * * *'\n"
+        "jobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        "on:\n  pull_request:\n    types: [opened, synchronize, ready_for_review]\n"
+        "jobs:\n  test:\n    runs-on: {group: trusted, labels: [linux, x64]}\n"
+        "    steps:\n      - run: pytest\n",
+        "on: workflow_dispatch\njobs:\n  local:\n    uses: ./.github/workflows/build.yml\n",
+        "on: workflow_dispatch\njobs:\n  remote:\n"
+        "    uses: example/automation/.github/workflows/build.yml@v1\n",
+    ],
+)
+def test_supported_github_ci_forms_are_reported(tmp_path: Path, content: str) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, ".github/workflows/ci.yml", content)
+    _commit(repo, "supported github workflow")
+    snapshot = _scan(repo)
+    assert any(
+        item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
+    )
+    assert not any(item.code == "DELIVERY.CI_ABSENT" for item in snapshot.findings)
 
 
 def test_ci_comments_do_not_become_security_test_or_rollback_controls(tmp_path: Path) -> None:
@@ -1301,6 +1377,30 @@ def test_budget_exhaustion_is_explicit_partial_result(
     assert snapshot.disposition in {"PARTIAL", "BLOCKED"}
     assert any(item.code == expected_code for item in snapshot.findings)
     assert set(snapshot.inventory) == set(_api().AUDIT_CATEGORIES)
+
+
+def test_path_and_directory_budgets_filter_before_adapter_evaluation(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "a/allowed/pyproject.toml", "[project]\nname = 'allowed'\nversion = '1'\n")
+    _write(repo, "b/deep/excluded/package.json", '{"name":"excluded"}')
+    _commit(repo, "budgeted paths")
+    snapshot = _scan(repo, max_directories=2, max_path_depth=32)
+    assert any(item.code == "BUDGET.DIRECTORY_COUNT" for item in snapshot.findings)
+    emitted_paths = {
+        item.path for category in snapshot.inventory.values() for item in category.items
+    } | {path for item in snapshot.boundary_candidates for path in item.evidence_paths}
+    assert "a/allowed/pyproject.toml" in emitted_paths
+    assert "b/deep/excluded/package.json" not in emitted_paths
+
+    depth_limited = _scan(repo, max_path_depth=2)
+    assert any(
+        item.code == "BUDGET.PATH_DEPTH" and "b/deep/excluded/package.json" in item.evidence_refs
+        for item in depth_limited.findings
+    )
+    depth_paths = {
+        item.path for category in depth_limited.inventory.values() for item in category.items
+    } | {path for item in depth_limited.boundary_candidates for path in item.evidence_paths}
+    assert "b/deep/excluded/package.json" not in depth_paths
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -355,6 +355,19 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(scanner, "_OBJECT_FORMAT_LENGTH", {"sha1": 1, "sha256": 1})
         assert scanner._implementation_digest() != original
+    runtime_digest = scanner._module_runtime_digest("repository.scanner")
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(
+            scanner,
+            "_IMPLEMENTATION_PATHS",
+            {"repository.scanner": Path("/different/checkout/scanner.py")},
+        )
+        runtime_patch.setattr(
+            scanner,
+            "_IMPORTED_SOURCE_DIGESTS",
+            {"repository.scanner": "sha256:" + "f" * 64},
+        )
+        assert scanner._module_runtime_digest("repository.scanner") == runtime_digest
 
     mismatched_sources = dict(scanner._IMPORTED_SOURCE_DIGESTS)
     mismatched_sources["repository.scanner"] = "sha256:" + "0" * 64
@@ -837,13 +850,34 @@ def test_non_github_ci_is_not_reported_as_ci_absent(tmp_path: Path) -> None:
     ("path", "content"),
     [
         (".gitlab-ci.yml", "variables:\n  FOO: bar\n"),
+        (".gitlab-ci.yml", "empty:\n  script: []\n"),
+        (".gitlab-ci.yml", "empty:\n  trigger: {}\n"),
+        (".gitlab-ci.yml", "empty:\n  trigger:\n    strategy: depend\n"),
         ("azure-pipelines.yml", "steps: []\n"),
+        ("azure-pipelines.yml", "jobs:\n  - job: empty\n"),
+        ("azure-pipelines.yml", "steps:\n  - checkout: none\n"),
         (
             ".github/workflows/ci.yml",
             "name: empty\non: [push]\njobs:\n  empty: {}\n",
         ),
         (".circleci/config.yml", "version: 2.1\njobs: []\n"),
+        (
+            ".circleci/config.yml",
+            "version: 2.1\njobs:\n  empty:\n    steps:\n      - '  '\n",
+        ),
+        (
+            ".circleci/config.yml",
+            "version: 2.1\njobs:\n  empty:\n    steps:\n      - run:\n          name: empty\n",
+        ),
         ("bitbucket-pipelines.yml", "pipelines:\n  default:\n"),
+        (
+            "bitbucket-pipelines.yml",
+            "pipelines:\n  default:\n    - step:\n        script:\n          - '  '\n",
+        ),
+        (
+            "bitbucket-pipelines.yml",
+            "pipelines:\n  default:\n    - step:\n        script:\n          - pipe: '  '\n",
+        ),
     ],
 )
 def test_non_runnable_ci_scaffolds_do_not_suppress_missing_ci(
@@ -2612,6 +2646,20 @@ def test_governance_runner_budget_must_match_recorded_collector_budget() -> None
             max_output_bytes=2_048,
         )
 
+    runner = governance.GovernanceCommandRunner(max_output_bytes=2_048)
+    collector = api.GovernanceCollector(
+        repository="example/fixture",
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
+        command_runner=runner,
+        max_output_bytes=2_048,
+    )
+    with pytest.raises(AttributeError):
+        runner.max_output_bytes = 4_096  # type: ignore[misc]
+    object.__setattr__(runner, "_max_output_bytes", 4_096)
+    with pytest.raises(api.RepositorySecurityError, match="changed after"):
+        collector.observe(Path.cwd(), ref="HEAD")
+
 
 def test_scan_and_observation_never_create_branches_commits_or_remote_mutations(
     tmp_path: Path,
@@ -2943,7 +2991,7 @@ def test_git_readers_disable_lazy_fetch_and_repository_defined_accelerators() ->
     assert scanner_environment["GIT_CONFIG_VALUE_0"] == "false"
     governance_runner = governance.GovernanceCommandRunner()
     assert scanner_environment["GIT_CONFIG_VALUE_5"] == "false"
-    assert governance_runner.identity.endswith("1.9.0")
+    assert governance_runner.identity.endswith("1.10.0")
 
 
 def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) -> None:
@@ -2999,6 +3047,52 @@ def test_noncomplete_snapshot_and_observation_cannot_form_a_lifecycle_reference(
     ).observe(repo, ref="main")
     with pytest.raises(ValueError, match="snapshot is not complete"):
         snapshot.assessment_reference(observation)
+
+
+def test_complete_snapshot_can_delegate_only_mutable_work_to_governance(
+    tmp_path: Path,
+) -> None:
+    canonical = importlib.import_module("pmpe.contracts.canonical")
+    repo = _init_repo(tmp_path)
+    snapshot = _scan(repo)
+    complete_snapshot = replace(
+        snapshot,
+        disposition="COMPLETE",
+        findings=(),
+        unsupported_categories=("active_divergent_work",),
+        snapshot_digest="",
+    )
+    snapshot_payload = complete_snapshot.as_dict()
+    snapshot_payload.pop("snapshot_digest")
+    complete_snapshot = replace(
+        complete_snapshot,
+        snapshot_digest=canonical.canonical_digest(snapshot_payload),
+    )
+    observation = (
+        _api()
+        .GovernanceCollector(
+            repository="example/fixture",
+            snapshot=complete_snapshot,
+            clock=_fixed_clock(),
+            id_provider=_fixed_ids(),
+        )
+        .observe(repo, ref="main")
+    )
+    complete_observation = replace(
+        observation,
+        disposition="COMPLETE",
+        unknowns=(),
+        observation_output_digest="",
+    )
+    observation_payload = complete_observation.as_dict()
+    observation_payload.pop("observation_output_digest")
+    complete_observation = replace(
+        complete_observation,
+        observation_output_digest=canonical.canonical_digest(observation_payload),
+    )
+    reference = complete_snapshot.assessment_reference(complete_observation)
+    assert reference["repository_snapshot_disposition"] == "COMPLETE"
+    assert reference["governance_observation_disposition"] == "COMPLETE"
 
 
 def test_snapshot_rejects_governance_observation_from_another_repository(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -1,0 +1,581 @@
+"""Issue #64 RED contract for deterministic repository intelligence."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+def _api() -> ModuleType:
+    try:
+        return importlib.import_module("pmpe.repository")
+    except ModuleNotFoundError:
+        pytest.fail(
+            "issue #64 repository-intelligence API is not implemented",
+            pytrace=False,
+        )
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _write(repo: Path, relative: str, content: str | bytes) -> None:
+    target = repo / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, bytes):
+        target.write_bytes(content)
+    else:
+        target.write_text(content)
+
+
+def _commit(repo: Path, message: str = "fixture") -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _init_repo(tmp_path: Path, *, mixed: bool = True) -> Path:
+    repo = tmp_path / "fixture-repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "--initial-branch=main")
+    _git(repo, "config", "user.email", "fixture@localhost")
+    _git(repo, "config", "user.name", "Fixture")
+    _write(repo, "README.md", "# Fixture\n")
+    if mixed:
+        _write(
+            repo,
+            "pyproject.toml",
+            "[project]\nname='fixture'\nversion='1.0.0'\ndependencies=[]\n",
+        )
+        _write(repo, "src/widget/__init__.py", '"""Widget package."""\n')
+        _write(repo, "tests/unit/test_widget.py", "def test_widget():\n    assert True\n")
+        _write(
+            repo,
+            "packages/web/package.json",
+            json.dumps({"name": "web", "version": "1.0.0", "scripts": {"test": "vitest"}}),
+        )
+        _write(repo, "packages/web/package-lock.json", '{"lockfileVersion":3}\n')
+        _write(repo, "packages/web/src/index.ts", "export const ok = true;\n")
+        _write(repo, "services/api/openapi.json", '{"openapi":"3.1.0","paths":{}}\n')
+        _write(repo, "services/api/migrations/001_create.sql", "create table item(id int);\n")
+        _write(repo, "Dockerfile", "FROM python:3.11-slim\nHEALTHCHECK CMD true\n")
+        _write(repo, "compose.yaml", "services:\n  api:\n    build: .\n")
+        _write(
+            repo,
+            ".github/workflows/ci.yml",
+            "name: ci\non: [push]\njobs:\n  test:\n    runs-on: ubuntu-latest\n",
+        )
+        _write(repo, ".github/CODEOWNERS", "/src/ @platform\n")
+        _write(repo, "docs/adr/0001.md", "# ADR 0001\n")
+        _write(repo, "ops/alerts.yaml", "alerts:\n  - name: api-down\n")
+        _write(repo, "ops/slo.yaml", "availability: 99.9\n")
+        _write(repo, "scripts/generate_client.py", "# deterministic generator entrypoint\n")
+    _commit(repo)
+    return repo
+
+
+def _config(**changes: Any) -> Any:
+    api = _api()
+    base = api.ScanConfig(
+        repository="example/fixture",
+        default_branch="main",
+        max_files=1_000,
+        max_total_bytes=10_000_000,
+        max_file_bytes=1_000_000,
+        max_commands=5_000,
+        command_timeout_seconds=10,
+        max_path_depth=32,
+    )
+    return replace(base, **changes)
+
+
+def _scan(repo: Path, **changes: Any) -> Any:
+    return _api().RepositoryScanner(config=_config(**changes)).scan(repo, commit="HEAD")
+
+
+def test_exact_sha_snapshot_is_byte_deterministic_and_has_no_timestamp(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    first = _scan(repo)
+    second = _scan(repo)
+    assert first.canonical_bytes() == second.canonical_bytes()
+    assert first.snapshot_digest == second.snapshot_digest
+    assert first.commit_sha == _git(repo, "rev-parse", "HEAD")
+    assert "observed_at" not in first.as_dict()
+    assert "worktree" not in first.as_dict()
+    assert "pull_requests" not in first.as_dict()
+
+
+def test_dirty_tracked_content_does_not_change_exact_commit_snapshot(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    before = _scan(repo)
+    _write(repo, "README.md", "dirty worktree value\n")
+    after = _scan(repo)
+    assert before.canonical_bytes() == after.canonical_bytes()
+    assert (repo / "README.md").read_text() == "dirty worktree value\n"
+
+
+def test_new_commit_changes_tree_and_snapshot_digests(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    first = _scan(repo)
+    _write(repo, "README.md", "# Changed\n")
+    _commit(repo, "change tracked content")
+    second = _scan(repo)
+    assert first.commit_sha != second.commit_sha
+    assert first.tracked_tree_digest != second.tracked_tree_digest
+    assert first.snapshot_digest != second.snapshot_digest
+
+
+def test_adapter_order_does_not_change_output_but_version_does(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    adapters = api.default_adapters()
+    first = api.RepositoryScanner(config=_config(), adapters=adapters).scan(repo, commit="HEAD")
+    reordered = api.RepositoryScanner(config=_config(), adapters=tuple(reversed(adapters))).scan(
+        repo, commit="HEAD"
+    )
+    assert first.canonical_bytes() == reordered.canonical_bytes()
+
+    changed = (replace(adapters[0], version="99.0.0"), *adapters[1:])
+    versioned = api.RepositoryScanner(config=_config(), adapters=changed).scan(repo, commit="HEAD")
+    assert first.adapter_set_digest != versioned.adapter_set_digest
+    assert first.snapshot_digest != versioned.snapshot_digest
+
+
+def test_all_audit_categories_are_present_and_active_work_is_separate(tmp_path: Path) -> None:
+    api = _api()
+    snapshot = _scan(_init_repo(tmp_path))
+    assert set(snapshot.inventory) == set(api.AUDIT_CATEGORIES)
+    active = snapshot.inventory["active_divergent_work"]
+    assert active.status == "UNSUPPORTED"
+    assert "GovernanceObservation" in active.reason
+
+
+def test_inventory_and_boundary_candidates_have_exact_file_evidence(tmp_path: Path) -> None:
+    snapshot = _scan(_init_repo(tmp_path))
+    boundaries = snapshot.boundary_candidates
+    assert {item.kind for item in boundaries} >= {"PACKAGE", "SERVICE", "APPLICATION"}
+    assert all(item.evidence_paths for item in boundaries)
+    assert all(item.confidence in {"HIGH", "MEDIUM", "LOW"} for item in boundaries)
+    for item in snapshot.inventory["languages_build_ecosystems"].items:
+        assert item.path
+        assert item.file_digest.startswith("sha256:")
+        assert item.detector_id and item.detector_version
+
+
+def test_adapter_metadata_is_versioned_and_declares_supported_categories(
+    tmp_path: Path,
+) -> None:
+    snapshot = _scan(_init_repo(tmp_path))
+    adapter_ids = {item.adapter_id for item in snapshot.adapters}
+    assert adapter_ids >= {
+        "core.repository-topology",
+        "stack.python",
+        "stack.node-web",
+        "stack.docker-compose",
+        "delivery.github-actions",
+        "interface.schema-api",
+        "repository.pmpe",
+    }
+    assert all(item.version and item.file_patterns for item in snapshot.adapters)
+    assert all(item.supported_categories for item in snapshot.adapters)
+    assert all(item.failure_behavior == "VISIBLE_PARTIAL_OR_BLOCKED" for item in snapshot.adapters)
+
+
+def test_api_data_generated_client_migration_and_contract_sync_are_inventory_items(
+    tmp_path: Path,
+) -> None:
+    snapshot = _scan(_init_repo(tmp_path))
+    kinds = {item.kind for item in snapshot.inventory["apis_data"].items}
+    assert {"OPENAPI", "MIGRATION", "CODE_GENERATOR"} <= kinds
+
+
+def test_tests_delivery_security_observability_and_governance_are_evidence_backed(
+    tmp_path: Path,
+) -> None:
+    snapshot = _scan(_init_repo(tmp_path))
+    assert snapshot.inventory["tests_quality"].items
+    assert snapshot.inventory["delivery_environments"].items
+    assert snapshot.inventory["security_privacy"].items
+    assert snapshot.inventory["observability_operations"].items
+    assert snapshot.inventory["documentation_governance"].items
+
+
+def test_missing_ci_and_missing_test_categories_are_findings_not_guesses(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    snapshot = _scan(repo)
+    codes = {item.code for item in snapshot.findings}
+    assert "DELIVERY.CI_ABSENT" in codes
+    assert "QUALITY.TEST_CATEGORY_ABSENT" in codes
+    assert all(item.evidence_refs for item in snapshot.findings)
+    assert all(item.confidence in {"HIGH", "MEDIUM", "LOW"} for item in snapshot.findings)
+
+
+def test_multiple_lockfiles_version_drift_and_duplicate_config_are_risk_signals(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _write(repo, "packages/admin/package.json", '{"name":"admin","engines":{"node":"20"}}')
+    _write(repo, "packages/admin/yarn.lock", "# yarn lock\n")
+    _write(repo, ".python-version", "3.12\n")
+    _commit(repo, "add drift fixtures")
+    snapshot = _scan(repo)
+    codes = {item.code for item in snapshot.findings}
+    assert "DEPENDENCY.MULTIPLE_LOCK_ECOSYSTEMS" in codes
+    assert "RUNTIME.VERSION_DRIFT_SIGNAL" in codes
+
+
+def test_unknown_ecosystem_is_explicitly_unsupported(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "main.unknownlang", "opaque\n")
+    _commit(repo, "unknown stack")
+    snapshot = _scan(repo)
+    category = snapshot.inventory["languages_build_ecosystems"]
+    assert category.status == "UNSUPPORTED"
+    assert snapshot.disposition == "BLOCKED"
+    assert category.reason
+
+
+def test_malformed_manifest_and_workflow_are_visible_findings(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _write(repo, "packages/web/package.json", "{not-json")
+    _write(repo, ".github/workflows/ci.yml", "jobs: [\n")
+    _commit(repo, "malformed inputs")
+    snapshot = _scan(repo)
+    codes = {item.code for item in snapshot.findings}
+    assert "MANIFEST.MALFORMED" in codes
+    assert "WORKFLOW.MALFORMED" in codes
+    assert snapshot.disposition in {"PARTIAL", "BLOCKED"}
+
+
+def test_adapter_failure_is_visible_and_cannot_remove_categories(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+
+    @api.repository_adapter(
+        adapter_id="test.exploding",
+        version="1.0.0",
+        file_patterns=("**/*",),
+        supported_categories=("security_privacy",),
+    )
+    def exploding(_context: Any) -> Any:
+        raise RuntimeError("detector failed")
+
+    snapshot = api.RepositoryScanner(
+        config=_config(), adapters=(*api.default_adapters(), exploding)
+    ).scan(repo, commit="HEAD")
+    assert set(snapshot.inventory) == set(api.AUDIT_CATEGORIES)
+    assert snapshot.disposition in {"PARTIAL", "BLOCKED"}
+    assert any(item.code == "ADAPTER.FAILURE" for item in snapshot.findings)
+
+
+@pytest.mark.parametrize(
+    ("config_change", "expected_code"),
+    [
+        ({"max_files": 2}, "BUDGET.FILE_COUNT"),
+        ({"max_total_bytes": 16}, "BUDGET.TOTAL_BYTES"),
+        ({"max_file_bytes": 8}, "BUDGET.FILE_BYTES"),
+        ({"max_path_depth": 1}, "BUDGET.PATH_DEPTH"),
+        ({"max_commands": 2}, "BUDGET.COMMAND_COUNT"),
+    ],
+)
+def test_budget_exhaustion_is_explicit_partial_result(
+    tmp_path: Path,
+    config_change: dict[str, int],
+    expected_code: str,
+) -> None:
+    snapshot = _scan(_init_repo(tmp_path), **config_change)
+    assert snapshot.disposition in {"PARTIAL", "BLOCKED"}
+    assert any(item.code == expected_code for item in snapshot.findings)
+    assert set(snapshot.inventory) == set(_api().AUDIT_CATEGORIES)
+
+
+def test_binary_files_are_structural_evidence_but_never_decoded(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _write(repo, "assets/blob.bin", b"\x00ghp_0123456789abcdefghijklmnop\xff")
+    _commit(repo, "binary")
+    snapshot = _scan(repo)
+    payload = snapshot.canonical_bytes()
+    assert b"ghp_0123456789abcdefghijklmnop" not in payload
+    assert any(
+        item.kind == "BINARY_FILE" for item in snapshot.inventory["repository_topology"].items
+    )
+
+
+def test_symlink_escape_is_refused_without_following_target(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    outside = tmp_path / "outside-secret"
+    outside.write_text("outside value")
+    (repo / "escape").symlink_to(outside)
+    _commit(repo, "escaping symlink")
+    snapshot = _scan(repo)
+    assert snapshot.disposition == "BLOCKED"
+    assert any(item.code == "SECURITY.SYMLINK_ESCAPE" for item in snapshot.findings)
+    assert "outside value" not in snapshot.canonical_bytes().decode()
+
+
+def test_configured_paths_must_be_repository_relative_and_contained(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    with pytest.raises(api.RepositorySecurityError, match="contained"):
+        api.RepositoryScanner(config=_config(include_paths=("../outside",))).scan(
+            repo, commit="HEAD"
+        )
+
+
+def test_planted_credentials_never_appear_in_snapshot(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    secret = "ghp_0123456789abcdefghijklmnop"
+    _write(repo, ".env.example", f"API_KEY={secret}\n")
+    _write(repo, "private.pem", "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----\n")
+    _commit(repo, "secret shapes")
+    payload = _scan(repo).canonical_bytes().decode()
+    assert secret not in payload
+    assert "PRIVATE KEY" not in payload
+    assert "redaction" in payload.lower()
+
+
+def test_redaction_failure_blocks_artifact_creation(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+
+    class BrokenRedactor:
+        version = "broken"
+
+        def sanitize(self, _value: Any) -> Any:
+            raise RuntimeError("redaction unavailable")
+
+    with pytest.raises(api.RepositorySecurityError, match="redaction"):
+        api.RepositoryScanner(config=_config(), redactor=BrokenRedactor()).scan(repo, commit="HEAD")
+
+
+class _FixedClock:
+    def now(self) -> str:
+        return "2026-08-01T00:00:00Z"
+
+
+class _FixedIds:
+    def new_id(self) -> str:
+        return "OBS-000001"
+
+
+class _FakeRemote:
+    tool_identity = "fake-github-readonly/1.0"
+    api_version = "github-rest/2026-03-10"
+
+    def collect(self, repository: str, ref: str) -> dict[str, Any]:
+        assert repository == "example/fixture"
+        return {
+            "remote_branches": [{"name": "origin/feature", "sha": "a" * 40}],
+            "pull_requests": [{"number": 7, "draft": True, "head": "a" * 40}],
+            "issues": [{"number": 8, "state": "OPEN"}],
+            "governance": {"branch_protection": "UNKNOWN"},
+            "query_provenance": [
+                {
+                    "query": "branches,pulls,issues,protection",
+                    "cursor": "cursor-2",
+                    "page": 2,
+                }
+            ],
+            "unknowns": [
+                {"fact": "secret_scanning", "status": "BLOCKED", "reason": "permission denied"}
+            ],
+            "safe_url": "https://user:password@example.invalid/repo?token=secret-value",
+            "authorization": "Bearer ghp_0123456789abcdefghijklmnop",
+        }
+
+
+class _DeniedRemote:
+    tool_identity = "fake-github-readonly/1.0"
+    api_version = "github-rest/2026-03-10"
+
+    def collect(self, _repository: str, _ref: str) -> dict[str, Any]:
+        raise PermissionError("token ghp_0123456789abcdefghijklmnop denied")
+
+
+def _observe(repo: Path, remote: Any = None) -> Any:
+    api = _api()
+    return api.GovernanceCollector(
+        repository="example/fixture",
+        clock=_FixedClock(),
+        id_provider=_FixedIds(),
+        remote_provider=remote,
+    ).observe(repo, ref="main")
+
+
+def test_governance_observation_records_dirty_index_worktree_and_untracked_state(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _write(repo, "README.md", "staged\n")
+    _git(repo, "add", "README.md")
+    _write(repo, "README.md", "staged and unstaged\n")
+    _write(repo, "untracked.txt", "untracked\n")
+    before = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    observation = _observe(repo)
+    after = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    assert before == after
+    assert observation.local_state.index_dirty is True
+    assert observation.local_state.worktree_dirty is True
+    assert observation.local_state.untracked is True
+    assert observation.observed_at == "2026-08-01T00:00:00Z"
+    assert observation.observation_id == "OBS-000001"
+    assert observation.artifact_kind == "GOVERNANCE_OBSERVATION"
+
+
+def test_branch_divergence_and_additional_worktrees_are_mutable_observations(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "switch", "-q", "-c", "feature")
+    _write(repo, "feature.txt", "feature\n")
+    _commit(repo, "feature")
+    _git(repo, "switch", "-q", "main")
+    _write(repo, "main.txt", "main\n")
+    _commit(repo, "main")
+    observation = _observe(repo)
+    feature = next(item for item in observation.local_branches if item.name == "feature")
+    assert feature.ahead >= 1 and feature.behind >= 1
+    assert observation.worktrees
+    assert "local_branches" not in _scan(repo).as_dict()
+
+
+def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path: Path) -> None:
+    observation = _observe(_init_repo(tmp_path), _FakeRemote())
+    payload = observation.canonical_bytes().decode()
+    assert observation.tool_identity == "fake-github-readonly/1.0"
+    assert observation.api_query_version == "github-rest/2026-03-10"
+    assert observation.query_provenance[0].cursor == "cursor-2"
+    assert observation.observation_input_digest.startswith("sha256:")
+    assert observation.observation_output_digest.startswith("sha256:")
+    assert "ghp_0123456789abcdefghijklmnop" not in payload
+    assert "password" not in payload
+    assert "secret-value" not in payload
+    assert "[REDACTED]" in payload
+
+
+def test_remote_permission_denial_is_blocked_unknown_not_inferred(tmp_path: Path) -> None:
+    observation = _observe(_init_repo(tmp_path), _DeniedRemote())
+    assert observation.disposition == "BLOCKED"
+    assert any(item.status in {"BLOCKED", "UNKNOWN"} for item in observation.unknowns)
+    assert observation.remote_branches == ()
+    assert "ghp_0123456789abcdefghijklmnop" not in observation.canonical_bytes().decode()
+
+
+def test_observation_is_reproducible_only_from_matching_recorded_inputs(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    first = _observe(repo, _FakeRemote())
+    second = _observe(repo, _FakeRemote())
+    assert first.canonical_bytes() == second.canonical_bytes()
+    _write(repo, "untracked.txt", "new observation input\n")
+    changed = _observe(repo, _FakeRemote())
+    assert first.observation_input_digest != changed.observation_input_digest
+    assert first.observation_output_digest != changed.observation_output_digest
+
+
+def test_scan_and_observation_never_create_branches_commits_or_remote_mutations(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_branches = _git(repo, "for-each-ref", "--format=%(refname)", "refs/heads")
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    _scan(repo)
+    _observe(repo, _FakeRemote())
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert _git(repo, "for-each-ref", "--format=%(refname)", "refs/heads") == before_branches
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+
+
+def test_scanner_does_not_execute_tracked_project_code(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    marker = tmp_path / "must-not-exist"
+    _write(repo, "setup.py", f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n")
+    _commit(repo, "hostile project code")
+    _scan(repo)
+    assert not marker.exists()
+
+
+class _MissingGitRunner:
+    identity = "missing-git"
+
+    def run(self, _args: tuple[str, ...], _cwd: Path, _timeout: int) -> Any:
+        raise FileNotFoundError("git is not installed")
+
+
+class _TimeoutRunner:
+    identity = "timeout-git"
+
+    def run(self, args: tuple[str, ...], _cwd: Path, _timeout: int) -> Any:
+        return _api().CommandResult(args=args, returncode=124, stdout="", stderr="", timed_out=True)
+
+
+class _MalformedRunner:
+    identity = "malformed-git"
+
+    def run(self, args: tuple[str, ...], _cwd: Path, _timeout: int) -> Any:
+        return _api().CommandResult(args=args, returncode=0, stdout="not-a-sha\n", stderr="")
+
+
+@pytest.mark.parametrize("runner", [_MissingGitRunner(), _TimeoutRunner(), _MalformedRunner()])
+def test_missing_git_timeout_or_malformed_output_fails_closed(
+    tmp_path: Path,
+    runner: Any,
+) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    with pytest.raises(api.RepositoryIntelligenceError):
+        api.RepositoryScanner(config=_config(), command_runner=runner).scan(repo, commit="HEAD")
+
+
+def test_invalid_repository_fails_closed(tmp_path: Path) -> None:
+    api = _api()
+    with pytest.raises(api.RepositoryIntelligenceError, match="Git repository"):
+        api.RepositoryScanner(config=_config()).scan(tmp_path, commit="HEAD")
+
+
+def test_cancellation_is_visible_and_never_silently_partial(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+
+    class Cancelled:
+        def cancelled(self) -> bool:
+            return True
+
+    snapshot = api.RepositoryScanner(config=_config(), cancellation=Cancelled()).scan(
+        repo, commit="HEAD"
+    )
+    assert snapshot.disposition == "BLOCKED"
+    assert any(item.code == "SCAN.CANCELLED" for item in snapshot.findings)
+
+
+def test_snapshot_and_observation_references_form_a_narrow_lifecycle_seam(
+    tmp_path: Path,
+) -> None:
+    snapshot = _scan(_init_repo(tmp_path))
+    observation = _observe(tmp_path / "fixture-repo")
+    reference = snapshot.assessment_reference(observation)
+    assert reference == {
+        "repository_snapshot_digest": snapshot.snapshot_digest,
+        "repository_commit": snapshot.commit_sha,
+        "governance_observation_id": observation.observation_id,
+        "governance_observation_digest": observation.observation_output_digest,
+    }
+    assert "architecture" not in reference
+    assert "recommendation" not in reference

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -351,31 +351,40 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
 ) -> None:
     scanner = importlib.import_module("pmpe.repository.scanner")
     original = scanner._implementation_digest()
+
+    def assert_digest_changed_or_mutation_rejected() -> None:
+        try:
+            candidate = scanner._implementation_digest()
+        except scanner.RepositorySecurityError as exc:
+            assert "imported-module state changed" in str(exc)
+        else:
+            assert candidate != original
+
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(scanner, "_valid_object_id", lambda _value, _format: True)
-        assert scanner._implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(scanner, "_OBJECT_FORMAT_LENGTH", {"sha1": 1, "sha256": 1})
-        assert scanner._implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     redaction = importlib.import_module("pmpe.repository.redaction")
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(redaction.EvidenceRedactor, "_token", re.compile(r"changed"))
-        assert scanner._implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     yaml_module = importlib.import_module("yaml")
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(yaml_module, "safe_load", lambda value: value)
-        assert scanner._implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(yaml_module, "load", lambda value, **_kwargs: value)
-        assert scanner._implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     rfc8785_module = importlib.import_module("rfc8785")
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(rfc8785_module, "dumps", lambda value: b"changed")
-        assert scanner._implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     rfc8785_impl = importlib.import_module("rfc8785._impl")
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(rfc8785_impl, "_serialize_str", lambda value, sink: None)
-        assert scanner._implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     hashlib_module = importlib.import_module("hashlib")
     original_sha256 = hashlib_module.sha256
     with monkeypatch.context() as runtime_patch:
@@ -384,22 +393,22 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
             "sha256",
             lambda payload=b"", *args, **kwargs: original_sha256(payload, *args, **kwargs),
         )
-        assert scanner._implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     urllib_parse = importlib.import_module("urllib.parse")
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(urllib_parse, "uses_netloc", [*urllib_parse.uses_netloc, "custom"])
-        assert scanner._implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     json_module = importlib.import_module("json")
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(json_module, "_default_decoder", json.JSONDecoder(strict=False))
-        assert scanner._implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(
             json_module._default_decoder,
             "scan_once",
             json.JSONDecoder(strict=False).scan_once,
         )
-        assert scanner._implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     for module_name, attribute in (
         ("configparser", "ConfigParser"),
         ("datetime", "datetime"),
@@ -419,7 +428,7 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
         module = importlib.import_module(module_name)
         with monkeypatch.context() as runtime_patch:
             runtime_patch.setattr(module, attribute, lambda *_args, **_kwargs: {})
-            assert scanner._implementation_digest() != original
+            assert_digest_changed_or_mutation_rejected()
     runtime_digest = scanner._module_runtime_digest("repository.scanner")
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(
@@ -441,6 +450,42 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
             scanner._IMPLEMENTATION_PATHS,
             mismatched_sources,
         )
+
+
+def test_implementation_digest_rejects_replaced_output_module_before_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    callback_ran = False
+
+    class PlatformProxy:
+        def python_version(self) -> str:
+            nonlocal callback_ran
+            callback_ran = True
+            return "forged"
+
+    monkeypatch.setattr(scanner, "platform", PlatformProxy())
+    with pytest.raises(scanner.RepositorySecurityError, match="imported-module"):
+        scanner._implementation_digest()
+    assert callback_ran is False
+
+
+def test_governance_digest_rejects_replaced_output_module_before_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    governance = importlib.import_module("pmpe.repository.governance")
+    callback_ran = False
+
+    class UuidProxy:
+        def uuid4(self) -> Any:
+            nonlocal callback_ran
+            callback_ran = True
+            return "forged"
+
+    monkeypatch.setattr(governance, "uuid", UuidProxy())
+    with pytest.raises(governance.RepositorySecurityError, match="imported-module"):
+        governance._governance_implementation_digest()
+    assert callback_ran is False
 
 
 def test_dormant_cancellation_signal_does_not_change_exact_snapshot(tmp_path: Path) -> None:
@@ -465,13 +510,22 @@ def test_governance_provenance_binds_every_material_repository_module() -> None:
         "contracts.canonical",
     }
     original = governance._governance_implementation_digest()
+
+    def assert_digest_changed_or_mutation_rejected() -> None:
+        try:
+            candidate = governance._governance_implementation_digest()
+        except governance.RepositorySecurityError as exc:
+            assert "imported-module state changed" in str(exc)
+        else:
+            assert candidate != original
+
     rfc8785_module = importlib.import_module("rfc8785")
     with pytest.MonkeyPatch.context() as runtime_patch:
         runtime_patch.setattr(rfc8785_module, "dumps", lambda value: b"changed")
-        assert governance._governance_implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
     with pytest.MonkeyPatch.context() as runtime_patch:
         runtime_patch.setattr(governance, "UTC", timezone(timedelta(hours=1)))
-        assert governance._governance_implementation_digest() != original
+        assert_digest_changed_or_mutation_rejected()
 
 
 def test_api_data_generated_client_migration_and_contract_sync_are_inventory_items(
@@ -3107,7 +3161,20 @@ def test_scanner_rejects_mutated_cancellation_state_before_callback_use(
 
     with pytest.raises(AttributeError):
         object.__setattr__(cancellation, "_event", MutatingState())
-    object.__setattr__(cancellation, "_cancelled", MutatingState())
+    object.__setattr__(cancellation, "_state", MutatingState())
+    with pytest.raises(api.RepositorySecurityError, match="sealed"):
+        api.RepositoryScanner(config=_config(), cancellation=cancellation).scan(repo, commit="HEAD")
+
+    class MutatingLock:
+        def __enter__(self) -> Any:
+            marker.write_text("mutated")
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            return None
+
+    cancellation = api.CancellationSignal()
+    object.__setattr__(cancellation, "_lock", MutatingLock())
     with pytest.raises(api.RepositorySecurityError, match="sealed"):
         api.RepositoryScanner(config=_config(), cancellation=cancellation).scan(repo, commit="HEAD")
     assert not marker.exists()
@@ -3128,6 +3195,37 @@ def test_redaction_collision_between_tracked_paths_blocks_snapshot(
         _scan(repo)
     assert _git(repo, "rev-parse", "HEAD") == before_head
     assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+
+
+def test_redaction_collision_between_evidence_locations_fails_closed() -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    original = {
+        "included_paths": [],
+        "inventory": {
+            "dependencies_integrations": {
+                "items": [
+                    {
+                        "path": "a/package.json",
+                        "location": "package.json#scripts.token=firstsecretvalue123",
+                    },
+                    {
+                        "path": "b/package.json",
+                        "location": "package.json#scripts.token=secondsecretvalue456",
+                    },
+                ]
+            }
+        },
+        "findings": [],
+        "boundary_candidates": [],
+    }
+    sanitized = json.loads(json.dumps(original))
+    for item in sanitized["inventory"]["dependencies_integrations"]["items"]:
+        item["location"] = "package.json#scripts.[REDACTED]"
+
+    groups = scanner._snapshot_identity_groups(original, sanitized)
+    with pytest.raises(scanner.RedactionError, match="distinct"):
+        for namespace, identities in groups.items():
+            scanner.assert_distinct_identities_preserved(namespace, identities)
 
 
 def test_redaction_collision_between_branch_names_blocks_observation(
@@ -3756,8 +3854,7 @@ def test_cancellation_during_adapter_blocks_snapshot_finalization(
     before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
 
     cancellation = api.CancellationSignal()
-    timer = threading.Timer(0.2, cancellation.cancel)
-    timer.start()
+    timer: threading.Timer | None = None
 
     def hanging_worker(
         _connection: Any,
@@ -3773,16 +3870,73 @@ def test_cancellation_during_adapter_blocks_snapshot_finalization(
         os.setsid()
         time.sleep(30)
 
+    original_bounded = scanner.RepositoryScanner._run_adapter_bounded
+
+    def cancel_during_bounded_adapter(self: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal timer
+        timer = threading.Timer(0.2, cancellation.cancel)
+        timer.start()
+        return original_bounded(self, *args, **kwargs)
+
     monkeypatch.setattr(scanner, "_adapter_worker", hanging_worker)
+    monkeypatch.setattr(
+        scanner.RepositoryScanner, "_run_adapter_bounded", cancel_during_bounded_adapter
+    )
     snapshot = api.RepositoryScanner(
         config=_config(),
         cancellation=cancellation,
     ).scan(repo, commit="HEAD")
+    assert timer is not None
     timer.join(timeout=1)
     assert snapshot.disposition == "BLOCKED"
     assert any(item.code == "SCAN.CANCELLED" and item.blocking for item in snapshot.findings)
     assert _git(repo, "rev-parse", "HEAD") == before_head
     assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+
+
+def test_cancellation_during_snapshot_digest_loses_atomic_admission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    api = _api()
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    repo = _init_repo(tmp_path)
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_index = (repo / ".git" / "index").read_bytes()
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    cancellation = api.CancellationSignal()
+    original_digest = scanner.canonical_digest
+    cancelled_at_admission = False
+
+    def cancel_before_digest(value: Any) -> str:
+        nonlocal cancelled_at_admission
+        if (
+            not cancelled_at_admission
+            and isinstance(value, dict)
+            and value.get("artifact_kind") == "REPOSITORY_SNAPSHOT"
+            and "snapshot_digest" not in value
+        ):
+            cancelled_at_admission = True
+            cancellation.cancel()
+        return original_digest(value)
+
+    monkeypatch.setattr(scanner, "canonical_digest", cancel_before_digest)
+    snapshot = api.RepositoryScanner(config=_config(), cancellation=cancellation).scan(
+        repo, commit="HEAD"
+    )
+
+    assert cancelled_at_admission
+    assert snapshot.disposition == "BLOCKED"
+    assert any(item.code == "SCAN.CANCELLED" and item.blocking for item in snapshot.findings)
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert (repo / ".git" / "index").read_bytes() == before_index
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+
+
+def test_cancellation_after_atomic_completion_cannot_invalidate_artifact() -> None:
+    signal = _api().CancellationSignal()
+    assert signal.claim_completion() is True
+    signal.cancel()
+    assert signal.cancelled() is False
 
 
 def test_governance_cancellation_terminates_bounded_command_and_preserves_repository(
@@ -3803,6 +3957,50 @@ def test_governance_cancellation_terminates_bounded_command_and_preserves_reposi
         collector.observe(repo, ref="main")
     assert _git(repo, "rev-parse", "HEAD") == before_head
     assert (repo / ".git" / "index").read_bytes() == before_index
+
+
+def test_cancellation_during_observation_digest_loses_atomic_admission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    repo = _init_repo(tmp_path)
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_index = (repo / ".git" / "index").read_bytes()
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    cancellation = api.CancellationSignal()
+    original_digest = governance.canonical_digest
+    cancelled_at_admission = False
+
+    def cancel_before_digest(value: Any) -> str:
+        nonlocal cancelled_at_admission
+        if (
+            not cancelled_at_admission
+            and isinstance(value, dict)
+            and value.get("artifact_kind") == "GOVERNANCE_OBSERVATION"
+            and "observation_output_digest" not in value
+        ):
+            cancelled_at_admission = True
+            cancellation.cancel()
+        return original_digest(value)
+
+    monkeypatch.setattr(governance, "canonical_digest", cancel_before_digest)
+    observation = api.GovernanceCollector(
+        repository="example/fixture",
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
+        cancellation=cancellation,
+    ).observe(repo, ref="main")
+
+    assert cancelled_at_admission
+    assert observation.disposition == "BLOCKED"
+    assert any(
+        item.fact == "observation_cancellation" and item.status == "BLOCKED"
+        for item in observation.unknowns
+    )
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert (repo / ".git" / "index").read_bytes() == before_index
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
 
 
 def test_git_readers_disable_lazy_fetch_and_repository_defined_accelerators() -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -1155,6 +1155,9 @@ def test_undiscoverable_or_unproven_local_github_targets_are_not_verified(
         "../../.github/workflows/x.yml@v1",
         "owner/repository/.github/workflows/nested/x.yml@v1",
         "owner/repository/action@../v1",
+        "owner/repository/action@refs/heads/.hidden",
+        "owner/repository/action@refs/heads/foo./bar",
+        "owner/repository/action@refs/heads/topic.lock/child",
     ],
 )
 def test_malformed_remote_github_references_are_not_verified(
@@ -1745,6 +1748,28 @@ def test_sensitive_mapping_fields_are_redacted_before_persistence(field: str) ->
     assert secret not in json.dumps(sanitized)
 
 
+@pytest.mark.parametrize(
+    ("header", "secrets"),
+    [
+        ("Authorization: Token opaque-secret", ("Token", "opaque-secret")),
+        (
+            'Authorization: Digest username="user", nonce="nonce-secret", '
+            'response="response-secret"',
+            ("username", "user", "nonce-secret", "response-secret"),
+        ),
+        ("Proxy-Authorization: Custom proxy-secret", ("Custom", "proxy-secret")),
+    ],
+)
+def test_complete_authorization_header_is_redacted_for_every_scheme(
+    header: str,
+    secrets: tuple[str, ...],
+) -> None:
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    sanitized = redaction.EvidenceRedactor(environment={}).sanitize(f"provider returned {header}")
+    assert sanitized == "provider returned Authorization: [REDACTED]"
+    assert all(secret not in sanitized for secret in secrets)
+
+
 def test_non_secret_boolean_control_with_sensitive_word_remains_typed() -> None:
     redaction = importlib.import_module("pmpe.repository.redaction")
     sanitized = redaction.EvidenceRedactor(environment={}).sanitize(
@@ -1942,6 +1967,11 @@ class _SecretBearingRemote(_FakeRemote):
                 "authorization": "Basic dXNlcjpwYXNzd29yZA==",
                 "x-api-key": "unstructured-bare-secret",
                 "note": "Authorization: Basic dXNlcjpwYXNzd29yZA==",
+                "custom_auth_note": "Authorization: Token opaque-authorization-secret",
+                "digest_auth_note": (
+                    'Authorization: Digest username="user", nonce="nonce-secret", '
+                    'response="response-secret"'
+                ),
                 "comment": "glpat-0123456789abcdefghijkl",
             }
         )
@@ -2552,6 +2582,9 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert any(item.fact == "remote_collection_attestation" for item in observation.unknowns)
     assert "ghp_0123456789abcdefghijklmnop" not in payload
     assert "dXNlcjpwYXNzd29yZA==" not in payload
+    assert "opaque-authorization-secret" not in payload
+    assert "nonce-secret" not in payload
+    assert "response-secret" not in payload
     assert "secret-value" not in payload
     assert "signed-secret" not in payload
     assert "unstructured-bare-secret" not in payload

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -812,6 +812,28 @@ def test_non_github_ci_is_not_reported_as_ci_absent(tmp_path: Path) -> None:
     assert not any(item.code == "DELIVERY.CI_ABSENT" for item in snapshot.findings)
 
 
+@pytest.mark.parametrize(
+    ("path", "content"),
+    [
+        (".gitlab-ci.yml", "variables:\n  FOO: bar\n"),
+        ("azure-pipelines.yml", "steps: []\n"),
+    ],
+)
+def test_non_runnable_ci_scaffolds_do_not_suppress_missing_ci(
+    tmp_path: Path,
+    path: str,
+    content: str,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, path, content)
+    _commit(repo, "non-runnable CI scaffold")
+    snapshot = _scan(repo)
+    assert not any(
+        item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
+    )
+    assert any(item.code == "DELIVERY.CI_ABSENT" for item in snapshot.findings)
+
+
 def test_ci_comments_do_not_become_security_test_or_rollback_controls(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path, mixed=False)
     _write(
@@ -1195,6 +1217,28 @@ def test_budget_exhaustion_is_explicit_partial_result(
     assert set(snapshot.inventory) == set(_api().AUDIT_CATEGORIES)
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("max_files", 100_001),
+        ("max_directories", 50_001),
+        ("max_total_bytes", 2_000_000_001),
+        ("max_file_bytes", 50_000_001),
+        ("max_tree_output_bytes", 128_000_001),
+        ("max_commands", 250_001),
+        ("command_timeout_seconds", 121),
+        ("max_path_depth", 257),
+    ],
+)
+def test_scan_budget_hard_ceilings_cannot_be_disabled(
+    tmp_path: Path,
+    field: str,
+    value: int,
+) -> None:
+    with pytest.raises(_api().RepositoryIntelligenceError, match="hard safety ceiling"):
+        _scan(_init_repo(tmp_path), **{field: value})
+
+
 def test_bounded_tree_enumeration_is_byte_deterministic(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     first = _scan(repo, max_tree_output_bytes=64)
@@ -1310,6 +1354,21 @@ def test_non_secret_boolean_control_with_sensitive_word_remains_typed() -> None:
     assert sanitized == {"required_signed_commits": True, "signature": "[REDACTED]"}
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://hooks.slack.com/services/T000/B000/slack-webhook-secret",
+        "https://discord.com/api/webhooks/123/discord-webhook-secret",
+        "https://api.telegram.org/bottelegram-secret/sendMessage",
+    ],
+)
+def test_credential_bearing_url_paths_are_redacted(url: str) -> None:
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    sanitized = redaction.EvidenceRedactor(environment={}).sanitize(url)
+    assert sanitized.endswith("/[REDACTED_PATH]")
+    assert "secret" not in sanitized
+
+
 def test_sensitive_environment_value_is_redacted_under_benign_field() -> None:
     redaction = importlib.import_module("pmpe.repository.redaction")
     secret = "opaque-credential-value-not-matching-a-token-shape"
@@ -1374,9 +1433,19 @@ class _FakeRemote:
             "complete": True,
             "repository": repository,
             "ref": ref,
+            "default_branch": "main",
             "observed_at": "2026-08-01T00:00:00Z",
             "coverage": ["remote_branches", "pull_requests", "issues", "governance"],
-            "remote_branches": [{"name": "origin/feature", "sha": "a" * 40}],
+            "remote_branches": [
+                {
+                    "name": "origin/feature",
+                    "sha": "a" * 40,
+                    "comparison_ref": ref,
+                    "ahead": 1,
+                    "behind": 0,
+                    "status": "OBSERVED",
+                }
+            ],
             "pull_requests": [
                 {
                     "number": 7,
@@ -1725,8 +1794,50 @@ def test_governance_observation_records_dirty_index_worktree_and_untracked_state
     assert observation.observed_at == "2026-08-01T00:00:00Z"
     assert observation.observation_id == "OBS-000001"
     assert observation.artifact_kind == "GOVERNANCE_OBSERVATION"
-    assert observation.disposition == "PARTIAL"
+    assert observation.disposition == "BLOCKED"
+    assert {item.fact for item in observation.unknowns} >= {
+        "dirty_index",
+        "dirty_worktree",
+        "untracked_files",
+    }
     assert any(item.fact == "remote_governance" for item in observation.unknowns)
+
+
+def test_concurrent_local_mutation_blocks_mixed_time_observation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    repo = _init_repo(tmp_path)
+    original = governance.GovernanceCommandRunner.run
+    status_calls = 0
+
+    def changing_status(
+        self: Any,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        cancellation: Any = None,
+    ) -> Any:
+        nonlocal status_calls
+        if args[1] == "status":
+            status_calls += 1
+            if status_calls == 2:
+                return api.CommandResult(
+                    args=args,
+                    returncode=0,
+                    stdout=b"?? concurrently-created.txt\0",
+                    stderr=b"",
+                )
+        return original(self, args, cwd, timeout, cancellation=cancellation)
+
+    monkeypatch.setattr(governance.GovernanceCommandRunner, "run", changing_status)
+    observation = _observe(repo)
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "concurrent_local_mutation" for item in observation.unknowns)
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == ""
 
 
 @pytest.mark.parametrize(
@@ -1803,6 +1914,8 @@ def test_branch_divergence_and_additional_worktrees_are_mutable_observations(
     observation = _observe(repo)
     feature = next(item for item in observation.local_branches if item.name == "feature")
     assert feature.ahead >= 1 and feature.behind >= 1
+    assert observation.current_branch == "main"
+    assert observation.configured_remotes == ()
     assert observation.worktrees
     assert "local_branches" not in _scan(repo).as_dict()
 
@@ -2022,12 +2135,19 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     payload = observation.canonical_bytes().decode()
     assert observation.disposition == "BLOCKED"
     assert any(item.fact == "remote_governance_completeness" for item in observation.unknowns)
-    assert observation.tool_identity == "recorded-remote-payload/1.1.0"
+    assert observation.tool_identity == "recorded-remote-payload/2.0.0"
     assert observation.api_query_version == "github-rest/2026-03-10"
     assert observation.query_provenance[0].surface == "remote_branches"
     assert observation.query_provenance[0].cursor == "branches-page-1"
     assert observation.observation_input_digest.startswith("sha256:")
     assert observation.observation_output_digest.startswith("sha256:")
+    assert observation.remote_default_branch == "main"
+    assert observation.remote_branches[0].comparison_ref == "main"
+    assert observation.remote_branches[0].ahead == 1
+    assert observation.remote_branches[0].status == "OBSERVED"
+    assert observation.remote_collection_provenance["source_kind"] == "RECORDED_UNATTESTED"
+    assert observation.remote_collection_provenance["attestation"] == "ABSENT"
+    assert any(item.fact == "remote_collection_attestation" for item in observation.unknowns)
     assert "ghp_0123456789abcdefghijklmnop" not in payload
     assert "dXNlcjpwYXNzd29yZA==" not in payload
     assert "secret-value" not in payload
@@ -2268,7 +2388,8 @@ def test_pull_request_staleness_and_conflict_evidence_are_explicit(tmp_path: Pat
     assert pull_request.updated_at == "2026-06-01T00:00:00Z"
     assert pull_request.stale is True
     assert pull_request.mergeability == "CONFLICTING"
-    assert observation.disposition == "COMPLETE"
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "remote_collection_attestation" for item in observation.unknowns)
 
 
 def test_unknown_pull_request_mergeability_blocks_complete_observation(tmp_path: Path) -> None:
@@ -2401,11 +2522,12 @@ def test_observation_input_digest_binds_freshness_and_collector_budgets(tmp_path
             max_remote_age_seconds=max_age,
         ).observe(repo, ref="main")
 
-    admitted = observe(300)
+    fresh = observe(300)
     blocked = observe(60)
-    assert admitted.disposition == "COMPLETE"
+    assert fresh.disposition == "BLOCKED"
+    assert any(item.fact == "remote_collection_attestation" for item in fresh.unknowns)
     assert blocked.disposition == "BLOCKED"
-    assert admitted.observation_input_digest != blocked.observation_input_digest
+    assert fresh.observation_input_digest != blocked.observation_input_digest
 
     alternate_stale_policy = api.GovernanceCollector(
         repository="example/fixture",
@@ -2415,7 +2537,40 @@ def test_observation_input_digest_binds_freshness_and_collector_budgets(tmp_path
         max_remote_age_seconds=300,
         stale_pull_request_after_seconds=60,
     ).observe(repo, ref="main")
-    assert admitted.observation_input_digest != alternate_stale_policy.observation_input_digest
+    assert fresh.observation_input_digest != alternate_stale_policy.observation_input_digest
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("command_timeout_seconds", 121),
+        ("max_commands", 20_001),
+        ("max_branches", 10_001),
+        ("max_output_bytes", 64_000_001),
+        ("max_remote_items", 100_001),
+        ("max_remote_age_seconds", 86_401),
+        ("stale_pull_request_after_seconds", 31_536_001),
+    ],
+)
+def test_governance_budget_hard_ceilings_cannot_be_disabled(
+    tmp_path: Path,
+    field: str,
+    value: int,
+) -> None:
+    api = _api()
+    kwargs = {
+        "repository": "example/fixture",
+        "clock": _fixed_clock(),
+        "id_provider": _fixed_ids(),
+        field: value,
+    }
+    if field == "max_output_bytes":
+        with pytest.raises(api.RepositoryIntelligenceError, match="hard ceiling"):
+            api.GovernanceCollector(**kwargs)
+        return
+    collector = api.GovernanceCollector(**kwargs)
+    with pytest.raises(api.RepositoryIntelligenceError, match="hard safety ceiling"):
+        collector.observe(_init_repo(tmp_path), ref="main")
 
 
 def test_scan_and_observation_never_create_branches_commits_or_remote_mutations(
@@ -2790,7 +2945,7 @@ def test_digest_bearing_artifacts_are_self_verified_before_reuse(tmp_path: Path)
         snapshot.assessment_reference(tampered_observation)
 
 
-def test_snapshot_and_observation_references_form_a_narrow_lifecycle_seam(
+def test_noncomplete_snapshot_and_observation_cannot_form_a_lifecycle_reference(
     tmp_path: Path,
 ) -> None:
     api = _api()
@@ -2802,15 +2957,8 @@ def test_snapshot_and_observation_references_form_a_narrow_lifecycle_seam(
         clock=_fixed_clock(),
         id_provider=_fixed_ids(),
     ).observe(repo, ref="main")
-    reference = snapshot.assessment_reference(observation)
-    assert reference == {
-        "repository_snapshot_digest": snapshot.snapshot_digest,
-        "repository_commit": snapshot.commit_sha,
-        "governance_observation_id": observation.observation_id,
-        "governance_observation_digest": observation.observation_output_digest,
-    }
-    assert "architecture" not in reference
-    assert "recommendation" not in reference
+    with pytest.raises(ValueError, match="snapshot is not complete"):
+        snapshot.assessment_reference(observation)
 
 
 def test_snapshot_rejects_governance_observation_from_another_repository(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -375,6 +375,17 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(rfc8785_impl, "_serialize_str", lambda value, sink: None)
         assert scanner._implementation_digest() != original
+    for module_name, attribute in (
+        ("configparser", "ConfigParser"),
+        ("fnmatch", "fnmatch"),
+        ("json", "loads"),
+        ("shlex", "split"),
+        ("tomllib", "loads"),
+    ):
+        module = importlib.import_module(module_name)
+        with monkeypatch.context() as runtime_patch:
+            runtime_patch.setattr(module, attribute, lambda *_args, **_kwargs: {})
+            assert scanner._implementation_digest() != original
     runtime_digest = scanner._module_runtime_digest("repository.scanner")
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(
@@ -1158,6 +1169,10 @@ def test_undiscoverable_or_unproven_local_github_targets_are_not_verified(
         "owner/repository/action@refs/heads/.hidden",
         "owner/repository/action@refs/heads/foo./bar",
         "owner/repository/action@refs/heads/topic.lock/child",
+        "bad_owner/repository/action@v1",
+        "bad.owner/repository/action@v1",
+        "bad--owner/repository/action@v1",
+        f"{'a' * 40}/repository/action@v1",
     ],
 )
 def test_malformed_remote_github_references_are_not_verified(
@@ -1756,6 +1771,11 @@ def test_sensitive_mapping_fields_are_redacted_before_persistence(field: str) ->
             'Authorization: Digest username="user", nonce="nonce-secret", '
             'response="response-secret"',
             ("username", "user", "nonce-secret", "response-secret"),
+        ),
+        (
+            'Authorization: Digest username="user",\r\n nonce="folded-nonce",\r\n'
+            ' response="folded-response"',
+            ("username", "user", "folded-nonce", "folded-response"),
         ),
         ("Proxy-Authorization: Custom proxy-secret", ("Custom", "proxy-secret")),
     ],

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -2934,6 +2934,103 @@ def test_unsealed_parent_collaborators_are_rejected_before_execution(tmp_path: P
     assert not marker.exists()
 
 
+def test_scanner_rejects_post_construction_adapter_substitution_before_mutation(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    adapters = importlib.import_module("pmpe.repository.adapters")
+    repo = _init_repo(tmp_path)
+    marker = repo / "adapter-substitution.txt"
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    candidate = api.RepositoryScanner(config=_config())
+
+    def mutating_evaluator(_context: Any) -> Any:
+        marker.write_text("mutated")
+        return adapters.AdapterResult()
+
+    replacement = replace(candidate.adapters[0], evaluator=mutating_evaluator)
+    substituted = (replacement, *candidate.adapters[1:])
+    with pytest.raises(AttributeError):
+        candidate.adapters = substituted
+    object.__setattr__(candidate, "_adapters", substituted)
+
+    with pytest.raises(api.RepositorySecurityError, match="provenance binding"):
+        candidate.scan(repo, commit="HEAD")
+    assert not marker.exists()
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+
+
+def test_scanner_rejects_every_replaced_execution_collaborator(tmp_path: Path) -> None:
+    api = _api()
+    scanner_module = importlib.import_module("pmpe.repository.scanner")
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    repo = _init_repo(tmp_path)
+    replacements = {
+        "config": replace(_config()),
+        "_runner": scanner_module.SubprocessCommandRunner(),
+        "_redactor": redaction.EvidenceRedactor(environment={}),
+        "_cancellation": api.CancellationSignal(),
+        "_extension_implementation_evidence": (),
+    }
+    for attribute, replacement in replacements.items():
+        candidate = api.RepositoryScanner(config=_config())
+        object.__setattr__(candidate, attribute, replacement)
+        with pytest.raises(api.RepositorySecurityError, match="sealed|provenance binding"):
+            candidate.scan(repo, commit="HEAD")
+
+    candidate = api.RepositoryScanner(config=_config())
+    candidate._extension_implementation_evidence[0]["source_digest"] = "sha256:tampered"
+    with pytest.raises(api.RepositorySecurityError, match="sealed"):
+        candidate.scan(repo, commit="HEAD")
+
+    candidate = api.RepositoryScanner(config=_config())
+    object.__setattr__(candidate.redactor, "_environment_secrets", ("tampered",))
+    with pytest.raises(api.RepositorySecurityError, match="sealed"):
+        candidate.scan(repo, commit="HEAD")
+
+
+def test_governance_rejects_every_replaced_execution_collaborator(tmp_path: Path) -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    repo = _init_repo(tmp_path)
+    snapshot = _scan(repo)
+    remote = _sealed_remote(_FakeRemote())
+    replacements = {
+        "_snapshot": replace(snapshot),
+        "_clock": _fixed_clock(),
+        "_id_provider": _fixed_ids(),
+        "_remote_provider": remote,
+        "_runner": governance.GovernanceCommandRunner(),
+        "_redactor": redaction.EvidenceRedactor(environment={}),
+        "_cancellation": api.CancellationSignal(),
+        "_extension_implementation_evidence": (),
+        "max_commands": 1,
+    }
+    for attribute, replacement in replacements.items():
+        candidate = api.GovernanceCollector(
+            repository="example/fixture",
+            snapshot=snapshot,
+            clock=_fixed_clock(),
+            id_provider=_fixed_ids(),
+        )
+        object.__setattr__(candidate, attribute, replacement)
+        with pytest.raises(api.RepositorySecurityError, match="sealed|provenance binding"):
+            candidate.observe(repo, ref="main")
+
+    candidate = api.GovernanceCollector(
+        repository="example/fixture",
+        snapshot=snapshot,
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
+    )
+    candidate._extension_implementation_evidence[0]["source_digest"] = "sha256:tampered"
+    with pytest.raises(api.RepositorySecurityError, match="sealed"):
+        candidate.observe(repo, ref="main")
+
+
 def test_unproven_remote_pagination_is_blocked_not_complete(tmp_path: Path) -> None:
     observation = _observe(_init_repo(tmp_path), _PartialRemote())
     assert observation.disposition == "BLOCKED"

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -153,7 +153,7 @@ def test_scoped_scan_is_explicitly_partial_and_keeps_full_tree_binding(tmp_path:
     scoped = _scan(repo, include_paths=("src",))
     assert scoped.scan_scope == "INCLUDED_PATHS"
     assert scoped.included_paths == ("src",)
-    assert scoped.disposition == "PARTIAL"
+    assert scoped.disposition == "BLOCKED"
     assert scoped.tracked_tree_digest == full.tracked_tree_digest
     assert scoped.scanned_content_digest != full.scanned_content_digest
     assert any(item.code == "SCAN.SCOPED_PARTIAL" for item in scoped.findings)
@@ -380,7 +380,7 @@ def test_api_codegen_declarations_bind_tracked_inputs_outputs_and_exporter(
                 "name": "web",
                 "scripts": {
                     "generate:api-types": (
-                        "openapi-typescript ../backend/openapi.json -o src/lib/api-types.gen.ts"
+                        "openapi-typescript ../backend/schema.json -o src/lib/api.ts"
                     )
                 },
             }
@@ -388,13 +388,18 @@ def test_api_codegen_declarations_bind_tracked_inputs_outputs_and_exporter(
     )
     _write(
         repo,
-        "products/backend/openapi.json",
-        '{"openapi":"3.1.0","info":{"title":"Fixture","version":"1"},"paths":{}}',
+        "products/backend/schema.json",
+        '{"$schema":"https://json-schema.org/draft/2020-12/schema"}',
     )
-    _write(repo, "products/web/src/lib/api-types.gen.ts", "export interface paths {}\n")
+    _write(repo, "products/web/src/lib/api.ts", "export interface paths {}\n")
     _write(
         repo,
-        "products/backend/scripts/export_openapi.py",
+        "openapi.json",
+        '{"openapi":"3.1.0","info":{"title":"Fixture","version":"1"},"paths":{}}',
+    )
+    _write(
+        repo,
+        "scripts/export_openapi.py",
         'target = root / "openapi.json"\ntarget.write_text("{}")\n',
     )
     _commit(repo, "code generation relationship")
@@ -413,18 +418,31 @@ def test_api_codegen_declarations_bind_tracked_inputs_outputs_and_exporter(
     }
     assert {item.path for item in relationship} == {
         "products/web/package.json",
-        "products/backend/openapi.json",
-        "products/web/src/lib/api-types.gen.ts",
+        "products/backend/schema.json",
+        "products/web/src/lib/api.ts",
     }
     export_relationship = [
-        item
-        for item in evidence
-        if item.location == "products/backend/scripts/export_openapi.py#export"
+        item for item in evidence if item.location == "scripts/export_openapi.py#export"
     ]
     assert {item.kind for item in export_relationship} == {
         "CODE_GENERATOR_SIGNAL",
         "CODE_GENERATION_OUTPUT",
     }
+
+
+def test_openapi_named_source_or_documentation_is_not_parsed_as_a_contract(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "docs/openapi-guide.md", "# OpenAPI authoring guide\n")
+    _write(repo, "src/openapi_helpers.py", "def helper() -> None:\n    pass\n")
+    _commit(repo, "non-contract OpenAPI names")
+    snapshot = _scan(repo)
+    assert not any(
+        item.code == "INTERFACE.DECLARATION_INVALID"
+        and set(item.evidence_refs) & {"docs/openapi-guide.md", "src/openapi_helpers.py"}
+        for item in snapshot.findings
+    )
 
 
 def test_incomplete_api_codegen_relationship_fails_closed(tmp_path: Path) -> None:
@@ -623,6 +641,26 @@ def test_unhandled_required_subcategory_is_blocked_not_silently_absent(
         item.code == "AUDIT.UNSUPPORTED_SUBCATEGORY" and "data-model.yaml" in item.evidence_refs
         for item in snapshot.findings
     )
+
+
+def test_every_required_internal_audit_subcategory_is_explicit(tmp_path: Path) -> None:
+    snapshot = _scan(_init_repo(tmp_path, mixed=False))
+    unsupported = {
+        item.explanation
+        for item in snapshot.findings
+        if item.code == "AUDIT.REQUIRED_SUBCATEGORY_UNSUPPORTED"
+    }
+    assert all(
+        any(capability in explanation for explanation in unsupported)
+        for capability in (
+            "ignored paths",
+            "internal dependency direction",
+            "shared-library relationships",
+            "storage models",
+            "deployment-evidence mechanisms",
+        )
+    )
+    assert snapshot.disposition == "BLOCKED"
 
 
 def test_blocked_subcategory_status_survives_a_concurrent_partial_scan(
@@ -1136,6 +1174,21 @@ def test_sensitive_environment_value_is_redacted_under_benign_field() -> None:
     assert sanitized["message"] == "provider returned [REDACTED_ENV]"
 
 
+def test_home_path_minimization_is_host_state_independent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    monkeypatch.setenv("HOME", "/Users/first-host")
+    first = redaction.EvidenceRedactor(environment={}).sanitize(
+        "/Users/repository-owner/work/repository"
+    )
+    monkeypatch.setenv("HOME", "/home/second-host")
+    second = redaction.EvidenceRedactor(environment={}).sanitize(
+        "/Users/repository-owner/work/repository"
+    )
+    assert first == second == "$HOME/work/repository"
+
+
 def _fixed_clock() -> Any:
     return _api().RecordedUtcClock("2026-08-01T00:00:00Z")
 
@@ -1179,6 +1232,11 @@ class _FakeRemote:
                 "schema_version": "pmpe.repository-governance/v1",
                 "branch_protection": {"observed": True, "required_checks": ["ci"]},
                 "review_policy": {"required_approvals": 1},
+                "security_settings": {
+                    "observed": True,
+                    "leak_detection": "ENABLED",
+                    "dependency_alerts": "ENABLED",
+                },
             },
             "query_provenance": [
                 {
@@ -1257,6 +1315,13 @@ class _ExtraCoverageRemote(_FakeRemote):
     def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
         payload = super().collect(repository, ref, **bounds)
         payload["coverage"].append("deployments")
+        return payload
+
+
+class _MissingSecuritySettingsRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        del payload["governance"]["security_settings"]
         return payload
 
 
@@ -1783,7 +1848,10 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "[REDACTED]" in payload
 
 
-@pytest.mark.parametrize("remote", [_InvalidIssueStateRemote(), _ExtraCoverageRemote()])
+@pytest.mark.parametrize(
+    "remote",
+    [_InvalidIssueStateRemote(), _ExtraCoverageRemote(), _MissingSecuritySettingsRemote()],
+)
 def test_untyped_or_overbroad_remote_metadata_cannot_be_complete(
     tmp_path: Path,
     remote: Any,
@@ -1791,7 +1859,12 @@ def test_untyped_or_overbroad_remote_metadata_cannot_be_complete(
     observation = _observe(_init_repo(tmp_path), remote)
     assert observation.disposition == "BLOCKED"
     assert any(
-        item.fact in {"remote_metadata_shape", "remote_metadata_completeness"}
+        item.fact
+        in {
+            "remote_governance_completeness",
+            "remote_metadata_shape",
+            "remote_metadata_completeness",
+        }
         for item in observation.unknowns
     )
 

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -389,6 +389,10 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(urllib_parse, "uses_netloc", [*urllib_parse.uses_netloc, "custom"])
         assert scanner._implementation_digest() != original
+    json_module = importlib.import_module("json")
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(json_module, "_default_decoder", json.JSONDecoder(strict=False))
+        assert scanner._implementation_digest() != original
     for module_name, attribute in (
         ("configparser", "ConfigParser"),
         ("datetime", "datetime"),
@@ -402,6 +406,8 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
         ("_json", "scanstring"),
         ("_sre", "compile"),
         ("math", "isfinite"),
+        ("re._compiler", "_compile"),
+        ("re._parser", "parse"),
     ):
         module = importlib.import_module(module_name)
         with monkeypatch.context() as runtime_patch:
@@ -1826,6 +1832,22 @@ def test_complete_authorization_header_is_redacted_for_every_scheme(
     assert all(secret not in sanitized for secret in secrets)
 
 
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Cookie: session=primary-secret; csrf=secondary-secret",
+        "Set-Cookie: session=primary-secret; HttpOnly; csrf=secondary-secret",
+        "Cookie: session=primary-secret;\r\n csrf=folded-secondary-secret",
+    ],
+)
+def test_complete_cookie_header_is_redacted(header: str) -> None:
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    sanitized = redaction.EvidenceRedactor(environment={}).sanitize(f"provider returned {header}")
+    assert sanitized == "provider returned Cookie: [REDACTED]"
+    assert "primary-secret" not in sanitized
+    assert "secondary-secret" not in sanitized
+
+
 def test_non_secret_boolean_control_with_sensitive_word_remains_typed() -> None:
     redaction = importlib.import_module("pmpe.repository.redaction")
     sanitized = redaction.EvidenceRedactor(environment={}).sanitize(
@@ -2017,6 +2039,9 @@ class _SecretBearingRemote(_FakeRemote):
                 "azure_note": "AccountName=demo;AccountKey=azure-secret-value==;Endpoint=x",
                 "odbc_note": "Driver=x;UID=demo;PWD={odbc secret value};Server=db",
                 "cookie_note": "Cookie: session=cookie-secret; theme=dark",
+                "folded_cookie_note": (
+                    "Set-Cookie: session=cookie-secret;\r\n csrf=secondary-cookie-secret"
+                ),
                 "aws_note": "aws_secret_access_key=aws-secret-value",
                 "safe_url": "https://user:password@example.invalid/repo?token=secret-value",
                 "signed_url": "https://storage.example.invalid/blob?sv=1&sig=signed-secret",
@@ -2671,6 +2696,7 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "azure-secret-value" not in payload
     assert "odbc secret value" not in payload
     assert "cookie-secret" not in payload
+    assert "secondary-cookie-secret" not in payload
     assert "aws-secret-value" not in payload
     assert "query-json-secret" not in payload
     assert "pass-json-secret" not in payload

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -1148,6 +1148,48 @@ def test_undiscoverable_or_unproven_local_github_targets_are_not_verified(
     assert any(item.code == "WORKFLOW.STRUCTURE_UNPROVEN" for item in snapshot.findings)
 
 
+@pytest.mark.parametrize(
+    "uses",
+    [
+        "../..@v1",
+        "../../.github/workflows/x.yml@v1",
+        "owner/repository/.github/workflows/nested/x.yml@v1",
+        "owner/repository/action@../v1",
+    ],
+)
+def test_malformed_remote_github_references_are_not_verified(
+    tmp_path: Path,
+    uses: str,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    is_workflow = ".github/workflows" in uses
+    job = (
+        f"  invalid:\n    uses: {uses}\n"
+        if is_workflow
+        else f"  invalid:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: {uses}\n"
+    )
+    _write(repo, ".github/workflows/ci.yml", f"on: [push]\njobs:\n{job}")
+    _commit(repo, "invalid remote github reference")
+    snapshot = _scan(repo)
+    assert not any(
+        item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
+    )
+    assert any(item.code == "WORKFLOW.STRUCTURE_UNPROVEN" for item in snapshot.findings)
+
+
+def test_late_governance_cancellation_changes_the_input_binding() -> None:
+    governance = importlib.import_module("pmpe.repository.governance")
+    inputs = {
+        "evaluation_disposition": "COMPLETE",
+        "evaluation_unknowns": [],
+        "safe": True,
+    }
+    initial = importlib.import_module("pmpe.contracts.canonical").canonical_digest(inputs)
+    rebound = governance._late_cancellation_input_digest(inputs)
+    assert rebound != initial
+    assert rebound == governance._late_cancellation_input_digest(inputs)
+
+
 def test_supported_github_needs_graph_and_matrix_objects_are_verified(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path, mixed=False)
     _write(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -1356,6 +1356,57 @@ def test_governance_observation_records_dirty_index_worktree_and_untracked_state
     assert any(item.fact == "remote_governance" for item in observation.unknowns)
 
 
+@pytest.mark.parametrize(
+    "status_output",
+    [
+        "XX malformed\0",
+        "??\0",
+        "?? \0",
+        "M malformed\0",
+        "?? untracked-without-terminator",
+    ],
+)
+def test_malformed_porcelain_status_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    status_output: str,
+) -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    repo = _init_repo(tmp_path)
+    original = governance.GovernanceCommandRunner.run
+
+    def malformed_status(
+        self: Any,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        cancellation: Any = None,
+    ) -> Any:
+        if args[1] == "status":
+            return api.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=status_output,
+                stderr="",
+            )
+        return original(self, args, cwd, timeout, cancellation=cancellation)
+
+    monkeypatch.setattr(governance.GovernanceCommandRunner, "run", malformed_status)
+    with pytest.raises(api.RepositoryIntelligenceError, match="status output is malformed"):
+        _observe(repo)
+
+
+def test_nul_porcelain_status_preserves_rename_and_untracked_state() -> None:
+    governance = importlib.import_module("pmpe.repository.governance")
+    assert governance._parse_porcelain_status("R  new-name\0old-name\0?? untracked\0") == (
+        True,
+        False,
+        True,
+    )
+
+
 def test_gitlink_state_is_explicitly_unknown_instead_of_silently_clean(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     commit_sha = _git(repo, "rev-parse", "HEAD")
@@ -1536,6 +1587,57 @@ def test_malformed_or_contradictory_worktree_lifecycle_fails_closed(
         return original(self, args, cwd, timeout, cancellation=cancellation)
 
     monkeypatch.setattr(governance.GovernanceCommandRunner, "run", malformed_lifecycle)
+    observation = _observe(repo)
+    assert observation.disposition == "BLOCKED"
+    assert observation.worktrees == ()
+    assert any(item.fact == "worktree_record:1" for item in observation.unknowns)
+
+
+@pytest.mark.parametrize(
+    ("path_kind", "branch_ref"),
+    [
+        ("relative", "refs/heads/main"),
+        ("absolute", "refs/tags/v1"),
+        ("absolute", "main"),
+        ("absolute", "refs/heads/.hidden"),
+        ("absolute", "refs/heads/topic.lock/child"),
+    ],
+)
+def test_malformed_worktree_path_or_branch_ref_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    path_kind: str,
+    branch_ref: str,
+) -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    repo = _init_repo(tmp_path)
+    head = _git(repo, "rev-parse", "HEAD")
+    worktree_path = "relative/worktree" if path_kind == "relative" else str(repo)
+    original = governance.GovernanceCommandRunner.run
+
+    def malformed_worktree_identity(
+        self: Any,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        cancellation: Any = None,
+    ) -> Any:
+        if args[1:3] == ("worktree", "list"):
+            return api.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=(f"worktree {worktree_path}\0HEAD {head}\0branch {branch_ref}\0\0"),
+                stderr="",
+            )
+        return original(self, args, cwd, timeout, cancellation=cancellation)
+
+    monkeypatch.setattr(
+        governance.GovernanceCommandRunner,
+        "run",
+        malformed_worktree_identity,
+    )
     observation = _observe(repo)
     assert observation.disposition == "BLOCKED"
     assert observation.worktrees == ()
@@ -2220,7 +2322,7 @@ def test_git_readers_disable_lazy_fetch_and_repository_defined_accelerators() ->
     assert scanner_environment["GIT_CONFIG_VALUE_0"] == "false"
     governance_runner = governance.GovernanceCommandRunner()
     assert scanner_environment["GIT_CONFIG_VALUE_5"] == "false"
-    assert governance_runner.identity.endswith("1.8.0")
+    assert governance_runner.identity.endswith("1.9.0")
 
 
 def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -368,6 +368,89 @@ def test_api_data_generated_client_migration_and_contract_sync_are_inventory_ite
     )
 
 
+def test_api_codegen_declarations_bind_tracked_inputs_outputs_and_exporter(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(
+        repo,
+        "products/web/package.json",
+        json.dumps(
+            {
+                "name": "web",
+                "scripts": {
+                    "generate:api-types": (
+                        "openapi-typescript ../backend/openapi.json -o src/lib/api-types.gen.ts"
+                    )
+                },
+            }
+        ),
+    )
+    _write(
+        repo,
+        "products/backend/openapi.json",
+        '{"openapi":"3.1.0","info":{"title":"Fixture","version":"1"},"paths":{}}',
+    )
+    _write(repo, "products/web/src/lib/api-types.gen.ts", "export interface paths {}\n")
+    _write(
+        repo,
+        "products/backend/scripts/export_openapi.py",
+        'target = root / "openapi.json"\ntarget.write_text("{}")\n',
+    )
+    _commit(repo, "code generation relationship")
+
+    snapshot = _scan(repo)
+    evidence = snapshot.inventory["apis_data"].items
+    relationship = [
+        item
+        for item in evidence
+        if item.location == "products/web/package.json#scripts.generate:api-types"
+    ]
+    assert {item.kind for item in relationship} == {
+        "CODE_GENERATION_DECLARATION",
+        "CODE_GENERATION_INPUT",
+        "CODE_GENERATION_OUTPUT",
+    }
+    assert {item.path for item in relationship} == {
+        "products/web/package.json",
+        "products/backend/openapi.json",
+        "products/web/src/lib/api-types.gen.ts",
+    }
+    export_relationship = [
+        item
+        for item in evidence
+        if item.location == "products/backend/scripts/export_openapi.py#export"
+    ]
+    assert {item.kind for item in export_relationship} == {
+        "CODE_GENERATOR_SIGNAL",
+        "CODE_GENERATION_OUTPUT",
+    }
+
+
+def test_incomplete_api_codegen_relationship_fails_closed(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(
+        repo,
+        "products/web/package.json",
+        json.dumps(
+            {
+                "name": "web",
+                "scripts": {
+                    "generate:api-types": (
+                        "openapi-typescript ../backend/missing.json -o src/lib/api-types.gen.ts"
+                    )
+                },
+            }
+        ),
+    )
+    _commit(repo, "incomplete code generation relationship")
+    snapshot = _scan(repo)
+    assert snapshot.disposition == "BLOCKED"
+    assert any(
+        item.code == "INTERFACE.CODEGEN_RELATIONSHIP_INCOMPLETE" for item in snapshot.findings
+    )
+
+
 def test_database_privacy_and_observability_subcategories_are_explicit(
     tmp_path: Path,
 ) -> None:
@@ -963,6 +1046,8 @@ def test_submodule_gitlink_is_inventory_only_and_never_executed(tmp_path: Path) 
     _git(repo, "commit", "-q", "-m", "gitlink")
     snapshot = _scan(repo)
     assert any(item.kind == "SUBMODULE" for item in snapshot.inventory["repository_topology"].items)
+    assert snapshot.disposition == "BLOCKED"
+    assert any(item.code == "REPOSITORY.SUBMODULE_SCOPE_UNSCANNED" for item in snapshot.findings)
 
 
 def test_symlink_escape_is_refused_without_following_target(tmp_path: Path) -> None:
@@ -1094,20 +1179,6 @@ class _FakeRemote:
                 "schema_version": "pmpe.repository-governance/v1",
                 "branch_protection": {"observed": True, "required_checks": ["ci"]},
                 "review_policy": {"required_approvals": 1},
-                "database_note": (
-                    "DATABASE_URL=postgres://database-user:database-password@db.invalid/app"
-                    "?sslmode=require&token=query-secret"
-                ),
-                "azure_note": "AccountName=demo;AccountKey=azure-secret-value==;Endpoint=x",
-                "odbc_note": "Driver=x;UID=demo;PWD={odbc secret value};Server=db",
-                "cookie_note": "Cookie: session=cookie-secret; theme=dark",
-                "aws_note": "aws_secret_access_key=aws-secret-value",
-                "safe_url": "https://user:password@example.invalid/repo?token=secret-value",
-                "signed_url": "https://storage.example.invalid/blob?sv=1&sig=signed-secret",
-                "authorization": "Basic dXNlcjpwYXNzd29yZA==",
-                "x-api-key": "unstructured-bare-secret",
-                "note": "Authorization: Basic dXNlcjpwYXNzd29yZA==",
-                "comment": "glpat-0123456789abcdefghijkl",
             },
             "query_provenance": [
                 {
@@ -1149,6 +1220,44 @@ class _FakeRemote:
                 {"fact": "secret_scanning", "status": "BLOCKED", "reason": "permission denied"}
             ],
         }
+
+
+class _SecretBearingRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["governance"].update(
+            {
+                "database_note": (
+                    "DATABASE_URL=postgres://database-user:database-password@db.invalid/app"
+                    "?sslmode=require&token=query-secret"
+                ),
+                "azure_note": "AccountName=demo;AccountKey=azure-secret-value==;Endpoint=x",
+                "odbc_note": "Driver=x;UID=demo;PWD={odbc secret value};Server=db",
+                "cookie_note": "Cookie: session=cookie-secret; theme=dark",
+                "aws_note": "aws_secret_access_key=aws-secret-value",
+                "safe_url": "https://user:password@example.invalid/repo?token=secret-value",
+                "signed_url": "https://storage.example.invalid/blob?sv=1&sig=signed-secret",
+                "authorization": "Basic dXNlcjpwYXNzd29yZA==",
+                "x-api-key": "unstructured-bare-secret",
+                "note": "Authorization: Basic dXNlcjpwYXNzd29yZA==",
+                "comment": "glpat-0123456789abcdefghijkl",
+            }
+        )
+        return payload
+
+
+class _InvalidIssueStateRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["issues"][0]["state"] = "BANANA"
+        return payload
+
+
+class _ExtraCoverageRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["coverage"].append("deployments")
+        return payload
 
 
 class _DeniedRemote:
@@ -1645,8 +1754,10 @@ def test_malformed_worktree_path_or_branch_ref_fails_closed(
 
 
 def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path: Path) -> None:
-    observation = _observe(_init_repo(tmp_path), _FakeRemote())
+    observation = _observe(_init_repo(tmp_path), _SecretBearingRemote())
     payload = observation.canonical_bytes().decode()
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "remote_governance_completeness" for item in observation.unknowns)
     assert observation.tool_identity == "recorded-remote-payload/1.1.0"
     assert observation.api_query_version == "github-rest/2026-03-10"
     assert observation.query_provenance[0].surface == "remote_branches"
@@ -1672,6 +1783,19 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "[REDACTED]" in payload
 
 
+@pytest.mark.parametrize("remote", [_InvalidIssueStateRemote(), _ExtraCoverageRemote()])
+def test_untyped_or_overbroad_remote_metadata_cannot_be_complete(
+    tmp_path: Path,
+    remote: Any,
+) -> None:
+    observation = _observe(_init_repo(tmp_path), remote)
+    assert observation.disposition == "BLOCKED"
+    assert any(
+        item.fact in {"remote_metadata_shape", "remote_metadata_completeness"}
+        for item in observation.unknowns
+    )
+
+
 def test_arbitrary_remote_provider_is_rejected_before_it_can_mutate_repository(
     tmp_path: Path,
 ) -> None:
@@ -1695,6 +1819,21 @@ def test_arbitrary_remote_provider_is_rejected_before_it_can_mutate_repository(
             remote_provider=MutatingRemote(),
         )
     assert not marker.exists()
+
+
+def test_exact_collectors_reject_stateful_redactor_injection(tmp_path: Path) -> None:
+    api = _api()
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    redactor = redaction.EvidenceRedactor(environment={"PRIVATE_VALUE": "host-secret"})
+    with pytest.raises(api.RepositorySecurityError, match="state-free"):
+        api.RepositoryScanner(config=_config(), redactor=redactor)
+    with pytest.raises(api.RepositorySecurityError, match="state-free"):
+        api.GovernanceCollector(
+            repository="example/fixture",
+            clock=_fixed_clock(),
+            id_provider=_fixed_ids(),
+            redactor=redactor,
+        )
 
 
 def test_recorded_remote_provider_cannot_be_replaced_with_instance_code() -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -422,7 +422,20 @@ def test_entry_points_and_test_coverage_configuration_are_explicit_inventory(
     _write(
         repo,
         "services/api/pyproject.toml",
-        "[project]\nname='api'\nversion='1'\n[project.scripts]\napi='api.cli:main'\n",
+        (
+            "[project]\nname='api'\nversion='1'\n"
+            "[project.scripts]\napi='api.cli:main'\n"
+            "[tool.pytest.ini_options]\ntestpaths=['tests']\n"
+            "[tool.coverage.run]\nbranch=true\n"
+        ),
+    )
+    _write(
+        repo,
+        "services/worker/setup.cfg",
+        (
+            "[metadata]\nname = worker\n[tool:pytest]\ntestpaths = tests\n"
+            "[coverage:run]\nbranch = true\n"
+        ),
     )
     _write(repo, "services/api/src/api/__main__.py", "raise SystemExit(0)\n")
     _write(
@@ -433,7 +446,13 @@ def test_entry_points_and_test_coverage_configuration_are_explicit_inventory(
                 "name": "web",
                 "version": "1.0.0",
                 "main": "src/index.js",
-                "scripts": {"start": "node src/index.js"},
+                "scripts": {
+                    "start": "node src/index.js",
+                    "test": "vitest",
+                    "test:coverage": "vitest --coverage",
+                },
+                "vitest": {"globals": True},
+                "nyc": {"all": True},
             }
         ),
     )
@@ -457,6 +476,14 @@ def test_entry_points_and_test_coverage_configuration_are_explicit_inventory(
     ) in architecture
     assert ("apps/web/package.json", "DECLARED_ENTRY_POINT") in architecture
     assert ("apps/web/package.json", "DECLARED_RUN_ENTRY_POINT") in architecture
+    assert ("services/api/pyproject.toml", "TEST_CONFIGURATION") in quality
+    assert ("services/api/pyproject.toml", "COVERAGE_CONFIGURATION") in quality
+    assert ("services/worker/setup.cfg", "TEST_CONFIGURATION") in quality
+    assert ("services/worker/setup.cfg", "COVERAGE_CONFIGURATION") in quality
+    assert ("apps/web/package.json", "DECLARED_TEST_COMMAND") in quality
+    assert ("apps/web/package.json", "DECLARED_COVERAGE_COMMAND") in quality
+    assert ("apps/web/package.json", "TEST_CONFIGURATION") in quality
+    assert ("apps/web/package.json", "COVERAGE_CONFIGURATION") in quality
     assert ("apps/web/playwright.config.ts", "TEST_CONFIGURATION") in quality
     assert ("apps/web/vitest.config.ts", "TEST_CONFIGURATION") in quality
     assert (".coveragerc", "COVERAGE_CONFIGURATION") in quality
@@ -1312,6 +1339,48 @@ def test_malformed_worktree_record_is_blocked_without_placeholder_facts(
     assert observation.worktrees == ()
     assert any(item.fact == "worktree_record:1" for item in observation.unknowns)
     assert "UNKNOWN" not in observation.canonical_bytes().decode()
+
+
+def test_worktree_lifecycle_flags_are_preserved_and_prunable_state_blocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    repo = _init_repo(tmp_path)
+    head = _git(repo, "rev-parse", "HEAD")
+    original = governance.GovernanceCommandRunner.run
+
+    def lifecycle_worktree(
+        self: Any,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        cancellation: Any = None,
+    ) -> Any:
+        if args[1:3] == ("worktree", "list"):
+            return api.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=(
+                    f"worktree {repo}\0HEAD {head}\0detached\0locked maintenance\0"
+                    "prunable gitdir-missing\0\0"
+                ),
+                stderr="",
+            )
+        return original(self, args, cwd, timeout, cancellation=cancellation)
+
+    monkeypatch.setattr(governance.GovernanceCommandRunner, "run", lifecycle_worktree)
+    observation = _observe(repo)
+    worktree = observation.worktrees[0]
+    assert worktree.detached is True
+    assert worktree.bare is False
+    assert worktree.locked is True
+    assert worktree.locked_reason == "maintenance"
+    assert worktree.prunable is True
+    assert worktree.prunable_reason == "gitdir-missing"
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "worktree_prunable:1" for item in observation.unknowns)
 
 
 def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 import signal
 import subprocess
 import time
@@ -250,6 +251,22 @@ def test_output_affecting_injected_implementation_changes_provenance_digest(
     assert first.snapshot_digest != second.snapshot_digest
 
 
+def test_implementation_provenance_is_independent_of_checkout_path(tmp_path: Path) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    source = "def evaluate(context):\n    return len(context)\n"
+    implementations: list[Any] = []
+    for name in ("clone-a", "clone-b"):
+        source_path = tmp_path / name / "adapter.py"
+        source_path.parent.mkdir()
+        source_path.write_text(source)
+        namespace: dict[str, Any] = {"__name__": "fixture.adapter"}
+        exec(compile(source, str(source_path), "exec"), namespace)
+        implementations.append(namespace["evaluate"])
+    assert scanner._implementation_source_evidence(
+        "adapter:test", implementations[0]
+    ) == scanner._implementation_source_evidence("adapter:test", implementations[1])
+
+
 def test_all_audit_categories_are_present_and_active_work_is_separate(tmp_path: Path) -> None:
     api = _api()
     snapshot = _scan(_init_repo(tmp_path))
@@ -492,7 +509,10 @@ def test_shell_source_without_adapter_is_blocked_not_reported_absent(tmp_path: P
     assert any(item.code == "STACK.UNSUPPORTED_FILE_TYPE" for item in snapshot.findings)
 
 
-@pytest.mark.parametrize("manifest", ["Makefile", "WORKSPACE", "BUILD.bazel", "Jenkinsfile"])
+@pytest.mark.parametrize(
+    "manifest",
+    ["Makefile", "WORKSPACE", "BUILD.bazel", "Jenkinsfile", "Pipfile", "Rakefile", "Procfile"],
+)
 def test_extensionless_unsupported_ecosystem_is_blocked(tmp_path: Path, manifest: str) -> None:
     repo = _init_repo(tmp_path, mixed=False)
     _write(repo, manifest, "unsupported build definition\n")
@@ -502,6 +522,48 @@ def test_extensionless_unsupported_ecosystem_is_blocked(tmp_path: Path, manifest
     assert any(
         item.code == "STACK.UNSUPPORTED_ECOSYSTEM" and manifest in item.evidence_refs
         for item in snapshot.findings
+    )
+
+
+def test_adapter_cannot_fabricate_untracked_high_confidence_evidence(tmp_path: Path) -> None:
+    api = _api()
+    adapters = importlib.import_module("pmpe.repository.adapters")
+    models = importlib.import_module("pmpe.repository.models")
+    repo = _init_repo(tmp_path)
+
+    def fabricate(_context: Any) -> Any:
+        return adapters.AdapterResult(
+            items=(
+                (
+                    "repository_topology",
+                    models.EvidenceItem(
+                        kind="FABRICATED",
+                        path="does-not-exist.txt",
+                        file_digest="sha256:" + "0" * 64,
+                        detector_id="test.fabricator",
+                        detector_version=adapters.DETECTOR_VERSION,
+                        confidence="HIGH",
+                    ),
+                ),
+            )
+        )
+
+    adapter = api.RepositoryAdapter(
+        adapter_id="test.fabricator",
+        version="1.0.0",
+        file_patterns=("*",),
+        supported_categories=("repository_topology",),
+        evaluator=fabricate,
+    )
+    snapshot = api.RepositoryScanner(config=_config(), adapters=(adapter,)).scan(
+        repo, commit="HEAD"
+    )
+    assert snapshot.disposition == "BLOCKED"
+    assert any(item.code == "ADAPTER.INVALID_EVIDENCE" for item in snapshot.findings)
+    assert not any(
+        item.path == "does-not-exist.txt"
+        for category in snapshot.inventory.values()
+        for item in category.items
     )
 
 
@@ -654,6 +716,15 @@ def test_redaction_failure_blocks_artifact_creation(tmp_path: Path) -> None:
         api.RepositoryScanner(config=_config(), redactor=BrokenRedactor()).scan(repo, commit="HEAD")
 
 
+@pytest.mark.parametrize("field", ["token", "signature", "sig"])
+def test_sensitive_mapping_fields_are_redacted_before_persistence(field: str) -> None:
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    secret = "TOPSECRET123"
+    sanitized = redaction.EvidenceRedactor().sanitize({field: secret})
+    assert sanitized[field] == "[REDACTED]"
+    assert secret not in json.dumps(sanitized)
+
+
 class _FixedClock:
     def now(self) -> str:
         return "2026-08-01T00:00:00Z"
@@ -758,7 +829,6 @@ class _DeniedRemote:
 class _PartialRemote(_FakeRemote):
     def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
         payload = super().collect(repository, ref, **bounds)
-        payload.pop("complete")
         payload["query_provenance"][0]["has_next_page"] = True
         return payload
 
@@ -822,6 +892,15 @@ class _DuplicateRemote(_FakeRemote):
         payload = super().collect(repository, ref, **bounds)
         payload["remote_branches"].append(dict(payload["remote_branches"][0]))
         payload["query_provenance"][0]["result_count"] = 2
+        return payload
+
+
+class _CoerciblePrimitiveRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["pull_requests"][0]["draft"] = "false"
+        payload["issues"][0]["number"] = True
+        payload["query_provenance"][0]["has_next_page"] = "false"
         return payload
 
 
@@ -960,7 +1039,9 @@ def test_remote_provider_timeout_is_bounded_and_visible(tmp_path: Path) -> None:
     assert any(item.fact == "remote_governance" for item in observation.unknowns)
 
 
-@pytest.mark.parametrize("remote", [_MismatchedRemote(), _DuplicateRemote()])
+@pytest.mark.parametrize(
+    "remote", [_MismatchedRemote(), _DuplicateRemote(), _CoerciblePrimitiveRemote()]
+)
 def test_remote_identity_mismatch_or_duplicate_inventory_fails_closed(
     tmp_path: Path, remote: Any
 ) -> None:
@@ -973,7 +1054,8 @@ def test_remote_provider_cancellation_terminates_the_isolated_process() -> None:
     api = _api()
 
     class CancelSoon:
-        started = time.monotonic()
+        def __init__(self) -> None:
+            self.started = time.monotonic()
 
         def cancelled(self) -> bool:
             return time.monotonic() - self.started > 0.2
@@ -1221,15 +1303,23 @@ def test_cancellation_terminates_an_ordinary_bounded_git_command(
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_git = fake_bin / "git"
-    fake_git.write_text("#!/bin/sh\nsleep 30\n")
+    child_pid_path = tmp_path / "child.pid"
+    fake_git.write_text(
+        "#!/bin/sh\n"
+        "trap 'exit 0' TERM\n"
+        "( trap '' TERM; sleep 30 ) &\n"
+        f"echo $! > {child_pid_path}\n"
+        "while :; do sleep 1; done\n"
+    )
     fake_git.chmod(0o755)
     monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
 
     class CancelSoon:
-        started = time.monotonic()
+        def __init__(self) -> None:
+            self.started = time.monotonic()
 
         def cancelled(self) -> bool:
-            return time.monotonic() - self.started > 0.2
+            return child_pid_path.exists() and time.monotonic() - self.started > 0.2
 
     started = time.monotonic()
     result = scanner.SubprocessCommandRunner().run(
@@ -1238,6 +1328,16 @@ def test_cancellation_terminates_an_ordinary_bounded_git_command(
     assert time.monotonic() - started < 4
     assert result.returncode == 126
     assert result.timed_out is False
+    child_pid = int(child_pid_path.read_text())
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail("TERM-ignoring descendant survived bounded command cancellation")
 
 
 def test_cancellation_during_final_adapter_blocks_snapshot_finalization(tmp_path: Path) -> None:
@@ -1313,7 +1413,7 @@ def test_git_readers_disable_lazy_fetch_and_repository_defined_accelerators() ->
     assert scanner_environment["GIT_CONFIG_VALUE_0"] == "false"
     governance_runner = governance.GovernanceCommandRunner()
     assert scanner_environment["GIT_CONFIG_VALUE_5"] == "false"
-    assert governance_runner.identity.endswith("1.5.0")
+    assert governance_runner.identity.endswith("1.6.0")
 
 
 def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -870,6 +870,21 @@ def test_non_github_ci_is_not_reported_as_ci_absent(tmp_path: Path) -> None:
             "name: empty trigger\non: {}\njobs:\n  test:\n"
             "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
         ),
+        (
+            ".github/workflows/ci.yml",
+            "name: missing runner\non: [push]\njobs:\n  test:\n"
+            "    runs-on:\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: empty runner\non: [push]\njobs:\n  test:\n"
+            "    runs-on: '  '\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: empty runner labels\non: [push]\njobs:\n  test:\n"
+            "    runs-on: []\n    steps:\n      - run: pytest\n",
+        ),
         (".circleci/config.yml", "version: 2.1\njobs: []\n"),
         (
             ".circleci/config.yml",

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -1630,6 +1630,8 @@ def test_adapter_failure_is_visible_and_cannot_remove_categories(
         _expected_adapter_identity: int,
         _expected_evaluator_identity: int,
         _expected_module_state_digest: str,
+        _expected_import_state_digest: str,
+        _expected_import_identities: tuple[tuple[str, int], ...],
     ) -> None:
         os.setsid()
         connection.send_bytes(b'{"error_type":"RuntimeError","status":"ERROR"}')
@@ -2295,6 +2297,14 @@ class _DuplicateRemote(_FakeRemote):
         payload = super().collect(repository, ref, **bounds)
         payload["remote_branches"].append(dict(payload["remote_branches"][0]))
         payload["query_provenance"][0]["result_count"] = 2
+        return payload
+
+
+class _CollidingCursorRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["query_provenance"][0]["cursor"] = "token=firstsecretvalue123"
+        payload["query_provenance"][1]["cursor"] = "token=secondsecretvalue456"
         return payload
 
 
@@ -3062,6 +3072,26 @@ def test_scanner_rejects_in_place_adapter_mutation_before_evaluator_runs(
     assert not marker.exists()
 
 
+def test_scanner_rejects_adapter_import_proxy_before_callback_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    api = _api()
+    adapters = importlib.import_module("pmpe.repository.adapters")
+    repo = _init_repo(tmp_path)
+    marker = repo / "adapter-import-proxy-ran.txt"
+    candidate = api.RepositoryScanner(config=_config())
+
+    class YamlProxy:
+        def safe_load(self, _value: Any) -> Any:
+            marker.write_text("mutated")
+            return {}
+
+    monkeypatch.setattr(adapters, "yaml", YamlProxy())
+    with pytest.raises(api.RepositorySecurityError, match="adapter|registry"):
+        candidate.scan(repo, commit="HEAD")
+    assert not marker.exists()
+
+
 def test_scanner_rejects_mutated_cancellation_state_before_callback_use(
     tmp_path: Path,
 ) -> None:
@@ -3070,12 +3100,14 @@ def test_scanner_rejects_mutated_cancellation_state_before_callback_use(
     marker = repo / "cancellation-callback-ran.txt"
     cancellation = api.CancellationSignal()
 
-    class MutatingEvent:
-        def is_set(self) -> bool:
+    class MutatingState:
+        def __bool__(self) -> bool:
             marker.write_text("mutated")
             return False
 
-    object.__setattr__(cancellation, "_event", MutatingEvent())
+    with pytest.raises(AttributeError):
+        object.__setattr__(cancellation, "_event", MutatingState())
+    object.__setattr__(cancellation, "_cancelled", MutatingState())
     with pytest.raises(api.RepositorySecurityError, match="sealed"):
         api.RepositoryScanner(config=_config(), cancellation=cancellation).scan(repo, commit="HEAD")
     assert not marker.exists()
@@ -3110,6 +3142,20 @@ def test_redaction_collision_between_branch_names_blocks_observation(
 
     with pytest.raises(api.RepositorySecurityError, match="redaction"):
         _observe(repo)
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+
+
+def test_remote_cursor_redaction_collision_blocks_before_provenance_construction(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+    with pytest.raises(api.RepositorySecurityError, match="remote evidence redaction"):
+        _observe(repo, _CollidingCursorRemote())
     assert _git(repo, "rev-parse", "HEAD") == before_head
     assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
 
@@ -3721,6 +3767,8 @@ def test_cancellation_during_adapter_blocks_snapshot_finalization(
         _expected_adapter_identity: int,
         _expected_evaluator_identity: int,
         _expected_module_state_digest: str,
+        _expected_import_state_digest: str,
+        _expected_import_identities: tuple[tuple[str, int], ...],
     ) -> None:
         os.setsid()
         time.sleep(30)

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -6,6 +6,7 @@ import importlib
 import json
 import signal
 import subprocess
+import time
 from dataclasses import replace
 from pathlib import Path
 from types import ModuleType
@@ -177,6 +178,29 @@ def test_replace_refs_cannot_change_an_exact_commit_snapshot(tmp_path: Path) -> 
     with_replacement = api.RepositoryScanner(config=_config()).scan(repo, commit=original)
     assert with_replacement.canonical_bytes() == baseline.canonical_bytes()
     assert with_replacement.commit_sha == original
+
+
+def test_sha256_repository_is_exactly_bound_or_fails_explicitly(tmp_path: Path) -> None:
+    repo = tmp_path / "sha256-repo"
+    repo.mkdir()
+    result = subprocess.run(
+        ["git", "init", "-q", "--object-format=sha256", "--initial-branch=main"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip("installed Git explicitly does not support SHA-256 repositories")
+    _git(repo, "config", "user.email", "fixture@localhost")
+    _git(repo, "config", "user.name", "Fixture")
+    _write(repo, "README.md", "# SHA-256 fixture\n")
+    _commit(repo, "sha256 fixture")
+    snapshot = _scan(repo)
+    assert snapshot.git_object_format == "sha256"
+    assert len(snapshot.commit_sha) == 64
+    assert len(snapshot.tree_sha) == 64
+    assert snapshot.disposition != "ERROR"
 
 
 def test_adapter_order_does_not_change_output_but_version_does(tmp_path: Path) -> None:
@@ -615,7 +639,8 @@ class _FakeRemote:
             "pull_requests": [{"number": 7, "draft": True, "head": "a" * 40}],
             "issues": [{"number": 8, "state": "OPEN"}],
             "governance": {
-                "branch_protection": "UNKNOWN",
+                "branch_protection": {"observed": True, "required_checks": ["ci"]},
+                "review_policy": {"required_approvals": 1},
                 "database_note": (
                     "DATABASE_URL=postgres://database-user:database-password@db.invalid/app"
                     "?sslmode=require&token=query-secret"
@@ -663,6 +688,7 @@ class _FakeRemote:
                 {"fact": "secret_scanning", "status": "BLOCKED", "reason": "permission denied"}
             ],
             "safe_url": "https://user:password@example.invalid/repo?token=secret-value",
+            "signed_url": "https://storage.example.invalid/blob?sv=1&sig=signed-secret",
             "authorization": "Basic dXNlcjpwYXNzd29yZA==",
             "x-api-key": "unstructured-bare-secret",
             "note": "Authorization: Basic dXNlcjpwYXNzd29yZA==",
@@ -705,6 +731,32 @@ class _CountMismatchRemote(_FakeRemote):
         payload = super().collect(repository, ref, **bounds)
         payload["query_provenance"][0]["result_count"] = 0
         return payload
+
+
+class _EmptyGovernanceRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["governance"] = {}
+        payload["query_provenance"][-1]["result_count"] = 0
+        payload["unknowns"] = []
+        return payload
+
+
+class _UnknownGovernanceRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["governance"] = {
+            "branch_protection": "UNKNOWN",
+            "review_policy": {"required_approvals": 1},
+        }
+        payload["unknowns"] = []
+        return payload
+
+
+class _HangingRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        time.sleep(30)
+        return super().collect(repository, ref, **bounds)
 
 
 def _observe(repo: Path, remote: Any = None) -> Any:
@@ -779,6 +831,7 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "dXNlcjpwYXNzd29yZA==" not in payload
     assert "password" not in payload
     assert "secret-value" not in payload
+    assert "signed-secret" not in payload
     assert "unstructured-bare-secret" not in payload
     assert "glpat-0123456789abcdefghijkl" not in payload
     assert "database-user" not in payload
@@ -812,6 +865,55 @@ def test_remote_completeness_requires_per_surface_count_bound_pagination(
     observation = _observe(_init_repo(tmp_path), remote)
     assert observation.disposition == "BLOCKED"
     assert any(item.fact == "remote_metadata_completeness" for item in observation.unknowns)
+
+
+@pytest.mark.parametrize("remote", [_EmptyGovernanceRemote(), _UnknownGovernanceRemote()])
+def test_empty_or_unknown_governance_is_explicitly_blocked(
+    tmp_path: Path,
+    remote: Any,
+) -> None:
+    observation = _observe(_init_repo(tmp_path), remote)
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "remote_governance_completeness" for item in observation.unknowns)
+
+
+def test_remote_provider_timeout_is_bounded_and_visible(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    started = time.monotonic()
+    observation = api.GovernanceCollector(
+        repository="example/fixture",
+        clock=_FixedClock(),
+        id_provider=_FixedIds(),
+        remote_provider=_HangingRemote(),
+        command_timeout_seconds=1,
+    ).observe(repo, ref="main")
+    assert time.monotonic() - started < 4
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "remote_governance" for item in observation.unknowns)
+
+
+def test_remote_provider_cancellation_terminates_the_isolated_process() -> None:
+    api = _api()
+
+    class CancelSoon:
+        started = time.monotonic()
+
+        def cancelled(self) -> bool:
+            return time.monotonic() - self.started > 0.2
+
+    collector = api.GovernanceCollector(
+        repository="example/fixture",
+        clock=_FixedClock(),
+        id_provider=_FixedIds(),
+        remote_provider=_HangingRemote(),
+        command_timeout_seconds=10,
+        cancellation=CancelSoon(),
+    )
+    started = time.monotonic()
+    with pytest.raises(api.RepositoryIntelligenceError, match="cancelled"):
+        collector._collect_remote_bounded("main")
+    assert time.monotonic() - started < 4
 
 
 def test_remote_permission_denial_is_blocked_unknown_not_inferred(tmp_path: Path) -> None:
@@ -909,6 +1011,32 @@ def test_bounded_git_termination_targets_the_isolated_process_group(
     monkeypatch.setattr(governance.os, "killpg", record_group)
     governance._signal_process_group(Process(), signal.SIGKILL)
     assert calls == [(4242, signal.SIGTERM), (4242, signal.SIGKILL)]
+
+
+def test_bounded_git_termination_falls_back_to_the_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    governance = importlib.import_module("pmpe.repository.governance")
+    calls: list[signal.Signals] = []
+
+    def denied_group(_pid: int, _action: signal.Signals) -> None:
+        raise OSError("group signalling unavailable")
+
+    class Process:
+        pid = 4242
+
+        def send_signal(self, action: signal.Signals) -> None:
+            calls.append(action)
+
+        def kill(self) -> None:
+            pytest.fail("parent kill is unnecessary when send_signal succeeds")
+
+    monkeypatch.setattr(scanner.os, "killpg", denied_group)
+    scanner._signal_process_group(Process(), signal.SIGTERM)
+    monkeypatch.setattr(governance.os, "killpg", denied_group)
+    governance._signal_process_group(Process(), signal.SIGKILL)
+    assert calls == [signal.SIGTERM, signal.SIGKILL]
 
 
 def test_invalid_governance_ref_is_rejected_before_git_comparison(tmp_path: Path) -> None:
@@ -1010,6 +1138,43 @@ def test_cancellation_terminates_bounded_enumeration_and_preserves_repository(
     assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
 
 
+def test_cancellation_during_final_adapter_blocks_snapshot_finalization(tmp_path: Path) -> None:
+    api = _api()
+    adapters = importlib.import_module("pmpe.repository.adapters")
+    repo = _init_repo(tmp_path)
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+    class CancellationAfterAdapter:
+        active = False
+
+        def cancelled(self) -> bool:
+            return self.active
+
+    cancellation = CancellationAfterAdapter()
+
+    def evaluate(_context: Any) -> Any:
+        cancellation.active = True
+        return adapters.AdapterResult()
+
+    final_adapter = api.RepositoryAdapter(
+        adapter_id="test.final-cancellation",
+        version="1.0.0",
+        file_patterns=("*",),
+        supported_categories=("repository_topology",),
+        evaluator=evaluate,
+    )
+    snapshot = api.RepositoryScanner(
+        config=_config(),
+        adapters=(final_adapter,),
+        cancellation=cancellation,
+    ).scan(repo, commit="HEAD")
+    assert snapshot.disposition == "BLOCKED"
+    assert any(item.code == "SCAN.CANCELLED" and item.blocking for item in snapshot.findings)
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+
+
 def test_governance_cancellation_terminates_bounded_command_and_preserves_repository(
     tmp_path: Path,
 ) -> None:
@@ -1046,7 +1211,7 @@ def test_git_readers_disable_lazy_fetch_and_repository_defined_accelerators() ->
     assert scanner_environment["GIT_CONFIG_VALUE_0"] == "false"
     governance_runner = governance.GovernanceCommandRunner()
     assert scanner_environment["GIT_CONFIG_VALUE_5"] == "false"
-    assert governance_runner.identity.endswith("1.3.0")
+    assert governance_runner.identity.endswith("1.4.0")
 
 
 def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) -> None:
@@ -1076,3 +1241,17 @@ def test_snapshot_and_observation_references_form_a_narrow_lifecycle_seam(
     }
     assert "architecture" not in reference
     assert "recommendation" not in reference
+
+
+def test_snapshot_rejects_governance_observation_from_another_repository(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    snapshot = _scan(_init_repo(tmp_path))
+    observation = api.GovernanceCollector(
+        repository="different/repository",
+        clock=_FixedClock(),
+        id_provider=_FixedIds(),
+    ).observe(tmp_path / "fixture-repo", ref="main")
+    with pytest.raises(ValueError, match="repositories do not match"):
+        snapshot.assessment_reference(observation)

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -407,6 +407,11 @@ def test_governance_provenance_binds_every_material_repository_module() -> None:
         "repository.scanner",
         "contracts.canonical",
     }
+    original = governance._governance_implementation_digest()
+    rfc8785_module = importlib.import_module("rfc8785")
+    with pytest.MonkeyPatch.context() as runtime_patch:
+        runtime_patch.setattr(rfc8785_module, "dumps", lambda value: b"changed")
+        assert governance._governance_implementation_digest() != original
 
 
 def test_api_data_generated_client_migration_and_contract_sync_are_inventory_items(
@@ -1034,7 +1039,6 @@ def test_non_runnable_ci_scaffolds_do_not_suppress_missing_ci(
         "on:\n  pull_request:\n    types: [opened, synchronize, ready_for_review]\n"
         "jobs:\n  test:\n    runs-on: {group: trusted, labels: [linux, x64]}\n"
         "    steps:\n      - run: pytest\n",
-        "on: workflow_dispatch\njobs:\n  local:\n    uses: ./.github/workflows/build.yml\n",
         "on: workflow_dispatch\njobs:\n  remote:\n"
         "    uses: example/automation/.github/workflows/build.yml@v1\n",
     ],
@@ -1103,6 +1107,45 @@ def test_ambiguous_or_duplicate_github_workflow_keys_are_not_verified(
         item.code in {"WORKFLOW.MALFORMED", "WORKFLOW.STRUCTURE_UNPROVEN"}
         for item in snapshot.findings
     )
+
+
+@pytest.mark.parametrize(
+    ("path", "content"),
+    [
+        (
+            ".github/workflows/nested/ci.yml",
+            "on: [push]\njobs:\n  test:\n    runs-on: ubuntu-latest\n"
+            "    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "on: [push]\njobs:\n  missing:\n    uses: ./.github/workflows/missing.yml\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "on: [push]\njobs:\n  local:\n    runs-on: ubuntu-latest\n"
+            "    steps:\n      - uses: ./missing-action\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "true: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n"
+            "    steps:\n      - run: pytest\n",
+        ),
+    ],
+)
+def test_undiscoverable_or_unproven_local_github_targets_are_not_verified(
+    tmp_path: Path,
+    path: str,
+    content: str,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, path, content)
+    _commit(repo, "undiscoverable github workflow")
+    snapshot = _scan(repo)
+    assert not any(
+        item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
+    )
+    assert any(item.code == "WORKFLOW.STRUCTURE_UNPROVEN" for item in snapshot.findings)
 
 
 def test_supported_github_needs_graph_and_matrix_objects_are_verified(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -679,9 +679,54 @@ def test_every_required_internal_audit_subcategory_is_explicit(tmp_path: Path) -
             "bounded-context boundaries",
             "storage models",
             "deployment-evidence mechanisms",
+            "release workflows",
+            "preview environments",
+            "container definitions",
+            "infrastructure-as-code",
+            "deployment definitions",
+            "environment configuration shapes",
+            "rollback mechanisms",
+            "dependency audits",
+            "static application security testing",
+            "secret scanning",
+            "permissions",
+            "credential boundaries",
+            "data retention and privacy controls",
+            "security configuration",
+            "logs",
+            "metrics",
+            "traces",
+            "alerting",
+            "service-level objectives",
+            "health checks",
+            "incident and rollback evidence",
+            "telemetry schemas",
+            "production feedback paths",
         )
     )
     assert snapshot.disposition == "BLOCKED"
+
+
+def test_security_privacy_observability_and_delivery_facets_are_never_silent(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    for path in (".semgrep.yml", "gitleaks.toml", ".snyk", "sentry.yml"):
+        _write(repo, path, "enabled: true\n")
+    _commit(repo, "required audit facet signals")
+    snapshot = _scan(repo)
+    for category in (
+        "security_privacy",
+        "observability_operations",
+        "delivery_environments",
+    ):
+        assert snapshot.inventory[category].status == "BLOCKED"
+        assert any(
+            item.code == "AUDIT.REQUIRED_SUBCATEGORY_UNSUPPORTED"
+            and item.category == category
+            and item.blocking
+            for item in snapshot.findings
+        )
 
 
 def test_worker_library_and_infrastructure_boundaries_are_typed(tmp_path: Path) -> None:
@@ -840,6 +885,42 @@ def test_invalid_openapi_version_or_paths_are_not_high_confidence_evidence(
     snapshot = _scan(repo)
     assert snapshot.disposition == "BLOCKED"
     assert not any(item.kind == "OPENAPI" for item in snapshot.inventory["apis_data"].items)
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        (
+            "openapi-v1.json",
+            '{"openapi":"3.1.0","info":{"title":"x","version":"1"},"paths":{}}',
+        ),
+        (
+            "openapi_3_1.yaml",
+            'openapi: 3.1.0\ninfo: {title: x, version: "1"}\npaths: {}\n',
+        ),
+        (
+            "swagger.json",
+            '{"swagger":"2.0","info":{"title":"x","version":"1"},"paths":{}}',
+        ),
+    ],
+)
+def test_common_api_declaration_names_are_validated_and_inventoried(
+    tmp_path: Path,
+    path: str,
+    payload: str,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, path, payload)
+    _commit(repo, "common API declaration")
+    snapshot = _scan(repo)
+    assert any(
+        item.kind == "OPENAPI" and item.path == path
+        for item in snapshot.inventory["apis_data"].items
+    )
+    assert not any(
+        item.code == "INTERFACE.DECLARATION_INVALID" and path in item.evidence_refs
+        for item in snapshot.findings
+    )
 
 
 def test_tests_delivery_security_observability_and_governance_are_evidence_backed(
@@ -1221,6 +1302,14 @@ def test_sensitive_mapping_fields_are_redacted_before_persistence(field: str) ->
     assert secret not in json.dumps(sanitized)
 
 
+def test_non_secret_boolean_control_with_sensitive_word_remains_typed() -> None:
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    sanitized = redaction.EvidenceRedactor(environment={}).sanitize(
+        {"required_signed_commits": True, "signature": "secret-value"}
+    )
+    assert sanitized == {"required_signed_commits": True, "signature": "[REDACTED]"}
+
+
 def test_sensitive_environment_value_is_redacted_under_benign_field() -> None:
     redaction = importlib.import_module("pmpe.repository.redaction")
     secret = "opaque-credential-value-not-matching-a-token-shape"
@@ -1248,6 +1337,15 @@ def test_home_path_minimization_is_host_state_independent(
         "command failed under /home/repository-owner/work/repository: permission denied"
     )
     assert embedded == "command failed under $HOME/work/repository: permission denied"
+    for posix_home in (
+        "/root/work/repository",
+        "/var/root/work/repository",
+        "/usr/home/repository-owner/work/repository",
+    ):
+        assert (
+            redaction.EvidenceRedactor(environment={}).sanitize(posix_home)
+            == "$HOME/work/repository"
+        )
 
 
 def _fixed_clock() -> Any:
@@ -1290,9 +1388,23 @@ class _FakeRemote:
             ],
             "issues": [{"number": 8, "state": "OPEN"}],
             "governance": {
-                "schema_version": "pmpe.repository-governance/v1",
-                "branch_protection": {"observed": True, "required_checks": ["ci"]},
-                "review_policy": {"required_approvals": 1},
+                "schema_version": "pmpe.repository-governance/v2",
+                "branch_protection": {
+                    "observed": True,
+                    "protected": True,
+                    "required_checks": ["ci"],
+                    "required_signed_commits": True,
+                    "required_linear_history": True,
+                    "push_restrictions": True,
+                    "allow_force_pushes": False,
+                    "allow_deletions": False,
+                },
+                "review_policy": {
+                    "required_approvals": 1,
+                    "dismiss_stale_reviews": True,
+                    "require_code_owner_reviews": True,
+                    "require_last_push_approval": True,
+                },
                 "security_settings": {
                     "observed": True,
                     "leak_detection": "ENABLED",
@@ -1391,9 +1503,24 @@ class _UnobservedBranchProtectionRemote(_FakeRemote):
         payload = super().collect(repository, ref, **bounds)
         payload["governance"]["branch_protection"] = {
             "observed": False,
+            "protected": False,
             "required_checks": [],
+            "required_signed_commits": False,
+            "required_linear_history": False,
+            "push_restrictions": False,
+            "allow_force_pushes": False,
+            "allow_deletions": False,
         }
         payload["unknowns"] = []
+        return payload
+
+
+class _MaterialGovernanceVariantRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["governance"]["branch_protection"]["required_signed_commits"] = False
+        payload["governance"]["branch_protection"]["allow_force_pushes"] = True
+        payload["governance"]["review_policy"]["dismiss_stale_reviews"] = False
         return payload
 
 
@@ -1918,6 +2045,16 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "pass-json-secret" not in payload
     assert "[REDACTED_URL]" in payload
     assert "[REDACTED]" in payload
+
+
+def test_material_governance_controls_are_typed_and_digest_bound(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    protected = _observe(repo, _CompleteRemote())
+    variant = _observe(repo, _MaterialGovernanceVariantRemote())
+    assert protected.governance["branch_protection"]["required_signed_commits"] is True
+    assert protected.governance["review_policy"]["dismiss_stale_reviews"] is True
+    assert variant.governance["branch_protection"]["allow_force_pushes"] is True
+    assert protected.observation_output_digest != variant.observation_output_digest
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -129,6 +129,18 @@ def test_equivalent_ref_and_exact_sha_produce_same_snapshot(tmp_path: Path) -> N
     assert from_ref.canonical_bytes() == from_sha.canonical_bytes()
 
 
+def test_scoped_scan_is_explicitly_partial_and_keeps_full_tree_binding(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    full = _scan(repo)
+    scoped = _scan(repo, include_paths=("src",))
+    assert scoped.scan_scope == "INCLUDED_PATHS"
+    assert scoped.included_paths == ("src",)
+    assert scoped.disposition == "PARTIAL"
+    assert scoped.tracked_tree_digest == full.tracked_tree_digest
+    assert scoped.scanned_content_digest != full.scanned_content_digest
+    assert any(item.code == "SCAN.SCOPED_PARTIAL" for item in scoped.findings)
+
+
 def test_dirty_tracked_content_does_not_change_exact_commit_snapshot(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     before = _scan(repo)
@@ -261,6 +273,33 @@ def test_unknown_ecosystem_is_explicitly_unsupported(tmp_path: Path) -> None:
     assert category.reason
 
 
+def test_shell_source_without_adapter_is_blocked_not_reported_absent(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "deploy.sh", "#!/bin/sh\necho deploy\n")
+    _commit(repo, "unsupported shell stack")
+    snapshot = _scan(repo)
+    assert snapshot.disposition == "BLOCKED"
+    assert snapshot.inventory["languages_build_ecosystems"].status == "UNSUPPORTED"
+    assert any(item.code == "STACK.UNSUPPORTED_FILE_TYPE" for item in snapshot.findings)
+
+
+def test_source_names_containing_test_are_not_high_confidence_test_evidence(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "src/testimonial.py", "VALUE = 'not a test'\n")
+    _write(repo, "packages/latest.ts", "export const value = 'not a test';\n")
+    _commit(repo, "ordinary source names")
+    snapshot = _scan(repo)
+    test_paths = {
+        item.path
+        for item in snapshot.inventory["tests_quality"].items
+        if item.kind.endswith("TEST_FILE_SIGNAL")
+    }
+    assert "src/testimonial.py" not in test_paths
+    assert "packages/latest.ts" not in test_paths
+
+
 def test_malformed_manifest_and_workflow_are_visible_findings(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     _write(repo, "packages/web/package.json", "{not-json")
@@ -301,6 +340,7 @@ def test_adapter_failure_is_visible_and_cannot_remove_categories(tmp_path: Path)
         ({"max_directories": 1}, "BUDGET.DIRECTORY_COUNT"),
         ({"max_total_bytes": 16}, "BUDGET.TOTAL_BYTES"),
         ({"max_file_bytes": 8}, "BUDGET.FILE_BYTES"),
+        ({"max_tree_output_bytes": 32}, "BUDGET.TREE_OUTPUT_BYTES"),
         ({"max_path_depth": 1}, "BUDGET.PATH_DEPTH"),
         ({"max_commands": 2}, "BUDGET.COMMAND_COUNT"),
     ],
@@ -314,6 +354,14 @@ def test_budget_exhaustion_is_explicit_partial_result(
     assert snapshot.disposition in {"PARTIAL", "BLOCKED"}
     assert any(item.code == expected_code for item in snapshot.findings)
     assert set(snapshot.inventory) == set(_api().AUDIT_CATEGORIES)
+
+
+def test_bounded_tree_enumeration_is_byte_deterministic(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    first = _scan(repo, max_tree_output_bytes=64)
+    second = _scan(repo, max_tree_output_bytes=64)
+    assert first.canonical_bytes() == second.canonical_bytes()
+    assert any(item.code == "BUDGET.TREE_OUTPUT_BYTES" for item in first.findings)
 
 
 def test_binary_files_are_structural_evidence_but_never_decoded(tmp_path: Path) -> None:
@@ -401,6 +449,7 @@ class _FakeRemote:
     def collect(self, repository: str, ref: str) -> dict[str, Any]:
         assert repository == "example/fixture"
         return {
+            "complete": True,
             "remote_branches": [{"name": "origin/feature", "sha": "a" * 40}],
             "pull_requests": [{"number": 7, "draft": True, "head": "a" * 40}],
             "issues": [{"number": 8, "state": "OPEN"}],
@@ -410,13 +459,16 @@ class _FakeRemote:
                     "query": "branches,pulls,issues,protection",
                     "cursor": "cursor-2",
                     "page": 2,
+                    "has_next_page": False,
+                    "result_count": 3,
                 }
             ],
             "unknowns": [
                 {"fact": "secret_scanning", "status": "BLOCKED", "reason": "permission denied"}
             ],
             "safe_url": "https://user:password@example.invalid/repo?token=secret-value",
-            "authorization": "Bearer ghp_0123456789abcdefghijklmnop",
+            "authorization": "Basic dXNlcjpwYXNzd29yZA==",
+            "x-api-key": "unstructured-bare-secret",
         }
 
 
@@ -426,6 +478,14 @@ class _DeniedRemote:
 
     def collect(self, _repository: str, _ref: str) -> dict[str, Any]:
         raise PermissionError("token ghp_0123456789abcdefghijklmnop denied")
+
+
+class _PartialRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str) -> dict[str, Any]:
+        payload = super().collect(repository, ref)
+        payload.pop("complete")
+        payload["query_provenance"][0]["has_next_page"] = True
+        return payload
 
 
 def _observe(repo: Path, remote: Any = None) -> Any:
@@ -484,9 +544,17 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert observation.observation_input_digest.startswith("sha256:")
     assert observation.observation_output_digest.startswith("sha256:")
     assert "ghp_0123456789abcdefghijklmnop" not in payload
+    assert "dXNlcjpwYXNzd29yZA==" not in payload
     assert "password" not in payload
     assert "secret-value" not in payload
+    assert "unstructured-bare-secret" not in payload
     assert "[REDACTED]" in payload
+
+
+def test_unproven_remote_pagination_is_blocked_not_complete(tmp_path: Path) -> None:
+    observation = _observe(_init_repo(tmp_path), _PartialRemote())
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "remote_metadata_completeness" for item in observation.unknowns)
 
 
 def test_remote_permission_denial_is_blocked_unknown_not_inferred(tmp_path: Path) -> None:
@@ -520,6 +588,16 @@ def test_scan_and_observation_never_create_branches_commits_or_remote_mutations(
     assert _git(repo, "rev-parse", "HEAD") == before_head
     assert _git(repo, "for-each-ref", "--format=%(refname)", "refs/heads") == before_branches
     assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+
+
+def test_governance_observation_does_not_refresh_index_bytes_or_mtime(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    index = repo / ".git" / "index"
+    before_bytes = index.read_bytes()
+    before_mtime = index.stat().st_mtime_ns
+    _observe(repo)
+    assert index.read_bytes() == before_bytes
+    assert index.stat().st_mtime_ns == before_mtime
 
 
 def test_scanner_does_not_execute_tracked_project_code(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -415,6 +415,27 @@ def test_nested_package_manifests_create_explicit_architecture_boundaries(
     assert boundaries["products/example/backend"].confidence == "HIGH"
 
 
+def test_every_recognized_nested_python_manifest_creates_a_package_boundary(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "components/setup-project/setup.py", "from setuptools import setup\n")
+    _write(repo, "components/config-project/setup.cfg", "[metadata]\nname = config-project\n")
+    _write(repo, "components/pipfile-project/Pipfile", "[packages]\n")
+    _write(repo, "components/requirements-project/requirements-dev.txt", "pytest==9.1.1\n")
+    _commit(repo, "recognized nested Python boundaries")
+    snapshot = _scan(repo)
+    boundaries = {item.name: item for item in snapshot.boundary_candidates}
+    expected = {
+        "components/setup-project",
+        "components/config-project",
+        "components/pipfile-project",
+        "components/requirements-project",
+    }
+    assert expected <= set(boundaries)
+    assert all(boundaries[name].confidence == "HIGH" for name in expected)
+
+
 def test_unhandled_required_subcategory_is_blocked_not_silently_absent(
     tmp_path: Path,
 ) -> None:
@@ -428,6 +449,20 @@ def test_unhandled_required_subcategory_is_blocked_not_silently_absent(
         item.code == "AUDIT.UNSUPPORTED_SUBCATEGORY" and "data-model.yaml" in item.evidence_refs
         for item in snapshot.findings
     )
+
+
+def test_blocked_subcategory_status_survives_a_concurrent_partial_scan(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "data-model.yaml", "entities: []\n")
+    _write(repo, "extra.txt", "bounded\n")
+    _commit(repo, "blocked and partial evidence")
+    snapshot = _scan(repo, max_files=2)
+    assert snapshot.disposition == "BLOCKED"
+    assert snapshot.inventory["apis_data"].status == "BLOCKED"
+    assert "apis_data" in snapshot.unsupported_categories
+    assert any(item.code == "BUDGET.FILE_COUNT" for item in snapshot.findings)
 
 
 def test_integration_declarations_and_codeowners_are_evidence_backed(tmp_path: Path) -> None:
@@ -824,6 +859,25 @@ def test_planted_credentials_never_appear_in_snapshot(tmp_path: Path) -> None:
     assert secret not in payload
     assert "PRIVATE KEY" not in payload
     assert "redaction" in payload.lower()
+
+
+def test_environment_files_are_inventory_evidence_without_secret_values(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    secret = "ghp_0123456789abcdefghijklmnop"
+    _write(repo, ".env", f"TOKEN={secret}\n")
+    _write(repo, "config/.env.production", "DEPLOYMENT=production\n")
+    _commit(repo, "environment configuration shapes")
+    snapshot = _scan(repo)
+    delivery = snapshot.inventory["delivery_environments"].items
+    security = snapshot.inventory["security_privacy"].items
+    assert any(
+        item.path == ".env" and item.kind == "ENVIRONMENT_CONFIGURATION_SHAPE" for item in delivery
+    )
+    assert any(
+        item.path == "config/.env.production" and item.kind == "SECRET_CONFIGURATION_BOUNDARY"
+        for item in security
+    )
+    assert secret not in snapshot.canonical_bytes().decode()
 
 
 def test_redaction_failure_blocks_artifact_creation(
@@ -1533,25 +1587,41 @@ def test_scanner_does_not_execute_tracked_project_code(tmp_path: Path) -> None:
 
 def test_missing_git_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     api = _api()
+    scanner = importlib.import_module("pmpe.repository.scanner")
     repo = _init_repo(tmp_path)
-    empty_path = tmp_path / "empty-path"
-    empty_path.mkdir()
-    monkeypatch.setenv("PATH", str(empty_path))
+    monkeypatch.setattr(
+        scanner,
+        "_TRUSTED_GIT_CANDIDATES",
+        (tmp_path / "missing-system-git",),
+    )
     with pytest.raises(api.RepositoryIntelligenceError):
         api.RepositoryScanner(config=_config()).scan(repo, commit="HEAD")
 
 
-def test_git_timeout_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    api = _api()
+def test_git_timeout_is_bounded_and_visible(tmp_path: Path) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    result = scanner.SubprocessCommandRunner().run(("git", "version"), tmp_path, 0)
+    assert result.timed_out
+    assert result.returncode == 124
+
+
+def test_caller_path_cannot_select_the_git_executable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     repo = _init_repo(tmp_path)
-    fake_bin = tmp_path / "timeout-bin"
+    expected_head = _git(repo, "rev-parse", "HEAD")
+    fake_bin = tmp_path / "attacker-bin"
     fake_bin.mkdir()
+    marker = tmp_path / "caller-path-git-ran"
     fake_git = fake_bin / "git"
-    fake_git.write_text("#!/bin/sh\nsleep 30\n")
+    fake_git.write_text(f"#!/bin/sh\ntouch {marker}\nexit 9\n")
     fake_git.chmod(0o755)
-    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
-    with pytest.raises(api.RepositoryIntelligenceError, match="timed out"):
-        api.RepositoryScanner(config=_config(command_timeout_seconds=1)).scan(repo, commit="HEAD")
+    monkeypatch.setenv("PATH", str(fake_bin))
+    snapshot = _scan(repo)
+    observation = _observe(repo)
+    assert snapshot.commit_sha == expected_head
+    assert observation.local_state.head_sha == expected_head
+    assert not marker.exists()
 
 
 def test_malformed_git_output_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1591,25 +1661,56 @@ def test_invalid_repository_fails_closed(tmp_path: Path) -> None:
 def test_cancellation_is_visible_and_never_silently_partial(tmp_path: Path) -> None:
     api = _api()
     repo = _init_repo(tmp_path)
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_index = (repo / ".git" / "index").read_bytes()
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
     cancellation = api.CancellationSignal()
     cancellation.cancel()
-    snapshot = api.RepositoryScanner(config=_config(), cancellation=cancellation).scan(
-        repo, commit="HEAD"
-    )
-    assert snapshot.disposition == "BLOCKED"
-    assert any(item.code == "SCAN.CANCELLED" for item in snapshot.findings)
+    with pytest.raises(api.RepositoryScanCancelledError) as cancelled:
+        api.RepositoryScanner(config=_config(), cancellation=cancellation).scan(repo, commit="HEAD")
+    assert cancelled.value.finding.code == "SCAN.CANCELLED"
+    assert cancelled.value.finding.blocking
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert (repo / ".git" / "index").read_bytes() == before_index
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
 
 
 def test_cancellation_terminates_bounded_enumeration_and_preserves_repository(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     api = _api()
+    scanner = importlib.import_module("pmpe.repository.scanner")
     repo = _init_repo(tmp_path)
     before_head = _git(repo, "rev-parse", "HEAD")
     before_index = (repo / ".git" / "index").read_bytes()
     before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
 
-    cancellation = api.CancellationSignal(cancel_after_checks=2)
+    cancellation = api.CancellationSignal()
+    original = scanner.SubprocessCommandRunner.list_tree
+
+    def cancel_then_list(
+        self: Any,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        max_records: int,
+        max_output_bytes: int,
+        cancellation: Any = None,
+    ) -> Any:
+        assert cancellation is not None
+        cancellation.cancel()
+        return original(
+            self,
+            args,
+            cwd,
+            timeout,
+            max_records=max_records,
+            max_output_bytes=max_output_bytes,
+            cancellation=cancellation,
+        )
+
+    monkeypatch.setattr(scanner.SubprocessCommandRunner, "list_tree", cancel_then_list)
     snapshot = api.RepositoryScanner(config=_config(), cancellation=cancellation).scan(
         repo, commit="HEAD"
     )
@@ -1620,53 +1721,16 @@ def test_cancellation_terminates_bounded_enumeration_and_preserves_repository(
     assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
 
 
-def test_cancellation_terminates_an_ordinary_bounded_git_command(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_cancellation_terminates_an_initial_bounded_git_command(tmp_path: Path) -> None:
     scanner = importlib.import_module("pmpe.repository.scanner")
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    fake_git = fake_bin / "git"
-    child_pid_path = tmp_path / "child.pid"
-    fake_git.write_text(
-        "#!/bin/sh\n"
-        "trap 'exit 0' TERM\n"
-        "( trap '' TERM; sleep 30 ) &\n"
-        f"echo $! > {child_pid_path}\n"
-        "while :; do sleep 1; done\n"
-    )
-    fake_git.chmod(0o755)
-    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
-
-    cancellation = _api().CancellationSignal()
-
-    def cancel_after_start() -> None:
-        deadline = time.monotonic() + 2
-        while not child_pid_path.exists() and time.monotonic() < deadline:
-            time.sleep(0.01)
-        time.sleep(0.2)
-        cancellation.cancel()
-
-    cancellation_thread = threading.Thread(target=cancel_after_start, daemon=True)
-    cancellation_thread.start()
+    cancellation = _api().CancellationSignal(cancel_after_checks=1)
     started = time.monotonic()
     result = scanner.SubprocessCommandRunner().run(
         ("git", "version"), tmp_path, 10, cancellation=cancellation
     )
-    cancellation_thread.join(timeout=1)
     assert time.monotonic() - started < 4
     assert result.returncode == 126
     assert result.timed_out is False
-    child_pid = int(child_pid_path.read_text())
-    deadline = time.monotonic() + 2
-    while time.monotonic() < deadline:
-        try:
-            os.kill(child_pid, 0)
-        except ProcessLookupError:
-            break
-        time.sleep(0.05)
-    else:
-        pytest.fail("TERM-ignoring descendant survived bounded command cancellation")
 
 
 def test_cancellation_during_adapter_blocks_snapshot_finalization(
@@ -1727,7 +1791,7 @@ def test_git_readers_disable_lazy_fetch_and_repository_defined_accelerators() ->
     assert scanner_environment["GIT_CONFIG_VALUE_0"] == "false"
     governance_runner = governance.GovernanceCommandRunner()
     assert scanner_environment["GIT_CONFIG_VALUE_5"] == "false"
-    assert governance_runner.identity.endswith("1.7.0")
+    assert governance_runner.identity.endswith("1.8.0")
 
 
 def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -1813,6 +1813,47 @@ def test_sensitive_mapping_fields_are_redacted_before_persistence(field: str) ->
 
 
 @pytest.mark.parametrize(
+    "secret",
+    [
+        "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+        "sk-svcacct-abcdefghijklmnopqrstuvwxyz0123456789",
+        "sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789",
+        "sk-abcdefghijklmnopqrstuvwxyz0123456789",
+    ],
+)
+def test_modern_service_tokens_are_redacted_without_field_labels(secret: str) -> None:
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    sanitized = redaction.EvidenceRedactor(environment={}).sanitize(f"provider returned {secret}")
+    assert secret not in sanitized
+    assert sanitized == "provider returned [REDACTED]"
+
+
+@pytest.mark.parametrize(
+    ("evidence", "secret"),
+    [
+        ("collector exposed api_key opaque-key-material", "opaque-key-material"),
+        ("password hunter2", "hunter2"),
+        ('credential "opaque credential material"', "opaque credential material"),
+        ("note: access_token opaque-token-material", "opaque-token-material"),
+    ],
+)
+def test_whitespace_delimited_sensitive_assignments_are_redacted(
+    evidence: str,
+    secret: str,
+) -> None:
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    sanitized = redaction.EvidenceRedactor(environment={}).sanitize(evidence)
+    assert secret not in sanitized
+    assert "[REDACTED]" in sanitized
+
+
+def test_whitespace_redaction_preserves_noncredential_audit_phrases() -> None:
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    evidence = "credential boundaries and password policy and api_key ownership"
+    assert redaction.EvidenceRedactor(environment={}).sanitize(evidence) == evidence
+
+
+@pytest.mark.parametrize(
     ("header", "secrets"),
     [
         ("Authorization: Token opaque-secret", ("Token", "opaque-secret")),
@@ -2061,6 +2102,16 @@ class _SecretBearingRemote(_FakeRemote):
                     'response="response-secret"'
                 ),
                 "comment": "glpat-0123456789abcdefghijkl",
+                "modern_key_note": (
+                    "collector exposed api_key sk-proj-abcdefghijklmnopqrstuvwxyz0123456789"
+                ),
+            }
+        )
+        payload["unknowns"].append(
+            {
+                "fact": "credential_diagnostic",
+                "status": "BLOCKED",
+                "reason": "provider returned password hunter2",
             }
         )
         return payload
@@ -2707,6 +2758,8 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "aws-secret-value" not in payload
     assert "query-json-secret" not in payload
     assert "pass-json-secret" not in payload
+    assert "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789" not in payload
+    assert "hunter2" not in payload
     assert "[REDACTED_URL]" in payload
     assert "[REDACTED]" in payload
 

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -415,6 +415,53 @@ def test_nested_package_manifests_create_explicit_architecture_boundaries(
     assert boundaries["products/example/backend"].confidence == "HIGH"
 
 
+def test_entry_points_and_test_coverage_configuration_are_explicit_inventory(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(
+        repo,
+        "services/api/pyproject.toml",
+        "[project]\nname='api'\nversion='1'\n[project.scripts]\napi='api.cli:main'\n",
+    )
+    _write(repo, "services/api/src/api/__main__.py", "raise SystemExit(0)\n")
+    _write(
+        repo,
+        "apps/web/package.json",
+        json.dumps(
+            {
+                "name": "web",
+                "version": "1.0.0",
+                "main": "src/index.js",
+                "scripts": {"start": "node src/index.js"},
+            }
+        ),
+    )
+    _write(repo, "apps/web/playwright.config.ts", "export default {};\n")
+    _write(repo, "apps/web/vitest.config.ts", "export default {};\n")
+    _write(repo, ".coveragerc", "[run]\nbranch = True\n")
+    _commit(repo, "entry-point and quality configuration evidence")
+
+    snapshot = _scan(repo)
+    architecture = {
+        (item.path, item.kind) for item in snapshot.inventory["architecture_boundaries"].items
+    }
+    quality = {(item.path, item.kind) for item in snapshot.inventory["tests_quality"].items}
+    assert (
+        "services/api/pyproject.toml",
+        "DECLARED_ENTRY_POINT",
+    ) in architecture
+    assert (
+        "services/api/src/api/__main__.py",
+        "ENTRY_POINT_FILE_SIGNAL",
+    ) in architecture
+    assert ("apps/web/package.json", "DECLARED_ENTRY_POINT") in architecture
+    assert ("apps/web/package.json", "DECLARED_RUN_ENTRY_POINT") in architecture
+    assert ("apps/web/playwright.config.ts", "TEST_CONFIGURATION") in quality
+    assert ("apps/web/vitest.config.ts", "TEST_CONFIGURATION") in quality
+    assert (".coveragerc", "COVERAGE_CONFIGURATION") in quality
+
+
 def test_every_recognized_nested_python_manifest_creates_a_package_boundary(
     tmp_path: Path,
 ) -> None:
@@ -943,7 +990,15 @@ class _FakeRemote:
             "observed_at": "2026-08-01T00:00:00Z",
             "coverage": ["remote_branches", "pull_requests", "issues", "governance"],
             "remote_branches": [{"name": "origin/feature", "sha": "a" * 40}],
-            "pull_requests": [{"number": 7, "draft": True, "head": "a" * 40}],
+            "pull_requests": [
+                {
+                    "number": 7,
+                    "draft": True,
+                    "head": "a" * 40,
+                    "updated_at": "2026-07-31T12:00:00Z",
+                    "mergeability": "MERGEABLE",
+                }
+            ],
             "issues": [{"number": 8, "state": "OPEN"}],
             "governance": {
                 "branch_protection": {"observed": True, "required_checks": ["ci"]},
@@ -1024,6 +1079,29 @@ class _StaleRemote(_FakeRemote):
     def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
         payload = super().collect(repository, ref, **bounds)
         payload["observed_at"] = "2026-07-31T00:00:00Z"
+        payload["pull_requests"][0]["updated_at"] = "2026-07-30T12:00:00Z"
+        return payload
+
+
+class _CompleteRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["unknowns"] = []
+        return payload
+
+
+class _StaleConflictingPullRequestRemote(_CompleteRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["pull_requests"][0]["updated_at"] = "2026-06-01T00:00:00Z"
+        payload["pull_requests"][0]["mergeability"] = "CONFLICTING"
+        return payload
+
+
+class _UnknownMergeabilityRemote(_CompleteRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["pull_requests"][0]["mergeability"] = "UNKNOWN"
         return payload
 
 
@@ -1201,10 +1279,45 @@ def test_branch_divergence_and_additional_worktrees_are_mutable_observations(
     assert "local_branches" not in _scan(repo).as_dict()
 
 
+def test_malformed_worktree_record_is_blocked_without_placeholder_facts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    repo = _init_repo(tmp_path)
+    original = governance.GovernanceCommandRunner.run
+
+    def malformed_worktree(
+        self: Any,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        cancellation: Any = None,
+    ) -> Any:
+        if args[1:3] == ("worktree", "list"):
+            return api.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=(
+                    f"worktree {repo}\0mystery value\0HEAD {'a' * 40}\0branch refs/heads/main\0\0"
+                ),
+                stderr="",
+            )
+        return original(self, args, cwd, timeout, cancellation=cancellation)
+
+    monkeypatch.setattr(governance.GovernanceCommandRunner, "run", malformed_worktree)
+    observation = _observe(repo)
+    assert observation.disposition == "BLOCKED"
+    assert observation.worktrees == ()
+    assert any(item.fact == "worktree_record:1" for item in observation.unknowns)
+    assert "UNKNOWN" not in observation.canonical_bytes().decode()
+
+
 def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path: Path) -> None:
     observation = _observe(_init_repo(tmp_path), _FakeRemote())
     payload = observation.canonical_bytes().decode()
-    assert observation.tool_identity == "recorded-remote-payload/1.0.0"
+    assert observation.tool_identity == "recorded-remote-payload/1.1.0"
     assert observation.api_query_version == "github-rest/2026-03-10"
     assert observation.query_provenance[0].surface == "remote_branches"
     assert observation.query_provenance[0].cursor == "branches-page-1"
@@ -1258,6 +1371,66 @@ def test_recorded_remote_provider_cannot_be_replaced_with_instance_code() -> Non
     provider = _sealed_remote(_FakeRemote())
     with pytest.raises(AttributeError):
         provider.collect = lambda *_args, **_kwargs: {}  # type: ignore[method-assign]
+
+
+@pytest.mark.parametrize(
+    ("max_output_bytes", "max_items", "message"),
+    [(8, 1_000, "byte budget"), (8_000_000, 3, "item budget")],
+)
+def test_recorded_remote_provider_enforces_bounds_before_deserialization(
+    monkeypatch: pytest.MonkeyPatch,
+    max_output_bytes: int,
+    max_items: int,
+    message: str,
+) -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    provider = api.RecordedRemoteProvider(
+        {"collection": [1, 2, 3]},
+        api_version="fixture/1",
+    )
+    deserialized = False
+
+    def forbidden_loads(_payload: Any) -> Any:
+        nonlocal deserialized
+        deserialized = True
+        raise AssertionError("deserialization must not occur before preflight bounds")
+
+    monkeypatch.setattr(governance.json, "loads", forbidden_loads)
+    with pytest.raises(api.RepositoryIntelligenceError, match=message):
+        provider.collect(
+            "example/fixture",
+            "main",
+            timeout_seconds=1,
+            max_output_bytes=max_output_bytes,
+            max_items=max_items,
+            cancellation=None,
+        )
+    assert deserialized is False
+
+
+def test_recorded_remote_provider_checks_cancellation_before_deserialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _api()
+    governance = importlib.import_module("pmpe.repository.governance")
+    provider = api.RecordedRemoteProvider({"safe": True}, api_version="fixture/1")
+    cancellation = api.CancellationSignal()
+    cancellation.cancel()
+
+    def forbidden_loads(_payload: Any) -> Any:
+        raise AssertionError("cancelled replay must not deserialize")
+
+    monkeypatch.setattr(governance.json, "loads", forbidden_loads)
+    with pytest.raises(api.RepositoryIntelligenceError, match="cancelled"):
+        provider.collect(
+            "example/fixture",
+            "main",
+            timeout_seconds=1,
+            max_output_bytes=1_000,
+            max_items=100,
+            cancellation=cancellation,
+        )
 
 
 def test_unsealed_parent_collaborators_are_rejected_before_execution(tmp_path: Path) -> None:
@@ -1331,6 +1504,21 @@ def test_stale_remote_metadata_is_blocked_not_complete(tmp_path: Path) -> None:
     observation = _observe(_init_repo(tmp_path), _StaleRemote())
     assert observation.disposition == "BLOCKED"
     assert any(item.fact == "remote_metadata_completeness" for item in observation.unknowns)
+
+
+def test_pull_request_staleness_and_conflict_evidence_are_explicit(tmp_path: Path) -> None:
+    observation = _observe(_init_repo(tmp_path), _StaleConflictingPullRequestRemote())
+    pull_request = observation.pull_requests[0]
+    assert pull_request.updated_at == "2026-06-01T00:00:00Z"
+    assert pull_request.stale is True
+    assert pull_request.mergeability == "CONFLICTING"
+    assert observation.disposition == "COMPLETE"
+
+
+def test_unknown_pull_request_mergeability_blocks_complete_observation(tmp_path: Path) -> None:
+    observation = _observe(_init_repo(tmp_path), _UnknownMergeabilityRemote())
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "pull_request_mergeability:7" for item in observation.unknowns)
 
 
 @pytest.mark.parametrize("remote", [_SingleSurfaceRemote(), _CountMismatchRemote()])
@@ -1459,6 +1647,16 @@ def test_observation_input_digest_binds_freshness_and_collector_budgets(tmp_path
     assert admitted.disposition == "COMPLETE"
     assert blocked.disposition == "BLOCKED"
     assert admitted.observation_input_digest != blocked.observation_input_digest
+
+    alternate_stale_policy = api.GovernanceCollector(
+        repository="example/fixture",
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
+        remote_provider=_sealed_remote(_AgeSensitiveRemote()),
+        max_remote_age_seconds=300,
+        stale_pull_request_after_seconds=60,
+    ).observe(repo, ref="main")
+    assert admitted.observation_input_digest != alternate_stale_policy.observation_input_digest
 
 
 def test_scan_and_observation_never_create_branches_commits_or_remote_mutations(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -375,12 +375,28 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(rfc8785_impl, "_serialize_str", lambda value, sink: None)
         assert scanner._implementation_digest() != original
+    hashlib_module = importlib.import_module("hashlib")
+    original_sha256 = hashlib_module.sha256
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(
+            hashlib_module,
+            "sha256",
+            lambda payload=b"", *args, **kwargs: original_sha256(payload, *args, **kwargs),
+        )
+        assert scanner._implementation_digest() != original
     for module_name, attribute in (
         ("configparser", "ConfigParser"),
+        ("datetime", "datetime"),
         ("fnmatch", "fnmatch"),
         ("json", "loads"),
         ("shlex", "split"),
         ("tomllib", "loads"),
+        ("urllib.parse", "urlsplit"),
+        ("urllib.parse", "_coerce_args"),
+        ("_datetime", "datetime"),
+        ("_json", "scanstring"),
+        ("_sre", "compile"),
+        ("math", "isfinite"),
     ):
         module = importlib.import_module(module_name)
         with monkeypatch.context() as runtime_patch:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -11,7 +11,7 @@ import subprocess
 import threading
 import time
 from dataclasses import asdict, replace
-from datetime import timedelta, timezone
+from datetime import datetime, timedelta, timezone, tzinfo
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -356,7 +356,7 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
         try:
             candidate = scanner._implementation_digest()
         except scanner.RepositorySecurityError as exc:
-            assert "imported-module" in str(exc)
+            assert "changed" in str(exc)
         else:
             assert candidate != original
 
@@ -517,6 +517,64 @@ def test_implementation_digest_seals_adapter_isolation_and_yaml_version(
             scanner._implementation_digest()
 
 
+def test_implementation_digest_seals_returned_multiprocessing_context_members(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    context = scanner._SEALED_MULTIPROCESSING_CONTEXT
+    callback_ran = False
+
+    def pipe_proxy(*args: Any, **kwargs: Any) -> Any:
+        nonlocal callback_ran
+        callback_ran = True
+        return scanner.multiprocessing.Pipe(*args, **kwargs)
+
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(type(context), "Pipe", pipe_proxy)
+        with pytest.raises(scanner.RepositorySecurityError, match="context or members changed"):
+            scanner._implementation_digest()
+        assert callback_ran is False
+
+    replacement_context = type(context)()
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(scanner, "_SEALED_MULTIPROCESSING_CONTEXT", replacement_context)
+        with pytest.raises(scanner.RepositorySecurityError, match="context or members changed"):
+            scanner._implementation_digest()
+
+
+def test_imported_non_callable_globals_are_sealed_before_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    governance = importlib.import_module("pmpe.repository.governance")
+    assert "AUDIT_CATEGORIES" in scanner._SEALED_SCANNER_EXTERNAL_GLOBAL_NAMES
+    assert "UTC" in governance._SEALED_GOVERNANCE_EXTERNAL_GLOBAL_NAMES
+
+    monkeypatch.setattr(scanner, "AUDIT_CATEGORIES", ("forged",))
+    with pytest.raises(scanner.RepositorySecurityError, match="imported global bindings changed"):
+        scanner._implementation_digest()
+
+
+def test_governance_rejects_replaced_timezone_before_callbacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    governance = importlib.import_module("pmpe.repository.governance")
+    callback_ran = False
+
+    class TimezoneProxy(tzinfo):
+        def utcoffset(self, value: datetime | None) -> timedelta:
+            nonlocal callback_ran
+            callback_ran = True
+            return timedelta(0)
+
+    monkeypatch.setattr(governance, "UTC", TimezoneProxy())
+    with pytest.raises(
+        governance.RepositorySecurityError, match="imported global bindings changed"
+    ):
+        governance._governance_implementation_digest()
+    assert callback_ran is False
+
+
 def test_governance_digest_rejects_replaced_output_module_before_use(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -541,7 +599,7 @@ def test_governance_digest_rejects_in_place_module_attribute_before_use(
     governance = importlib.import_module("pmpe.repository.governance")
     attributes = dict(governance._SEALED_GOVERNANCE_MODULE_ATTRIBUTE_NAMES)
     assert "uuid4" in attributes["uuid"]
-    assert "get_context" in attributes["multiprocessing"]
+    assert "_sealed_multiprocessing_context" in governance._SEALED_GOVERNANCE_EXTERNAL_GLOBAL_NAMES
     callback_ran = False
     original_uuid4 = governance.uuid.uuid4
 
@@ -583,7 +641,7 @@ def test_governance_provenance_binds_every_material_repository_module() -> None:
         try:
             candidate = governance._governance_implementation_digest()
         except governance.RepositorySecurityError as exc:
-            assert "imported-module" in str(exc)
+            assert "imported" in str(exc)
         else:
             assert candidate != original
 

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -8,7 +8,7 @@ import os
 import signal
 import subprocess
 import time
-from dataclasses import replace
+from dataclasses import asdict, replace
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -204,8 +204,10 @@ def test_sha256_repository_is_exactly_bound_or_fails_explicitly(tmp_path: Path) 
     assert snapshot.disposition != "ERROR"
 
 
-def test_adapter_order_does_not_change_output_but_version_does(tmp_path: Path) -> None:
+def test_adapter_order_does_not_change_output_and_registry_is_sealed(tmp_path: Path) -> None:
     api = _api()
+    canonical = importlib.import_module("pmpe.contracts.canonical")
+    scanner = importlib.import_module("pmpe.repository.scanner")
     repo = _init_repo(tmp_path)
     adapters = api.default_adapters()
     first = api.RepositoryScanner(config=_config(), adapters=adapters).scan(repo, commit="HEAD")
@@ -215,40 +217,41 @@ def test_adapter_order_does_not_change_output_but_version_does(tmp_path: Path) -
     assert first.canonical_bytes() == reordered.canonical_bytes()
 
     changed = (replace(adapters[0], version="99.0.0"), *adapters[1:])
-    versioned = api.RepositoryScanner(config=_config(), adapters=changed).scan(repo, commit="HEAD")
-    assert first.adapter_set_digest != versioned.adapter_set_digest
-    assert first.snapshot_digest != versioned.snapshot_digest
+    original_digest = canonical.canonical_digest(
+        [asdict(scanner._metadata(item)) for item in adapters]
+    )
+    changed_digest = canonical.canonical_digest(
+        [asdict(scanner._metadata(item)) for item in changed]
+    )
+    assert original_digest != changed_digest
+    with pytest.raises(api.RepositorySecurityError, match="sealed built-in adapter registry"):
+        api.RepositoryScanner(config=_config(), adapters=changed)
 
 
-def test_output_affecting_injected_implementation_changes_provenance_digest(
+def test_unregistered_adapter_cannot_execute_or_mutate_the_repository(
     tmp_path: Path,
 ) -> None:
     api = _api()
     adapters = importlib.import_module("pmpe.repository.adapters")
     repo = _init_repo(tmp_path)
+    marker = repo / "adapter-mutated.txt"
 
-    def first_evaluator(_context: Any) -> Any:
+    def mutate_repository(_context: Any) -> Any:
+        marker.write_text("mutation\n")
         return adapters.AdapterResult()
 
-    def second_evaluator(context: Any) -> Any:
-        assert context.files or not context.files
-        return adapters.AdapterResult()
-
-    metadata = {
-        "adapter_id": "test.same-declaration",
-        "version": "1.0.0",
-        "file_patterns": ("*",),
-        "supported_categories": ("repository_topology",),
-    }
-    first = api.RepositoryScanner(
-        config=_config(), adapters=(api.RepositoryAdapter(evaluator=first_evaluator, **metadata),)
-    ).scan(repo, commit="HEAD")
-    second = api.RepositoryScanner(
-        config=_config(), adapters=(api.RepositoryAdapter(evaluator=second_evaluator, **metadata),)
-    ).scan(repo, commit="HEAD")
-    assert first.adapter_set_digest == second.adapter_set_digest
-    assert first.implementation_digest != second.implementation_digest
-    assert first.snapshot_digest != second.snapshot_digest
+    unregistered = api.RepositoryAdapter(
+        adapter_id="test.mutating-adapter",
+        version="1.0.0",
+        file_patterns=("*",),
+        supported_categories=("repository_topology",),
+        evaluator=mutate_repository,
+    )
+    before = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    with pytest.raises(api.RepositorySecurityError, match="sealed built-in adapter registry"):
+        api.RepositoryScanner(config=_config(), adapters=(unregistered,))
+    assert not marker.exists()
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before
 
 
 def test_implementation_provenance_is_independent_of_checkout_path(tmp_path: Path) -> None:
@@ -327,6 +330,17 @@ def test_snapshot_binds_implementation_modules_and_runtime_tool_versions(tmp_pat
         "python",
         "pyyaml",
         "rfc8785",
+    }
+
+
+def test_governance_provenance_binds_every_material_repository_module() -> None:
+    governance = importlib.import_module("pmpe.repository.governance")
+    assert set(governance.GOVERNANCE_IMPLEMENTATION_MODULES) == {
+        "repository.governance",
+        "repository.models",
+        "repository.redaction",
+        "repository.scanner",
+        "contracts.canonical",
     }
 
 
@@ -525,45 +539,50 @@ def test_extensionless_unsupported_ecosystem_is_blocked(tmp_path: Path, manifest
     )
 
 
-def test_adapter_cannot_fabricate_untracked_high_confidence_evidence(tmp_path: Path) -> None:
+def test_extensionless_executable_is_blocked_without_being_run(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    marker = tmp_path / "must-not-run"
+    script = repo / "bin" / "deploy"
+    _write(repo, "bin/deploy", f"#!/bin/sh\ntouch {marker}\n")
+    script.chmod(0o755)
+    _commit(repo, "extensionless executable")
+    snapshot = _scan(repo)
+    assert snapshot.disposition == "BLOCKED"
+    assert any(
+        item.code == "STACK.UNSUPPORTED_EXTENSIONLESS_PROGRAM"
+        and "bin/deploy" in item.evidence_refs
+        for item in snapshot.findings
+    )
+    assert not marker.exists()
+
+
+def test_adapter_cannot_fabricate_untracked_high_confidence_evidence() -> None:
     api = _api()
     adapters = importlib.import_module("pmpe.repository.adapters")
     models = importlib.import_module("pmpe.repository.models")
-    repo = _init_repo(tmp_path)
-
-    def fabricate(_context: Any) -> Any:
-        return adapters.AdapterResult(
-            items=(
-                (
-                    "repository_topology",
-                    models.EvidenceItem(
-                        kind="FABRICATED",
-                        path="does-not-exist.txt",
-                        file_digest="sha256:" + "0" * 64,
-                        detector_id="test.fabricator",
-                        detector_version=adapters.DETECTOR_VERSION,
-                        confidence="HIGH",
-                    ),
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    adapter = next(
+        item for item in api.default_adapters() if item.adapter_id == "core.repository-topology"
+    )
+    fabricated = adapters.AdapterResult(
+        items=(
+            (
+                "repository_topology",
+                models.EvidenceItem(
+                    kind="FABRICATED",
+                    path="does-not-exist.txt",
+                    file_digest="sha256:" + "0" * 64,
+                    detector_id=adapter.adapter_id,
+                    detector_version=adapter.detector_version,
+                    confidence="HIGH",
                 ),
-            )
+            ),
         )
-
-    adapter = api.RepositoryAdapter(
-        adapter_id="test.fabricator",
-        version="1.0.0",
-        file_patterns=("*",),
-        supported_categories=("repository_topology",),
-        evaluator=fabricate,
     )
-    snapshot = api.RepositoryScanner(config=_config(), adapters=(adapter,)).scan(
-        repo, commit="HEAD"
-    )
-    assert snapshot.disposition == "BLOCKED"
-    assert any(item.code == "ADAPTER.INVALID_EVIDENCE" for item in snapshot.findings)
-    assert not any(
-        item.path == "does-not-exist.txt"
-        for category in snapshot.inventory.values()
-        for item in category.items
+    assert not scanner.RepositoryScanner._adapter_result_is_valid(
+        adapter,
+        adapters.AdapterContext(files=()),
+        fabricated,
     )
 
 
@@ -596,22 +615,20 @@ def test_malformed_manifest_and_workflow_are_visible_findings(tmp_path: Path) ->
     assert snapshot.disposition in {"PARTIAL", "BLOCKED"}
 
 
-def test_adapter_failure_is_visible_and_cannot_remove_categories(tmp_path: Path) -> None:
+def test_adapter_failure_is_visible_and_cannot_remove_categories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     api = _api()
+    scanner = importlib.import_module("pmpe.repository.scanner")
     repo = _init_repo(tmp_path)
 
-    @api.repository_adapter(
-        adapter_id="test.exploding",
-        version="1.0.0",
-        file_patterns=("**/*",),
-        supported_categories=("security_privacy",),
-    )
-    def exploding(_context: Any) -> Any:
-        raise RuntimeError("detector failed")
+    def failing_worker(connection: Any, _adapter: Any, _context: Any) -> None:
+        os.setsid()
+        connection.send_bytes(b'{"error_type":"RuntimeError","status":"ERROR"}')
+        connection.close()
 
-    snapshot = api.RepositoryScanner(
-        config=_config(), adapters=(*api.default_adapters(), exploding)
-    ).scan(repo, commit="HEAD")
+    monkeypatch.setattr(scanner, "_adapter_worker", failing_worker)
+    snapshot = api.RepositoryScanner(config=_config()).scan(repo, commit="HEAD")
     assert set(snapshot.inventory) == set(api.AUDIT_CATEGORIES)
     assert snapshot.disposition in {"PARTIAL", "BLOCKED"}
     assert any(item.code == "ADAPTER.FAILURE" for item in snapshot.findings)
@@ -904,6 +921,19 @@ class _CoerciblePrimitiveRemote(_FakeRemote):
         return payload
 
 
+class _AgeSensitiveRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["observed_at"] = "2026-07-31T23:58:00Z"
+        payload["unknowns"] = []
+        return payload
+
+
+class _HugeNumericRemote(_FakeRemote):
+    def collect(self, _repository: str, _ref: str, **_bounds: Any) -> dict[str, Any]:
+        return {"numeric_payload": 10**3000}
+
+
 def _observe(repo: Path, remote: Any = None) -> Any:
     api = _api()
     return api.GovernanceCollector(
@@ -1039,6 +1069,20 @@ def test_remote_provider_timeout_is_bounded_and_visible(tmp_path: Path) -> None:
     assert any(item.fact == "remote_governance" for item in observation.unknowns)
 
 
+def test_remote_numeric_payload_cannot_bypass_parent_byte_bound(tmp_path: Path) -> None:
+    api = _api()
+    observation = api.GovernanceCollector(
+        repository="example/fixture",
+        clock=_FixedClock(),
+        id_provider=_FixedIds(),
+        remote_provider=_HugeNumericRemote(),
+        max_output_bytes=2_048,
+    ).observe(_init_repo(tmp_path), ref="main")
+    assert observation.disposition == "BLOCKED"
+    assert observation.remote_branches == ()
+    assert any(item.fact == "remote_governance" for item in observation.unknowns)
+
+
 @pytest.mark.parametrize(
     "remote", [_MismatchedRemote(), _DuplicateRemote(), _CoerciblePrimitiveRemote()]
 )
@@ -1091,6 +1135,26 @@ def test_observation_is_reproducible_only_from_matching_recorded_inputs(tmp_path
     changed = _observe(repo, _FakeRemote())
     assert first.observation_input_digest != changed.observation_input_digest
     assert first.observation_output_digest != changed.observation_output_digest
+
+
+def test_observation_input_digest_binds_freshness_and_collector_budgets(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+
+    def observe(max_age: int) -> Any:
+        return api.GovernanceCollector(
+            repository="example/fixture",
+            clock=_FixedClock(),
+            id_provider=_FixedIds(),
+            remote_provider=_AgeSensitiveRemote(),
+            max_remote_age_seconds=max_age,
+        ).observe(repo, ref="main")
+
+    admitted = observe(300)
+    blocked = observe(60)
+    assert admitted.disposition == "COMPLETE"
+    assert blocked.disposition == "BLOCKED"
+    assert admitted.observation_input_digest != blocked.observation_input_digest
 
 
 def test_scan_and_observation_never_create_branches_commits_or_remote_mutations(
@@ -1340,9 +1404,11 @@ def test_cancellation_terminates_an_ordinary_bounded_git_command(
         pytest.fail("TERM-ignoring descendant survived bounded command cancellation")
 
 
-def test_cancellation_during_final_adapter_blocks_snapshot_finalization(tmp_path: Path) -> None:
+def test_cancellation_during_adapter_blocks_snapshot_finalization(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     api = _api()
-    adapters = importlib.import_module("pmpe.repository.adapters")
+    scanner = importlib.import_module("pmpe.repository.scanner")
     repo = _init_repo(tmp_path)
     before_head = _git(repo, "rev-parse", "HEAD")
     before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
@@ -1355,20 +1421,13 @@ def test_cancellation_during_final_adapter_blocks_snapshot_finalization(tmp_path
 
     cancellation = CancellationAfterAdapter()
 
-    def evaluate(_context: Any) -> Any:
+    def hanging_worker(_connection: Any, _adapter: Any, _context: Any) -> None:
+        os.setsid()
         time.sleep(30)
-        return adapters.AdapterResult()
 
-    final_adapter = api.RepositoryAdapter(
-        adapter_id="test.final-cancellation",
-        version="1.0.0",
-        file_patterns=("*",),
-        supported_categories=("repository_topology",),
-        evaluator=evaluate,
-    )
+    monkeypatch.setattr(scanner, "_adapter_worker", hanging_worker)
     snapshot = api.RepositoryScanner(
         config=_config(),
-        adapters=(final_adapter,),
         cancellation=cancellation,
     ).scan(repo, commit="HEAD")
     assert snapshot.disposition == "BLOCKED"

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -1622,7 +1622,15 @@ def test_adapter_failure_is_visible_and_cannot_remove_categories(
     scanner = importlib.import_module("pmpe.repository.scanner")
     repo = _init_repo(tmp_path)
 
-    def failing_worker(connection: Any, _adapter: Any, _context: Any) -> None:
+    def failing_worker(
+        connection: Any,
+        _adapter: Any,
+        _context: Any,
+        _expected_state_digest: str,
+        _expected_adapter_identity: int,
+        _expected_evaluator_identity: int,
+        _expected_module_state_digest: str,
+    ) -> None:
         os.setsid()
         connection.send_bytes(b'{"error_type":"RuntimeError","status":"ERROR"}')
         connection.close()
@@ -1819,6 +1827,8 @@ def test_sensitive_mapping_fields_are_redacted_before_persistence(field: str) ->
         "sk-svcacct-abcdefghijklmnopqrstuvwxyz0123456789",
         "sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789",
         "sk-abcdefghijklmnopqrstuvwxyz0123456789",
+        "sk-or-v1-abcdefghijklmnopqrstuvwxyz0123456789",
+        "hf_abcdefghijklmnopqrstuvwxyz0123456789",
     ],
 )
 def test_modern_service_tokens_are_redacted_without_field_labels(secret: str) -> None:
@@ -1835,6 +1845,12 @@ def test_modern_service_tokens_are_redacted_without_field_labels(secret: str) ->
         ("password hunter2", "hunter2"),
         ('credential "opaque credential material"', "opaque credential material"),
         ("note: access_token opaque-token-material", "opaque-token-material"),
+        ("provider returned token opaqueCredentialMaterial123", "opaqueCredentialMaterial123"),
+        ("provider returned secret opaqueSecretMaterial123", "opaqueSecretMaterial123"),
+        (
+            "provider returned cookie session=opaque-cookie-material",
+            "session=opaque-cookie-material",
+        ),
     ],
 )
 def test_whitespace_delimited_sensitive_assignments_are_redacted(
@@ -1849,7 +1865,10 @@ def test_whitespace_delimited_sensitive_assignments_are_redacted(
 
 def test_whitespace_redaction_preserves_noncredential_audit_phrases() -> None:
     redaction = importlib.import_module("pmpe.repository.redaction")
-    evidence = "credential boundaries and password policy and api_key ownership"
+    evidence = (
+        "credential boundaries and password policy and api_key ownership and "
+        "secret scanning and token policy and cookie controls"
+    )
     assert redaction.EvidenceRedactor(environment={}).sanitize(evidence) == evidence
 
 
@@ -2105,6 +2124,8 @@ class _SecretBearingRemote(_FakeRemote):
                 "modern_key_note": (
                     "collector exposed api_key sk-proj-abcdefghijklmnopqrstuvwxyz0123456789"
                 ),
+                "generic_token_note": ("provider returned token opaqueCredentialMaterial123"),
+                "hugging_face_note": "provider returned hf_abcdefghijklmnopqrstuvwxyz0123456789",
             }
         )
         payload["unknowns"].append(
@@ -2759,6 +2780,8 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "query-json-secret" not in payload
     assert "pass-json-secret" not in payload
     assert "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789" not in payload
+    assert "opaqueCredentialMaterial123" not in payload
+    assert "hf_abcdefghijklmnopqrstuvwxyz0123456789" not in payload
     assert "hunter2" not in payload
     assert "[REDACTED_URL]" in payload
     assert "[REDACTED]" in payload
@@ -3011,6 +3034,82 @@ def test_scanner_rejects_post_construction_adapter_substitution_before_mutation(
     with pytest.raises(api.RepositorySecurityError, match="provenance binding"):
         candidate.scan(repo, commit="HEAD")
     assert not marker.exists()
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+
+
+def test_scanner_rejects_in_place_adapter_mutation_before_evaluator_runs(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    adapters = importlib.import_module("pmpe.repository.adapters")
+    repo = _init_repo(tmp_path)
+    marker = repo / "adapter-in-place-mutation.txt"
+    candidate = api.RepositoryScanner(config=_config())
+    adapter = candidate.adapters[0]
+    original_evaluator = adapter.evaluator
+
+    def mutating_evaluator(_context: Any) -> Any:
+        marker.write_text("mutated")
+        return adapters.AdapterResult()
+
+    try:
+        object.__setattr__(adapter, "evaluator", mutating_evaluator)
+        with pytest.raises(api.RepositorySecurityError, match="sealed|provenance"):
+            candidate.scan(repo, commit="HEAD")
+    finally:
+        object.__setattr__(adapter, "evaluator", original_evaluator)
+    assert not marker.exists()
+
+
+def test_scanner_rejects_mutated_cancellation_state_before_callback_use(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    marker = repo / "cancellation-callback-ran.txt"
+    cancellation = api.CancellationSignal()
+
+    class MutatingEvent:
+        def is_set(self) -> bool:
+            marker.write_text("mutated")
+            return False
+
+    object.__setattr__(cancellation, "_event", MutatingEvent())
+    with pytest.raises(api.RepositorySecurityError, match="sealed"):
+        api.RepositoryScanner(config=_config(), cancellation=cancellation).scan(repo, commit="HEAD")
+    assert not marker.exists()
+
+
+def test_redaction_collision_between_tracked_paths_blocks_snapshot(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "docs/token=firstsecretvalue/report.md", "first\n")
+    _write(repo, "docs/token=secondsecretvalue/report.md", "second\n")
+    _commit(repo, "credential-shaped path identities")
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+    with pytest.raises(api.RepositorySecurityError, match="redaction"):
+        _scan(repo)
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
+
+
+def test_redaction_collision_between_branch_names_blocks_observation(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    _git(repo, "branch", "token=firstsecretvalue")
+    _git(repo, "branch", "token=secondsecretvalue")
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+    with pytest.raises(api.RepositorySecurityError, match="redaction"):
+        _observe(repo)
     assert _git(repo, "rev-parse", "HEAD") == before_head
     assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
 
@@ -3614,7 +3713,15 @@ def test_cancellation_during_adapter_blocks_snapshot_finalization(
     timer = threading.Timer(0.2, cancellation.cancel)
     timer.start()
 
-    def hanging_worker(_connection: Any, _adapter: Any, _context: Any) -> None:
+    def hanging_worker(
+        _connection: Any,
+        _adapter: Any,
+        _context: Any,
+        _expected_state_digest: str,
+        _expected_adapter_identity: int,
+        _expected_evaluator_identity: int,
+        _expected_module_state_digest: str,
+    ) -> None:
         os.setsid()
         time.sleep(30)
 

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -778,6 +778,28 @@ def test_adapter_classified_file_types_are_not_also_reported_unsupported(tmp_pat
     )
 
 
+def test_every_recognized_python_and_node_source_emits_language_evidence(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "stubs/widget.pyi", "def ready() -> bool: ...\n")
+    _write(repo, "scripts/start.mjs", "export const ready = true;\n")
+    _write(repo, "scripts/config.cjs", "module.exports = { ready: true };\n")
+    _write(repo, "tests/unit/test_only.py", "def test_ready():\n    assert True\n")
+    _write(repo, "tests/web/widget.test.ts", "export const ready = true;\n")
+    _commit(repo, "recognized source variants")
+    snapshot = _scan(repo)
+    observed = {
+        (item.path, item.kind) for item in snapshot.inventory["languages_build_ecosystems"].items
+    }
+    assert {
+        ("stubs/widget.pyi", "PYTHON_SOURCE"),
+        ("scripts/start.mjs", "NODE_SOURCE"),
+        ("scripts/config.cjs", "NODE_SOURCE"),
+        ("tests/unit/test_only.py", "PYTHON_SOURCE"),
+        ("tests/web/widget.test.ts", "NODE_SOURCE"),
+    } <= observed
+    assert snapshot.inventory["languages_build_ecosystems"].status == "OBSERVED"
+
+
 @pytest.mark.parametrize(
     "manifest",
     ["Makefile", "WORKSPACE", "BUILD.bazel", "Jenkinsfile", "Rakefile", "Procfile"],
@@ -1069,6 +1091,7 @@ class _FakeRemote:
             ],
             "issues": [{"number": 8, "state": "OPEN"}],
             "governance": {
+                "schema_version": "pmpe.repository-governance/v1",
                 "branch_protection": {"observed": True, "required_checks": ["ci"]},
                 "review_policy": {"required_approvals": 1},
                 "database_note": (
@@ -1200,8 +1223,21 @@ class _UnknownGovernanceRemote(_FakeRemote):
     def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
         payload = super().collect(repository, ref, **bounds)
         payload["governance"] = {
+            "schema_version": "pmpe.repository-governance/v1",
             "branch_protection": "UNKNOWN",
             "review_policy": {"required_approvals": 1},
+        }
+        payload["unknowns"] = []
+        return payload
+
+
+class _ScalarGovernanceRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["governance"] = {
+            "schema_version": "pmpe.repository-governance/v1",
+            "branch_protection": True,
+            "review_policy": 1,
         }
         payload["unknowns"] = []
         return payload
@@ -1723,7 +1759,10 @@ def test_remote_completeness_requires_per_surface_count_bound_pagination(
     assert any(item.fact == "remote_metadata_completeness" for item in observation.unknowns)
 
 
-@pytest.mark.parametrize("remote", [_EmptyGovernanceRemote(), _UnknownGovernanceRemote()])
+@pytest.mark.parametrize(
+    "remote",
+    [_EmptyGovernanceRemote(), _UnknownGovernanceRemote(), _ScalarGovernanceRemote()],
+)
 def test_empty_or_unknown_governance_is_explicitly_blocked(
     tmp_path: Path,
     remote: Any,

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -356,7 +356,7 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
         try:
             candidate = scanner._implementation_digest()
         except scanner.RepositorySecurityError as exc:
-            assert "imported-module state changed" in str(exc)
+            assert "imported-module" in str(exc)
         else:
             assert candidate != original
 
@@ -470,6 +470,53 @@ def test_implementation_digest_rejects_replaced_output_module_before_use(
     assert callback_ran is False
 
 
+def test_implementation_digest_seals_every_direct_module_attribute_before_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    attributes = dict(scanner._SEALED_SCANNER_MODULE_ATTRIBUTE_NAMES)
+    assert {"version", "PackageNotFoundError"} <= set(attributes["importlib_metadata"])
+    assert "python_version" in attributes["platform"]
+    assert "get_context" in attributes["multiprocessing"]
+    assert "__version__" in attributes["yaml"]
+
+    callback_ran = False
+    original_version = scanner.importlib_metadata.version
+
+    def version_proxy(distribution: str) -> str:
+        nonlocal callback_ran
+        callback_ran = True
+        return original_version(distribution)
+
+    monkeypatch.setattr(scanner.importlib_metadata, "version", version_proxy)
+    with pytest.raises(scanner.RepositorySecurityError, match="attributes changed"):
+        scanner.RepositoryScanner(config=_config())
+    assert callback_ran is False
+
+
+def test_implementation_digest_seals_adapter_isolation_and_yaml_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    callback_ran = False
+    original_context = scanner.multiprocessing.get_context
+
+    def context_proxy(*args: Any, **kwargs: Any) -> Any:
+        nonlocal callback_ran
+        callback_ran = True
+        return original_context(*args, **kwargs)
+
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(scanner.multiprocessing, "get_context", context_proxy)
+        with pytest.raises(scanner.RepositorySecurityError, match="attributes changed"):
+            scanner._implementation_digest()
+        assert callback_ran is False
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(scanner.yaml, "__version__", "forged-version")
+        with pytest.raises(scanner.RepositorySecurityError, match="attributes changed"):
+            scanner._implementation_digest()
+
+
 def test_governance_digest_rejects_replaced_output_module_before_use(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -484,6 +531,27 @@ def test_governance_digest_rejects_replaced_output_module_before_use(
 
     monkeypatch.setattr(governance, "uuid", UuidProxy())
     with pytest.raises(governance.RepositorySecurityError, match="imported-module"):
+        governance._governance_implementation_digest()
+    assert callback_ran is False
+
+
+def test_governance_digest_rejects_in_place_module_attribute_before_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    governance = importlib.import_module("pmpe.repository.governance")
+    attributes = dict(governance._SEALED_GOVERNANCE_MODULE_ATTRIBUTE_NAMES)
+    assert "uuid4" in attributes["uuid"]
+    assert "get_context" in attributes["multiprocessing"]
+    callback_ran = False
+    original_uuid4 = governance.uuid.uuid4
+
+    def uuid_proxy() -> Any:
+        nonlocal callback_ran
+        callback_ran = True
+        return original_uuid4()
+
+    monkeypatch.setattr(governance.uuid, "uuid4", uuid_proxy)
+    with pytest.raises(governance.RepositorySecurityError, match="attributes changed"):
         governance._governance_implementation_digest()
     assert callback_ran is False
 
@@ -515,7 +583,7 @@ def test_governance_provenance_binds_every_material_repository_module() -> None:
         try:
             candidate = governance._governance_implementation_digest()
         except governance.RepositorySecurityError as exc:
-            assert "imported-module state changed" in str(exc)
+            assert "imported-module" in str(exc)
         else:
             assert candidate != original
 
@@ -3904,22 +3972,17 @@ def test_cancellation_during_snapshot_digest_loses_atomic_admission(
     before_index = (repo / ".git" / "index").read_bytes()
     before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
     cancellation = api.CancellationSignal()
-    original_digest = scanner.canonical_digest
+    original_claim = scanner.CancellationSignal.claim_completion
     cancelled_at_admission = False
 
-    def cancel_before_digest(value: Any) -> str:
+    def cancel_before_claim(self: Any) -> bool:
         nonlocal cancelled_at_admission
-        if (
-            not cancelled_at_admission
-            and isinstance(value, dict)
-            and value.get("artifact_kind") == "REPOSITORY_SNAPSHOT"
-            and "snapshot_digest" not in value
-        ):
+        if not cancelled_at_admission:
             cancelled_at_admission = True
-            cancellation.cancel()
-        return original_digest(value)
+            self.cancel()
+        return original_claim(self)
 
-    monkeypatch.setattr(scanner, "canonical_digest", cancel_before_digest)
+    monkeypatch.setattr(scanner.CancellationSignal, "claim_completion", cancel_before_claim)
     snapshot = api.RepositoryScanner(config=_config(), cancellation=cancellation).scan(
         repo, commit="HEAD"
     )
@@ -3969,22 +4032,17 @@ def test_cancellation_during_observation_digest_loses_atomic_admission(
     before_index = (repo / ".git" / "index").read_bytes()
     before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
     cancellation = api.CancellationSignal()
-    original_digest = governance.canonical_digest
+    original_claim = governance.CancellationSignal.claim_completion
     cancelled_at_admission = False
 
-    def cancel_before_digest(value: Any) -> str:
+    def cancel_before_claim(self: Any) -> bool:
         nonlocal cancelled_at_admission
-        if (
-            not cancelled_at_admission
-            and isinstance(value, dict)
-            and value.get("artifact_kind") == "GOVERNANCE_OBSERVATION"
-            and "observation_output_digest" not in value
-        ):
+        if not cancelled_at_admission:
             cancelled_at_admission = True
-            cancellation.cancel()
-        return original_digest(value)
+            self.cancel()
+        return original_claim(self)
 
-    monkeypatch.setattr(governance, "canonical_digest", cancel_before_digest)
+    monkeypatch.setattr(governance.CancellationSignal, "claim_completion", cancel_before_claim)
     observation = api.GovernanceCollector(
         repository="example/fixture",
         clock=_fixed_clock(),

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -125,6 +125,16 @@ def test_exact_sha_snapshot_is_byte_deterministic_and_has_no_timestamp(tmp_path:
     assert "observed_at" not in first.as_dict()
     assert "worktree" not in first.as_dict()
     assert "pull_requests" not in first.as_dict()
+    assert ("git", "version") in {item.args for item in first.command_provenance}
+
+
+def test_exact_sha_snapshot_does_not_depend_on_host_secret_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_repo(tmp_path)
+    baseline = _scan(repo)
+    monkeypatch.setenv("CLAUDESECRET", "repository")
+    assert _scan(repo).canonical_bytes() == baseline.canonical_bytes()
 
 
 def test_equivalent_ref_and_exact_sha_produce_same_snapshot(tmp_path: Path) -> None:
@@ -502,6 +512,38 @@ def test_multiple_lockfiles_version_drift_and_duplicate_config_are_risk_signals(
     assert "RUNTIME.VERSION_DRIFT_SIGNAL" in codes
 
 
+def test_python_manifests_and_lockfiles_are_explicit_inventory(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "services/api/requirements.txt", "rfc8785==0.1.4\n")
+    _write(repo, "services/api/requirements.lock", "rfc8785==0.1.4\n")
+    _write(repo, "services/worker/Pipfile", "[packages]\nrfc8785='==0.1.4'\n")
+    _write(repo, "services/worker/Pipfile.lock", "{}\n")
+    _write(repo, "services/worker/poetry.lock", "# generated lock\n")
+    _write(repo, "services/worker/uv.lock", "version = 1\n")
+    _write(repo, "services/legacy/setup.cfg", "[metadata]\nname = legacy\n")
+    _commit(repo, "python dependency inputs")
+    snapshot = _scan(repo)
+    items = snapshot.inventory["languages_build_ecosystems"].items
+    manifest_paths = {item.path for item in items if item.kind == "PYTHON_MANIFEST"}
+    lock_paths = {item.path for item in items if item.kind == "PYTHON_LOCKFILE"}
+    assert {
+        "services/api/requirements.txt",
+        "services/worker/Pipfile",
+        "services/legacy/setup.cfg",
+    } <= manifest_paths
+    assert {
+        "services/api/requirements.lock",
+        "services/worker/Pipfile.lock",
+        "services/worker/poetry.lock",
+        "services/worker/uv.lock",
+    } <= lock_paths
+    assert not any(
+        item.code == "STACK.UNSUPPORTED_ECOSYSTEM"
+        and any("Pipfile" in ref for ref in item.evidence_refs)
+        for item in snapshot.findings
+    )
+
+
 def test_unknown_ecosystem_is_explicitly_unsupported(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path, mixed=False)
     _write(repo, "main.unknownlang", "opaque\n")
@@ -525,7 +567,7 @@ def test_shell_source_without_adapter_is_blocked_not_reported_absent(tmp_path: P
 
 @pytest.mark.parametrize(
     "manifest",
-    ["Makefile", "WORKSPACE", "BUILD.bazel", "Jenkinsfile", "Pipfile", "Rakefile", "Procfile"],
+    ["Makefile", "WORKSPACE", "BUILD.bazel", "Jenkinsfile", "Rakefile", "Procfile"],
 )
 def test_extensionless_unsupported_ecosystem_is_blocked(tmp_path: Path, manifest: str) -> None:
     repo = _init_repo(tmp_path, mixed=False)
@@ -626,6 +668,8 @@ def test_adapter_failure_is_visible_and_cannot_remove_categories(
         os.setsid()
         connection.send_bytes(b'{"error_type":"RuntimeError","status":"ERROR"}')
         connection.close()
+        while True:
+            signal.pause()
 
     monkeypatch.setattr(scanner, "_adapter_worker", failing_worker)
     snapshot = api.RepositoryScanner(config=_config()).scan(repo, commit="HEAD")
@@ -742,6 +786,16 @@ def test_sensitive_mapping_fields_are_redacted_before_persistence(field: str) ->
     assert secret not in json.dumps(sanitized)
 
 
+def test_sensitive_environment_value_is_redacted_under_benign_field() -> None:
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    secret = "opaque-credential-value-not-matching-a-token-shape"
+    sanitized = redaction.EvidenceRedactor(environment={"CLAUDESECRET": secret}).sanitize(
+        {"message": f"provider returned {secret}"}
+    )
+    assert secret not in json.dumps(sanitized)
+    assert sanitized["message"] == "provider returned [REDACTED_ENV]"
+
+
 class _FixedClock:
     def now(self) -> str:
         return "2026-08-01T00:00:00Z"
@@ -786,6 +840,12 @@ class _FakeRemote:
                 "odbc_note": "Driver=x;UID=demo;PWD={odbc secret value};Server=db",
                 "cookie_note": "Cookie: session=cookie-secret; theme=dark",
                 "aws_note": "aws_secret_access_key=aws-secret-value",
+                "safe_url": "https://user:password@example.invalid/repo?token=secret-value",
+                "signed_url": "https://storage.example.invalid/blob?sv=1&sig=signed-secret",
+                "authorization": "Basic dXNlcjpwYXNzd29yZA==",
+                "x-api-key": "unstructured-bare-secret",
+                "note": "Authorization: Basic dXNlcjpwYXNzd29yZA==",
+                "comment": "glpat-0123456789abcdefghijkl",
             },
             "query_provenance": [
                 {
@@ -826,12 +886,6 @@ class _FakeRemote:
             "unknowns": [
                 {"fact": "secret_scanning", "status": "BLOCKED", "reason": "permission denied"}
             ],
-            "safe_url": "https://user:password@example.invalid/repo?token=secret-value",
-            "signed_url": "https://storage.example.invalid/blob?sv=1&sig=signed-secret",
-            "authorization": "Basic dXNlcjpwYXNzd29yZA==",
-            "x-api-key": "unstructured-bare-secret",
-            "note": "Authorization: Basic dXNlcjpwYXNzd29yZA==",
-            "comment": "glpat-0123456789abcdefghijkl",
         }
 
 
@@ -930,8 +984,16 @@ class _AgeSensitiveRemote(_FakeRemote):
 
 
 class _HugeNumericRemote(_FakeRemote):
-    def collect(self, _repository: str, _ref: str, **_bounds: Any) -> dict[str, Any]:
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        del repository, ref, bounds
         return {"numeric_payload": 10**3000}
+
+
+class _ExtraFieldRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["unexpected"] = "unreviewed provider surface"
+        return payload
 
 
 def _observe(repo: Path, remote: Any = None) -> Any:
@@ -1084,7 +1146,13 @@ def test_remote_numeric_payload_cannot_bypass_parent_byte_bound(tmp_path: Path) 
 
 
 @pytest.mark.parametrize(
-    "remote", [_MismatchedRemote(), _DuplicateRemote(), _CoerciblePrimitiveRemote()]
+    "remote",
+    [
+        _MismatchedRemote(),
+        _DuplicateRemote(),
+        _CoerciblePrimitiveRemote(),
+        _ExtraFieldRemote(),
+    ],
 )
 def test_remote_identity_mismatch_or_duplicate_inventory_fails_closed(
     tmp_path: Path, remote: Any
@@ -1472,7 +1540,7 @@ def test_git_readers_disable_lazy_fetch_and_repository_defined_accelerators() ->
     assert scanner_environment["GIT_CONFIG_VALUE_0"] == "false"
     governance_runner = governance.GovernanceCommandRunner()
     assert scanner_environment["GIT_CONFIG_VALUE_5"] == "false"
-    assert governance_runner.identity.endswith("1.6.0")
+    assert governance_runner.identity.endswith("1.7.0")
 
 
 def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -166,6 +166,19 @@ def test_new_commit_changes_tree_and_snapshot_digests(tmp_path: Path) -> None:
     assert first.snapshot_digest != second.snapshot_digest
 
 
+def test_replace_refs_cannot_change_an_exact_commit_snapshot(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    original = _git(repo, "rev-parse", "HEAD")
+    baseline = api.RepositoryScanner(config=_config()).scan(repo, commit=original)
+    _write(repo, "README.md", "# Replacement content\n")
+    replacement = _commit(repo, "replacement target")
+    _git(repo, "replace", original, replacement)
+    with_replacement = api.RepositoryScanner(config=_config()).scan(repo, commit=original)
+    assert with_replacement.canonical_bytes() == baseline.canonical_bytes()
+    assert with_replacement.commit_sha == original
+
+
 def test_adapter_order_does_not_change_output_but_version_does(tmp_path: Path) -> None:
     api = _api()
     repo = _init_repo(tmp_path)
@@ -247,7 +260,12 @@ def test_api_data_generated_client_migration_and_contract_sync_are_inventory_ite
 ) -> None:
     snapshot = _scan(_init_repo(tmp_path))
     kinds = {item.kind for item in snapshot.inventory["apis_data"].items}
-    assert {"OPENAPI", "MIGRATION", "CODE_GENERATOR"} <= kinds
+    assert {"OPENAPI", "MIGRATION_SIGNAL", "CODE_GENERATOR_SIGNAL"} <= kinds
+    assert all(
+        item.confidence == "MEDIUM"
+        for item in snapshot.inventory["apis_data"].items
+        if item.kind.endswith("_SIGNAL")
+    )
 
 
 def test_integration_declarations_and_codeowners_are_evidence_backed(tmp_path: Path) -> None:
@@ -302,6 +320,33 @@ def test_ci_comments_do_not_become_security_test_or_rollback_controls(tmp_path: 
     assert any(item.code == "DELIVERY.ROLLBACK_EVIDENCE_ABSENT" for item in snapshot.findings)
 
 
+def test_recursive_workflow_alias_is_cycle_bounded_and_deterministic(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(
+        repo,
+        ".github/workflows/ci.yml",
+        "on: [push]\njobs: &jobs\n  recursive: *jobs\n",
+    )
+    _commit(repo, "recursive workflow")
+    first = _scan(repo)
+    second = _scan(repo)
+    assert first.canonical_bytes() == second.canonical_bytes()
+    assert not any(item.code == "ADAPTER.FAILURE" for item in first.findings)
+
+
+def test_disabled_docker_healthcheck_is_not_positive_health_evidence(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "Dockerfile", "FROM scratch\nHEALTHCHECK NONE\n")
+    _commit(repo, "disabled health check")
+    snapshot = _scan(repo)
+    kinds = {item.kind for item in snapshot.inventory["observability_operations"].items}
+    assert "HEALTH_CHECK" not in kinds
+    assert "HEALTH_CHECK_DISABLED_SIGNAL" in kinds
+    assert any(
+        item.code == "OPERATIONS.OBSERVABILITY_EVIDENCE_ABSENT" for item in snapshot.findings
+    )
+
+
 def test_malformed_openapi_is_blocked_and_never_emitted_as_api_evidence(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path, mixed=False)
     _write(repo, "openapi.yaml", "# not an OpenAPI declaration\n{}\n")
@@ -309,6 +354,25 @@ def test_malformed_openapi_is_blocked_and_never_emitted_as_api_evidence(tmp_path
     snapshot = _scan(repo)
     assert snapshot.disposition == "BLOCKED"
     assert any(item.code == "INTERFACE.DECLARATION_INVALID" for item in snapshot.findings)
+    assert not any(item.kind == "OPENAPI" for item in snapshot.inventory["apis_data"].items)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"openapi":"future","info":{"title":"x","version":"1"},"paths":{}}',
+        '{"openapi":"3.1.0","info":{"title":"x","version":"1"},"paths":{"bad":[]}}',
+    ],
+)
+def test_invalid_openapi_version_or_paths_are_not_high_confidence_evidence(
+    tmp_path: Path,
+    payload: str,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "openapi.json", payload)
+    _commit(repo, "invalid OpenAPI semantics")
+    snapshot = _scan(repo)
+    assert snapshot.disposition == "BLOCKED"
     assert not any(item.kind == "OPENAPI" for item in snapshot.inventory["apis_data"].items)
 
 
@@ -556,15 +620,44 @@ class _FakeRemote:
                     "DATABASE_URL=postgres://database-user:database-password@db.invalid/app"
                     "?sslmode=require&token=query-secret"
                 ),
+                "azure_note": "AccountName=demo;AccountKey=azure-secret-value==;Endpoint=x",
+                "odbc_note": "Driver=x;UID=demo;PWD={odbc secret value};Server=db",
+                "cookie_note": "Cookie: session=cookie-secret; theme=dark",
+                "aws_note": "aws_secret_access_key=aws-secret-value",
             },
             "query_provenance": [
                 {
-                    "query": "branches,pulls,issues,protection",
-                    "cursor": "cursor-2",
-                    "page": 2,
+                    "surface": "remote_branches",
+                    "query": "branches",
+                    "cursor": "branches-page-1",
+                    "page": 1,
                     "has_next_page": False,
-                    "result_count": 3,
-                }
+                    "result_count": 1,
+                },
+                {
+                    "surface": "pull_requests",
+                    "query": "pulls",
+                    "cursor": "pulls-page-1",
+                    "page": 1,
+                    "has_next_page": False,
+                    "result_count": 1,
+                },
+                {
+                    "surface": "issues",
+                    "query": "issues",
+                    "cursor": "issues-page-1",
+                    "page": 1,
+                    "has_next_page": False,
+                    "result_count": 1,
+                },
+                {
+                    "surface": "governance",
+                    "query": "protection",
+                    "cursor": "governance-page-1",
+                    "page": 1,
+                    "has_next_page": False,
+                    "result_count": 1,
+                },
             ],
             "unknowns": [
                 {"fact": "secret_scanning", "status": "BLOCKED", "reason": "permission denied"}
@@ -600,6 +693,20 @@ class _StaleRemote(_FakeRemote):
         return payload
 
 
+class _SingleSurfaceRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["query_provenance"] = payload["query_provenance"][:1]
+        return payload
+
+
+class _CountMismatchRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["query_provenance"][0]["result_count"] = 0
+        return payload
+
+
 def _observe(repo: Path, remote: Any = None) -> Any:
     api = _api()
     return api.GovernanceCollector(
@@ -632,6 +739,16 @@ def test_governance_observation_records_dirty_index_worktree_and_untracked_state
     assert any(item.fact == "remote_governance" for item in observation.unknowns)
 
 
+def test_gitlink_state_is_explicitly_unknown_instead_of_silently_clean(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    commit_sha = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "update-index", "--add", "--cacheinfo", f"160000,{commit_sha},deps/sub")
+    _git(repo, "commit", "-q", "-m", "gitlink fixture")
+    observation = _observe(repo)
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "submodule_worktree_state" for item in observation.unknowns)
+
+
 def test_branch_divergence_and_additional_worktrees_are_mutable_observations(
     tmp_path: Path,
 ) -> None:
@@ -654,7 +771,8 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     payload = observation.canonical_bytes().decode()
     assert observation.tool_identity == "fake-github-readonly/1.0"
     assert observation.api_query_version == "github-rest/2026-03-10"
-    assert observation.query_provenance[0].cursor == "cursor-2"
+    assert observation.query_provenance[0].surface == "remote_branches"
+    assert observation.query_provenance[0].cursor == "branches-page-1"
     assert observation.observation_input_digest.startswith("sha256:")
     assert observation.observation_output_digest.startswith("sha256:")
     assert "ghp_0123456789abcdefghijklmnop" not in payload
@@ -666,6 +784,10 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "database-user" not in payload
     assert "database-password" not in payload
     assert "query-secret" not in payload
+    assert "azure-secret-value" not in payload
+    assert "odbc secret value" not in payload
+    assert "cookie-secret" not in payload
+    assert "aws-secret-value" not in payload
     assert "[REDACTED_URL]" in payload
     assert "[REDACTED]" in payload
 
@@ -678,6 +800,16 @@ def test_unproven_remote_pagination_is_blocked_not_complete(tmp_path: Path) -> N
 
 def test_stale_remote_metadata_is_blocked_not_complete(tmp_path: Path) -> None:
     observation = _observe(_init_repo(tmp_path), _StaleRemote())
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "remote_metadata_completeness" for item in observation.unknowns)
+
+
+@pytest.mark.parametrize("remote", [_SingleSurfaceRemote(), _CountMismatchRemote()])
+def test_remote_completeness_requires_per_surface_count_bound_pagination(
+    tmp_path: Path,
+    remote: Any,
+) -> None:
+    observation = _observe(_init_repo(tmp_path), remote)
     assert observation.disposition == "BLOCKED"
     assert any(item.fact == "remote_metadata_completeness" for item in observation.unknowns)
 
@@ -910,10 +1042,11 @@ def test_git_readers_disable_lazy_fetch_and_repository_defined_accelerators() ->
     governance = importlib.import_module("pmpe.repository.governance")
     scanner_environment = scanner.SubprocessCommandRunner._environment()
     assert scanner_environment["GIT_NO_LAZY_FETCH"] == "1"
+    assert scanner_environment["GIT_NO_REPLACE_OBJECTS"] == "1"
     assert scanner_environment["GIT_CONFIG_VALUE_0"] == "false"
     governance_runner = governance.GovernanceCommandRunner()
     assert scanner_environment["GIT_CONFIG_VALUE_5"] == "false"
-    assert governance_runner.identity.endswith("1.2.0")
+    assert governance_runner.identity.endswith("1.3.0")
 
 
 def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -860,6 +860,16 @@ def test_non_github_ci_is_not_reported_as_ci_absent(tmp_path: Path) -> None:
             ".github/workflows/ci.yml",
             "name: empty\non: [push]\njobs:\n  empty: {}\n",
         ),
+        (
+            ".github/workflows/ci.yml",
+            "name: empty trigger\non: []\njobs:\n  test:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "name: empty trigger\non: {}\njobs:\n  test:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        ),
         (".circleci/config.yml", "version: 2.1\njobs: []\n"),
         (
             ".circleci/config.yml",
@@ -1419,7 +1429,10 @@ def test_non_secret_boolean_control_with_sensitive_word_remains_typed() -> None:
     "url",
     [
         "https://hooks.slack.com/services/T000/B000/slack-webhook-secret",
+        "https://hooks.slack.com./services/T000/B000/slack-webhook-secret",
         "https://discord.com/api/webhooks/123/discord-webhook-secret",
+        "https://canary.discord.com/api/webhooks/123/discord-webhook-secret",
+        "https://ptb.discord.com./api/webhooks/123/discord-webhook-secret",
         "https://api.telegram.org/bottelegram-secret/sendMessage",
     ],
 )

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -219,6 +219,37 @@ def test_adapter_order_does_not_change_output_but_version_does(tmp_path: Path) -
     assert first.snapshot_digest != versioned.snapshot_digest
 
 
+def test_output_affecting_injected_implementation_changes_provenance_digest(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    adapters = importlib.import_module("pmpe.repository.adapters")
+    repo = _init_repo(tmp_path)
+
+    def first_evaluator(_context: Any) -> Any:
+        return adapters.AdapterResult()
+
+    def second_evaluator(context: Any) -> Any:
+        assert context.files or not context.files
+        return adapters.AdapterResult()
+
+    metadata = {
+        "adapter_id": "test.same-declaration",
+        "version": "1.0.0",
+        "file_patterns": ("*",),
+        "supported_categories": ("repository_topology",),
+    }
+    first = api.RepositoryScanner(
+        config=_config(), adapters=(api.RepositoryAdapter(evaluator=first_evaluator, **metadata),)
+    ).scan(repo, commit="HEAD")
+    second = api.RepositoryScanner(
+        config=_config(), adapters=(api.RepositoryAdapter(evaluator=second_evaluator, **metadata),)
+    ).scan(repo, commit="HEAD")
+    assert first.adapter_set_digest == second.adapter_set_digest
+    assert first.implementation_digest != second.implementation_digest
+    assert first.snapshot_digest != second.snapshot_digest
+
+
 def test_all_audit_categories_are_present_and_active_work_is_separate(tmp_path: Path) -> None:
     api = _api()
     snapshot = _scan(_init_repo(tmp_path))
@@ -262,7 +293,8 @@ def test_adapter_metadata_is_versioned_and_declares_supported_categories(
 
 def test_snapshot_binds_implementation_modules_and_runtime_tool_versions(tmp_path: Path) -> None:
     scanner = importlib.import_module("pmpe.repository.scanner")
-    snapshot = _scan(_init_repo(tmp_path))
+    repository_scanner = scanner.RepositoryScanner(config=_config())
+    snapshot = repository_scanner.scan(_init_repo(tmp_path), commit="HEAD")
     assert set(scanner.IMPLEMENTATION_MODULES) == {
         "repository.adapters",
         "repository.models",
@@ -270,7 +302,9 @@ def test_snapshot_binds_implementation_modules_and_runtime_tool_versions(tmp_pat
         "repository.scanner",
         "contracts.canonical",
     }
-    assert snapshot.implementation_digest == scanner._implementation_digest()
+    assert snapshot.implementation_digest == scanner._implementation_digest(
+        repository_scanner._extension_implementation_evidence
+    )
     assert {item.tool for item in snapshot.tool_versions} == {
         "git",
         "python",
@@ -458,6 +492,19 @@ def test_shell_source_without_adapter_is_blocked_not_reported_absent(tmp_path: P
     assert any(item.code == "STACK.UNSUPPORTED_FILE_TYPE" for item in snapshot.findings)
 
 
+@pytest.mark.parametrize("manifest", ["Makefile", "WORKSPACE", "BUILD.bazel", "Jenkinsfile"])
+def test_extensionless_unsupported_ecosystem_is_blocked(tmp_path: Path, manifest: str) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, manifest, "unsupported build definition\n")
+    _commit(repo, f"add {manifest}")
+    snapshot = _scan(repo)
+    assert snapshot.disposition == "BLOCKED"
+    assert any(
+        item.code == "STACK.UNSUPPORTED_ECOSYSTEM" and manifest in item.evidence_refs
+        for item in snapshot.findings
+    )
+
+
 def test_source_names_containing_test_are_not_high_confidence_test_evidence(
     tmp_path: Path,
 ) -> None:
@@ -633,6 +680,8 @@ class _FakeRemote:
         assert bounds["max_items"] > 0
         return {
             "complete": True,
+            "repository": repository,
+            "ref": ref,
             "observed_at": "2026-08-01T00:00:00Z",
             "coverage": ["remote_branches", "pull_requests", "issues", "governance"],
             "remote_branches": [{"name": "origin/feature", "sha": "a" * 40}],
@@ -653,7 +702,9 @@ class _FakeRemote:
             "query_provenance": [
                 {
                     "surface": "remote_branches",
-                    "query": "branches",
+                    "query": (
+                        'branches {"token":"query-json-secret","password":"pass-json-secret"}'
+                    ),
                     "cursor": "branches-page-1",
                     "page": 1,
                     "has_next_page": False,
@@ -759,6 +810,21 @@ class _HangingRemote(_FakeRemote):
         return super().collect(repository, ref, **bounds)
 
 
+class _MismatchedRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["repository"] = "different/repository"
+        return payload
+
+
+class _DuplicateRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["remote_branches"].append(dict(payload["remote_branches"][0]))
+        payload["query_provenance"][0]["result_count"] = 2
+        return payload
+
+
 def _observe(repo: Path, remote: Any = None) -> Any:
     api = _api()
     return api.GovernanceCollector(
@@ -829,7 +895,6 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert observation.observation_output_digest.startswith("sha256:")
     assert "ghp_0123456789abcdefghijklmnop" not in payload
     assert "dXNlcjpwYXNzd29yZA==" not in payload
-    assert "password" not in payload
     assert "secret-value" not in payload
     assert "signed-secret" not in payload
     assert "unstructured-bare-secret" not in payload
@@ -841,6 +906,8 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "odbc secret value" not in payload
     assert "cookie-secret" not in payload
     assert "aws-secret-value" not in payload
+    assert "query-json-secret" not in payload
+    assert "pass-json-secret" not in payload
     assert "[REDACTED_URL]" in payload
     assert "[REDACTED]" in payload
 
@@ -891,6 +958,15 @@ def test_remote_provider_timeout_is_bounded_and_visible(tmp_path: Path) -> None:
     assert time.monotonic() - started < 4
     assert observation.disposition == "BLOCKED"
     assert any(item.fact == "remote_governance" for item in observation.unknowns)
+
+
+@pytest.mark.parametrize("remote", [_MismatchedRemote(), _DuplicateRemote()])
+def test_remote_identity_mismatch_or_duplicate_inventory_fails_closed(
+    tmp_path: Path, remote: Any
+) -> None:
+    observation = _observe(_init_repo(tmp_path), remote)
+    assert observation.disposition == "BLOCKED"
+    assert any(item.fact == "remote_metadata_shape" for item in observation.unknowns)
 
 
 def test_remote_provider_cancellation_terminates_the_isolated_process() -> None:
@@ -1138,6 +1214,32 @@ def test_cancellation_terminates_bounded_enumeration_and_preserves_repository(
     assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before_status
 
 
+def test_cancellation_terminates_an_ordinary_bounded_git_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_git = fake_bin / "git"
+    fake_git.write_text("#!/bin/sh\nsleep 30\n")
+    fake_git.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+
+    class CancelSoon:
+        started = time.monotonic()
+
+        def cancelled(self) -> bool:
+            return time.monotonic() - self.started > 0.2
+
+    started = time.monotonic()
+    result = scanner.SubprocessCommandRunner().run(
+        ("git", "version"), tmp_path, 10, cancellation=CancelSoon()
+    )
+    assert time.monotonic() - started < 4
+    assert result.returncode == 126
+    assert result.timed_out is False
+
+
 def test_cancellation_during_final_adapter_blocks_snapshot_finalization(tmp_path: Path) -> None:
     api = _api()
     adapters = importlib.import_module("pmpe.repository.adapters")
@@ -1146,15 +1248,15 @@ def test_cancellation_during_final_adapter_blocks_snapshot_finalization(tmp_path
     before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
 
     class CancellationAfterAdapter:
-        active = False
+        started = time.monotonic()
 
         def cancelled(self) -> bool:
-            return self.active
+            return time.monotonic() - self.started > 0.2
 
     cancellation = CancellationAfterAdapter()
 
     def evaluate(_context: Any) -> Any:
-        cancellation.active = True
+        time.sleep(30)
         return adapters.AdapterResult()
 
     final_adapter = api.RepositoryAdapter(
@@ -1211,7 +1313,7 @@ def test_git_readers_disable_lazy_fetch_and_repository_defined_accelerators() ->
     assert scanner_environment["GIT_CONFIG_VALUE_0"] == "false"
     governance_runner = governance.GovernanceCommandRunner()
     assert scanner_environment["GIT_CONFIG_VALUE_5"] == "false"
-    assert governance_runner.identity.endswith("1.4.0")
+    assert governance_runner.identity.endswith("1.5.0")
 
 
 def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) -> None:
@@ -1230,8 +1332,15 @@ def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) ->
 def test_snapshot_and_observation_references_form_a_narrow_lifecycle_seam(
     tmp_path: Path,
 ) -> None:
-    snapshot = _scan(_init_repo(tmp_path))
-    observation = _observe(tmp_path / "fixture-repo")
+    api = _api()
+    repo = _init_repo(tmp_path)
+    snapshot = _scan(repo)
+    observation = api.GovernanceCollector(
+        repository="example/fixture",
+        snapshot=snapshot,
+        clock=_FixedClock(),
+        id_provider=_FixedIds(),
+    ).observe(repo, ref="main")
     reference = snapshot.assessment_reference(observation)
     assert reference == {
         "repository_snapshot_digest": snapshot.snapshot_digest,

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import json
 import os
+import re
 import signal
 import subprocess
 import threading
@@ -354,6 +355,18 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
         assert scanner._implementation_digest() != original
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(scanner, "_OBJECT_FORMAT_LENGTH", {"sha1": 1, "sha256": 1})
+        assert scanner._implementation_digest() != original
+    redaction = importlib.import_module("pmpe.repository.redaction")
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(redaction.EvidenceRedactor, "_token", re.compile(r"changed"))
+        assert scanner._implementation_digest() != original
+    yaml_module = importlib.import_module("yaml")
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(yaml_module, "safe_load", lambda value: value)
+        assert scanner._implementation_digest() != original
+    rfc8785_module = importlib.import_module("rfc8785")
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(rfc8785_module, "dumps", lambda value: b"changed")
         assert scanner._implementation_digest() != original
     runtime_digest = scanner._module_runtime_digest("repository.scanner")
     with monkeypatch.context() as runtime_patch:
@@ -1028,6 +1041,55 @@ def test_supported_github_ci_forms_are_reported(tmp_path: Path, content: str) ->
         item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
     )
     assert not any(item.code == "DELIVERY.CI_ABSENT" for item in snapshot.findings)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "on: [push]\npermissions:\n  arbitrary-scope: read\njobs:\n  test:\n"
+        "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        "on: [push]\njobs:\n  test:\n    needs: missing\n"
+        "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        "on: [push]\njobs:\n  first:\n    needs: second\n"
+        "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n"
+        "  second:\n    needs: first\n    runs-on: ubuntu-latest\n"
+        "    steps:\n      - run: pytest\n",
+        "on: [push]\njobs:\n  test:\n    strategy:\n      matrix:\n"
+        "        include: [ubuntu-latest]\n    runs-on: ubuntu-latest\n"
+        "    steps:\n      - run: pytest\n",
+    ],
+)
+def test_unproven_github_relationships_and_scopes_are_not_verified(
+    tmp_path: Path,
+    content: str,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, ".github/workflows/ci.yml", content)
+    _commit(repo, "unproven github workflow")
+    snapshot = _scan(repo)
+    assert not any(
+        item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
+    )
+    assert any(item.code == "WORKFLOW.STRUCTURE_UNPROVEN" for item in snapshot.findings)
+
+
+def test_supported_github_needs_graph_and_matrix_objects_are_verified(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(
+        repo,
+        ".github/workflows/ci.yml",
+        "on: [push]\npermissions:\n  contents: read\njobs:\n  build:\n"
+        "    strategy:\n      matrix:\n        python: ['3.12']\n"
+        "        include:\n          - python: '3.13'\n            experimental: true\n"
+        "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n"
+        "  report:\n    needs: build\n    runs-on: ubuntu-latest\n"
+        "    steps:\n      - run: echo done\n",
+    )
+    _commit(repo, "supported github dependency graph")
+    snapshot = _scan(repo)
+    assert any(
+        item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
+    )
 
 
 def test_ci_comments_do_not_become_security_test_or_rollback_controls(tmp_path: Path) -> None:
@@ -2730,6 +2792,21 @@ def test_observation_is_reproducible_only_from_matching_recorded_inputs(tmp_path
     changed = _observe(repo, _FakeRemote())
     assert first.observation_input_digest != changed.observation_input_digest
     assert first.observation_output_digest != changed.observation_output_digest
+
+
+def test_observation_input_digest_binds_staged_object_identity(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _write(repo, "README.md", "first staged value\n")
+    _git(repo, "add", "README.md")
+    first = _observe(repo, _FakeRemote())
+
+    _write(repo, "README.md", "second staged value\n")
+    _git(repo, "add", "README.md")
+    second = _observe(repo, _FakeRemote())
+
+    assert first.local_state == second.local_state
+    assert first.observation_input_digest != second.observation_input_digest
+    assert first.observation_output_digest != second.observation_output_digest
 
 
 def test_observation_input_digest_binds_freshness_and_collector_budgets(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -428,6 +428,7 @@ def test_api_codegen_declarations_bind_tracked_inputs_outputs_and_exporter(
         "CODE_GENERATOR_SIGNAL",
         "CODE_GENERATION_OUTPUT",
     }
+    assert all(item.confidence == "MEDIUM" for item in export_relationship)
 
 
 def test_openapi_named_source_or_documentation_is_not_parsed_as_a_contract(
@@ -441,6 +442,20 @@ def test_openapi_named_source_or_documentation_is_not_parsed_as_a_contract(
     assert not any(
         item.code == "INTERFACE.DECLARATION_INVALID"
         and set(item.evidence_refs) & {"docs/openapi-guide.md", "src/openapi_helpers.py"}
+        for item in snapshot.findings
+    )
+
+
+def test_binary_api_declaration_is_blocked_not_silently_omitted(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "openapi.json", b'{"openapi":"3.1.0"}\0')
+    _commit(repo, "binary API declaration")
+    snapshot = _scan(repo)
+    assert snapshot.disposition == "BLOCKED"
+    assert any(
+        item.code == "INTERFACE.DECLARATION_INVALID"
+        and item.evidence_refs == ("openapi.json",)
+        and item.blocking
         for item in snapshot.findings
     )
 
@@ -656,11 +671,53 @@ def test_every_required_internal_audit_subcategory_is_explicit(tmp_path: Path) -
             "ignored paths",
             "internal dependency direction",
             "shared-library relationships",
+            "CLI boundaries",
+            "worker boundaries",
+            "library boundaries",
+            "infrastructure-area boundaries",
+            "module boundaries",
+            "bounded-context boundaries",
             "storage models",
             "deployment-evidence mechanisms",
         )
     )
     assert snapshot.disposition == "BLOCKED"
+
+
+def test_worker_library_and_infrastructure_boundaries_are_typed(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "workers/queue/worker.py", "def run() -> None:\n    pass\n")
+    _write(repo, "libraries/shared/lib.py", "VALUE = 1\n")
+    _write(repo, "infra/runtime/main.tf", "terraform {}\n")
+    _commit(repo, "typed boundary areas")
+    snapshot = _scan(repo)
+    boundaries = {(item.kind, item.name) for item in snapshot.boundary_candidates}
+    assert {
+        ("WORKER", "workers/queue"),
+        ("LIBRARY", "libraries/shared"),
+        ("INFRASTRUCTURE_AREA", "infra/runtime"),
+    } <= boundaries
+    unsupported = {
+        item.explanation
+        for item in snapshot.findings
+        if item.code == "AUDIT.REQUIRED_SUBCATEGORY_UNSUPPORTED"
+    }
+    assert not any("worker boundaries" in explanation for explanation in unsupported)
+    assert not any("library boundaries" in explanation for explanation in unsupported)
+    assert not any("infrastructure-area boundaries" in explanation for explanation in unsupported)
+
+
+def test_migration_path_signal_cannot_prove_storage_model_coverage(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "migrations/README.md", "Migration process documentation only.\n")
+    _commit(repo, "migration documentation")
+    snapshot = _scan(repo)
+    assert any(
+        item.code == "AUDIT.REQUIRED_SUBCATEGORY_UNSUPPORTED"
+        and "storage models" in item.explanation
+        and item.blocking
+        for item in snapshot.findings
+    )
 
 
 def test_blocked_subcategory_status_survives_a_concurrent_partial_scan(
@@ -1187,6 +1244,10 @@ def test_home_path_minimization_is_host_state_independent(
         "/Users/repository-owner/work/repository"
     )
     assert first == second == "$HOME/work/repository"
+    embedded = redaction.EvidenceRedactor(environment={}).sanitize(
+        "command failed under /home/repository-owner/work/repository: permission denied"
+    )
+    assert embedded == "command failed under $HOME/work/repository: permission denied"
 
 
 def _fixed_clock() -> Any:
@@ -1322,6 +1383,17 @@ class _MissingSecuritySettingsRemote(_FakeRemote):
     def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
         payload = super().collect(repository, ref, **bounds)
         del payload["governance"]["security_settings"]
+        return payload
+
+
+class _UnobservedBranchProtectionRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["governance"]["branch_protection"] = {
+            "observed": False,
+            "required_checks": [],
+        }
+        payload["unknowns"] = []
         return payload
 
 
@@ -1850,7 +1922,12 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
 
 @pytest.mark.parametrize(
     "remote",
-    [_InvalidIssueStateRemote(), _ExtraCoverageRemote(), _MissingSecuritySettingsRemote()],
+    [
+        _InvalidIssueStateRemote(),
+        _ExtraCoverageRemote(),
+        _MissingSecuritySettingsRemote(),
+        _UnobservedBranchProtectionRemote(),
+    ],
 )
 def test_untyped_or_overbroad_remote_metadata_cannot_be_complete(
     tmp_path: Path,

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -393,6 +393,13 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(json_module, "_default_decoder", json.JSONDecoder(strict=False))
         assert scanner._implementation_digest() != original
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(
+            json_module._default_decoder,
+            "scan_once",
+            json.JSONDecoder(strict=False).scan_once,
+        )
+        assert scanner._implementation_digest() != original
     for module_name, attribute in (
         ("configparser", "ConfigParser"),
         ("datetime", "datetime"),

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import signal
 import subprocess
 from dataclasses import replace
 from pathlib import Path
@@ -71,7 +72,11 @@ def _init_repo(tmp_path: Path, *, mixed: bool = True) -> Path:
         )
         _write(repo, "packages/web/package-lock.json", '{"lockfileVersion":3}\n')
         _write(repo, "packages/web/src/index.ts", "export const ok = true;\n")
-        _write(repo, "services/api/openapi.json", '{"openapi":"3.1.0","paths":{}}\n')
+        _write(
+            repo,
+            "services/api/openapi.json",
+            '{"openapi":"3.1.0","info":{"title":"Fixture","version":"1"},"paths":{}}\n',
+        )
         _write(repo, "services/api/migrations/001_create.sql", "create table item(id int);\n")
         _write(repo, "Dockerfile", "FROM python:3.11-slim\nHEALTHCHECK CMD true\n")
         _write(repo, "compose.yaml", "services:\n  api:\n    build: .\n")
@@ -276,6 +281,35 @@ def test_non_github_ci_is_not_reported_as_ci_absent(tmp_path: Path) -> None:
         item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
     )
     assert not any(item.code == "DELIVERY.CI_ABSENT" for item in snapshot.findings)
+
+
+def test_ci_comments_do_not_become_security_test_or_rollback_controls(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(
+        repo,
+        ".github/workflows/ci.yml",
+        "name: empty\non: [push]\njobs: {}\n# test security rollback\n",
+    )
+    _write(repo, "Dockerfile", "# HEALTHCHECK CMD false\nFROM scratch\n")
+    _commit(repo, "comment-only CI claims")
+    snapshot = _scan(repo)
+    kinds = {item.kind for category in snapshot.inventory.values() for item in category.items}
+    assert "CI_TEST_MAPPING_SIGNAL" not in kinds
+    assert "SECURITY_CONTROL_SIGNAL" not in kinds
+    assert "ROLLBACK_SIGNAL" not in kinds
+    assert "HEALTH_CHECK" not in kinds
+    assert any(item.code == "SECURITY.CONTROL_EVIDENCE_ABSENT" for item in snapshot.findings)
+    assert any(item.code == "DELIVERY.ROLLBACK_EVIDENCE_ABSENT" for item in snapshot.findings)
+
+
+def test_malformed_openapi_is_blocked_and_never_emitted_as_api_evidence(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "openapi.yaml", "# not an OpenAPI declaration\n{}\n")
+    _commit(repo, "invalid API declaration")
+    snapshot = _scan(repo)
+    assert snapshot.disposition == "BLOCKED"
+    assert any(item.code == "INTERFACE.DECLARATION_INVALID" for item in snapshot.findings)
+    assert not any(item.kind == "OPENAPI" for item in snapshot.inventory["apis_data"].items)
 
 
 def test_tests_delivery_security_observability_and_governance_are_evidence_backed(
@@ -516,7 +550,13 @@ class _FakeRemote:
             "remote_branches": [{"name": "origin/feature", "sha": "a" * 40}],
             "pull_requests": [{"number": 7, "draft": True, "head": "a" * 40}],
             "issues": [{"number": 8, "state": "OPEN"}],
-            "governance": {"branch_protection": "UNKNOWN"},
+            "governance": {
+                "branch_protection": "UNKNOWN",
+                "database_note": (
+                    "DATABASE_URL=postgres://database-user:database-password@db.invalid/app"
+                    "?sslmode=require&token=query-secret"
+                ),
+            },
             "query_provenance": [
                 {
                     "query": "branches,pulls,issues,protection",
@@ -623,6 +663,10 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "secret-value" not in payload
     assert "unstructured-bare-secret" not in payload
     assert "glpat-0123456789abcdefghijkl" not in payload
+    assert "database-user" not in payload
+    assert "database-password" not in payload
+    assert "query-secret" not in payload
+    assert "[REDACTED_URL]" in payload
     assert "[REDACTED]" in payload
 
 
@@ -690,6 +734,49 @@ def test_governance_observation_disables_repository_fsmonitor_hook(tmp_path: Pat
     _git(repo, "config", "core.fsmonitor", str(hook))
     _observe(repo)
     assert not marker.exists()
+
+
+def test_governance_refuses_repository_content_filters_without_executing_them(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    marker = tmp_path / "content-filter-must-not-run"
+    _write(repo, ".gitattributes", "README.md filter=hostile\n")
+    _commit(repo, "content filter attributes")
+    _git(repo, "config", "filter.hostile.clean", f"touch {marker}; cat")
+    _write(repo, "README.md", "dirty content\n")
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_index = (repo / ".git" / "index").read_bytes()
+    with pytest.raises(api.RepositorySecurityError, match="content filters"):
+        _observe(repo)
+    assert not marker.exists()
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert (repo / ".git" / "index").read_bytes() == before_index
+    assert (repo / "README.md").read_text() == "dirty content\n"
+
+
+def test_bounded_git_termination_targets_the_isolated_process_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    governance = importlib.import_module("pmpe.repository.governance")
+    calls: list[tuple[int, signal.Signals]] = []
+
+    def record_group(pid: int, action: signal.Signals) -> None:
+        calls.append((pid, action))
+
+    class Process:
+        pid = 4242
+
+        def send_signal(self, _action: signal.Signals) -> None:
+            pytest.fail("process-only fallback must not be used when process groups are available")
+
+    monkeypatch.setattr(scanner.os, "killpg", record_group)
+    scanner._signal_process_group(Process(), signal.SIGTERM)
+    monkeypatch.setattr(governance.os, "killpg", record_group)
+    governance._signal_process_group(Process(), signal.SIGKILL)
+    assert calls == [(4242, signal.SIGTERM), (4242, signal.SIGKILL)]
 
 
 def test_invalid_governance_ref_is_rejected_before_git_comparison(tmp_path: Path) -> None:
@@ -812,7 +899,7 @@ def test_governance_cancellation_terminates_bounded_command_and_preserves_reposi
         id_provider=_FixedIds(),
         cancellation=CancelInsideCommand(),
     )
-    with pytest.raises(api.RepositoryIntelligenceError, match="failed"):
+    with pytest.raises(api.RepositoryIntelligenceError, match="cancelled"):
         collector.observe(repo, ref="main")
     assert _git(repo, "rev-parse", "HEAD") == before_head
     assert (repo / ".git" / "index").read_bytes() == before_index
@@ -825,7 +912,8 @@ def test_git_readers_disable_lazy_fetch_and_repository_defined_accelerators() ->
     assert scanner_environment["GIT_NO_LAZY_FETCH"] == "1"
     assert scanner_environment["GIT_CONFIG_VALUE_0"] == "false"
     governance_runner = governance.GovernanceCommandRunner()
-    assert governance_runner.identity.endswith("1.1.0")
+    assert scanner_environment["GIT_CONFIG_VALUE_5"] == "false"
+    assert governance_runner.identity.endswith("1.2.0")
 
 
 def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -7,6 +7,7 @@ import json
 import os
 import signal
 import subprocess
+import threading
 import time
 from dataclasses import asdict, replace
 from pathlib import Path
@@ -388,6 +389,30 @@ def test_database_privacy_and_observability_subcategories_are_explicit(
         item.path == "prometheus.yml" and item.kind == "OBSERVABILITY_CONFIG_SIGNAL"
         for item in snapshot.inventory["observability_operations"].items
     )
+
+
+def test_nested_package_manifests_create_explicit_architecture_boundaries(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "products/example/backend/pyproject.toml", "[project]\nname='backend'\n")
+    _write(repo, "products/example/frontend/package.json", '{"name":"frontend"}\n')
+    _write(repo, "products/example/e2e/package.json", '{"name":"e2e"}\n')
+    _commit(repo, "nested package boundaries")
+    snapshot = _scan(repo)
+    boundaries = {item.name: item for item in snapshot.boundary_candidates}
+    assert {
+        "products/example/backend",
+        "products/example/frontend",
+        "products/example/e2e",
+    } <= set(boundaries)
+    assert boundaries["products/example/backend"].evidence_paths == (
+        "products/example/backend/pyproject.toml",
+    )
+    assert boundaries["products/example/frontend"].evidence_paths == (
+        "products/example/frontend/package.json",
+    )
+    assert boundaries["products/example/backend"].confidence == "HIGH"
 
 
 def test_unhandled_required_subcategory_is_blocked_not_silently_absent(
@@ -801,18 +826,19 @@ def test_planted_credentials_never_appear_in_snapshot(tmp_path: Path) -> None:
     assert "redaction" in payload.lower()
 
 
-def test_redaction_failure_blocks_artifact_creation(tmp_path: Path) -> None:
+def test_redaction_failure_blocks_artifact_creation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     api = _api()
+    redaction = importlib.import_module("pmpe.repository.redaction")
     repo = _init_repo(tmp_path)
 
-    class BrokenRedactor:
-        version = "broken"
+    def unavailable(_self: Any, _value: Any) -> Any:
+        raise RuntimeError("redaction unavailable")
 
-        def sanitize(self, _value: Any) -> Any:
-            raise RuntimeError("redaction unavailable")
-
+    monkeypatch.setattr(redaction.EvidenceRedactor, "sanitize", unavailable)
     with pytest.raises(api.RepositorySecurityError, match="redaction"):
-        api.RepositoryScanner(config=_config(), redactor=BrokenRedactor()).scan(repo, commit="HEAD")
+        api.RepositoryScanner(config=_config()).scan(repo, commit="HEAD")
 
 
 @pytest.mark.parametrize("field", ["token", "signature", "sig"])
@@ -834,14 +860,12 @@ def test_sensitive_environment_value_is_redacted_under_benign_field() -> None:
     assert sanitized["message"] == "provider returned [REDACTED_ENV]"
 
 
-class _FixedClock:
-    def now(self) -> str:
-        return "2026-08-01T00:00:00Z"
+def _fixed_clock() -> Any:
+    return _api().RecordedUtcClock("2026-08-01T00:00:00Z")
 
 
-class _FixedIds:
-    def new_id(self) -> str:
-        return "OBS-000001"
+def _fixed_ids() -> Any:
+    return _api().RecordedObservationIds("OBS-000001")
 
 
 class _FakeRemote:
@@ -1068,8 +1092,8 @@ def _observe(repo: Path, remote: Any = None) -> Any:
     api = _api()
     return api.GovernanceCollector(
         repository="example/fixture",
-        clock=_FixedClock(),
-        id_provider=_FixedIds(),
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
         remote_provider=_sealed_remote(remote) if remote is not None else None,
     ).observe(repo, ref="main")
 
@@ -1169,8 +1193,8 @@ def test_arbitrary_remote_provider_is_rejected_before_it_can_mutate_repository(
     with pytest.raises(api.RepositorySecurityError, match="sealed data-only provider"):
         api.GovernanceCollector(
             repository="example/fixture",
-            clock=_FixedClock(),
-            id_provider=_FixedIds(),
+            clock=_fixed_clock(),
+            id_provider=_fixed_ids(),
             remote_provider=MutatingRemote(),
         )
     assert not marker.exists()
@@ -1180,6 +1204,67 @@ def test_recorded_remote_provider_cannot_be_replaced_with_instance_code() -> Non
     provider = _sealed_remote(_FakeRemote())
     with pytest.raises(AttributeError):
         provider.collect = lambda *_args, **_kwargs: {}  # type: ignore[method-assign]
+
+
+def test_unsealed_parent_collaborators_are_rejected_before_execution(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    marker = repo / "collaborator-mutation.txt"
+
+    class MutatingCollaborator:
+        identity = "untrusted"
+        version = "untrusted"
+
+        def _mutate(self) -> None:
+            marker.write_text("mutated")
+
+        def run(self, *_args: Any, **_kwargs: Any) -> Any:
+            self._mutate()
+            return None
+
+        def sanitize(self, value: Any) -> Any:
+            self._mutate()
+            return value
+
+        def cancelled(self) -> bool:
+            self._mutate()
+            return False
+
+        def now(self) -> str:
+            self._mutate()
+            return "2026-08-01T00:00:00Z"
+
+        def new_id(self) -> str:
+            self._mutate()
+            return "OBS-UNTRUSTED"
+
+    untrusted = MutatingCollaborator()
+    for argument in (
+        {"command_runner": untrusted},
+        {"redactor": untrusted},
+        {"cancellation": untrusted},
+    ):
+        with pytest.raises(api.RepositorySecurityError, match="sealed"):
+            api.RepositoryScanner(config=_config(), **argument)
+    governance_arguments = (
+        {"clock": untrusted, "id_provider": _fixed_ids()},
+        {"clock": _fixed_clock(), "id_provider": untrusted},
+        {
+            "clock": _fixed_clock(),
+            "id_provider": _fixed_ids(),
+            "command_runner": untrusted,
+        },
+        {"clock": _fixed_clock(), "id_provider": _fixed_ids(), "redactor": untrusted},
+        {
+            "clock": _fixed_clock(),
+            "id_provider": _fixed_ids(),
+            "cancellation": untrusted,
+        },
+    )
+    for arguments in governance_arguments:
+        with pytest.raises(api.RepositorySecurityError, match="sealed"):
+            api.GovernanceCollector(repository="example/fixture", **arguments)
+    assert not marker.exists()
 
 
 def test_unproven_remote_pagination_is_blocked_not_complete(tmp_path: Path) -> None:
@@ -1220,8 +1305,8 @@ def test_remote_provider_timeout_is_bounded_and_visible(tmp_path: Path) -> None:
     started = time.monotonic()
     observation = api.GovernanceCollector(
         repository="example/fixture",
-        clock=_FixedClock(),
-        id_provider=_FixedIds(),
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
         remote_provider=_sealed_remote(_HangingRemote()),
         command_timeout_seconds=1,
     ).observe(repo, ref="main")
@@ -1234,8 +1319,8 @@ def test_remote_numeric_payload_cannot_bypass_parent_byte_bound(tmp_path: Path) 
     api = _api()
     observation = api.GovernanceCollector(
         repository="example/fixture",
-        clock=_FixedClock(),
-        id_provider=_FixedIds(),
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
         remote_provider=_sealed_remote(_HugeNumericRemote()),
         max_output_bytes=2_048,
     ).observe(_init_repo(tmp_path), ref="main")
@@ -1264,25 +1349,22 @@ def test_remote_identity_mismatch_or_duplicate_inventory_fails_closed(
 
 def test_remote_provider_cancellation_terminates_the_isolated_process() -> None:
     api = _api()
-
-    class CancelSoon:
-        def __init__(self) -> None:
-            self.started = time.monotonic()
-
-        def cancelled(self) -> bool:
-            return time.monotonic() - self.started > 0.2
+    cancellation = api.CancellationSignal()
+    timer = threading.Timer(0.2, cancellation.cancel)
+    timer.start()
 
     collector = api.GovernanceCollector(
         repository="example/fixture",
-        clock=_FixedClock(),
-        id_provider=_FixedIds(),
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
         remote_provider=_sealed_remote(_HangingRemote()),
         command_timeout_seconds=10,
-        cancellation=CancelSoon(),
+        cancellation=cancellation,
     )
     started = time.monotonic()
     with pytest.raises(api.RepositoryIntelligenceError, match="cancelled"):
         collector._collect_remote_bounded("main")
+    timer.join(timeout=1)
     assert time.monotonic() - started < 4
 
 
@@ -1312,8 +1394,8 @@ def test_observation_input_digest_binds_freshness_and_collector_budgets(tmp_path
     def observe(max_age: int) -> Any:
         return api.GovernanceCollector(
             repository="example/fixture",
-            clock=_FixedClock(),
-            id_provider=_FixedIds(),
+            clock=_fixed_clock(),
+            id_provider=_fixed_ids(),
             remote_provider=_sealed_remote(_AgeSensitiveRemote()),
             max_remote_age_seconds=max_age,
         ).observe(repo, ref="main")
@@ -1435,8 +1517,8 @@ def test_invalid_governance_ref_is_rejected_before_git_comparison(tmp_path: Path
     with pytest.raises(api.RepositorySecurityError, match="ref"):
         api.GovernanceCollector(
             repository="example/fixture",
-            clock=_FixedClock(),
-            id_provider=_FixedIds(),
+            clock=_fixed_clock(),
+            id_provider=_fixed_ids(),
         ).observe(repo, ref="--output=outside")
 
 
@@ -1449,36 +1531,55 @@ def test_scanner_does_not_execute_tracked_project_code(tmp_path: Path) -> None:
     assert not marker.exists()
 
 
-class _MissingGitRunner:
-    identity = "missing-git"
-
-    def run(self, _args: tuple[str, ...], _cwd: Path, _timeout: int) -> Any:
-        raise FileNotFoundError("git is not installed")
-
-
-class _TimeoutRunner:
-    identity = "timeout-git"
-
-    def run(self, args: tuple[str, ...], _cwd: Path, _timeout: int) -> Any:
-        return _api().CommandResult(args=args, returncode=124, stdout="", stderr="", timed_out=True)
-
-
-class _MalformedRunner:
-    identity = "malformed-git"
-
-    def run(self, args: tuple[str, ...], _cwd: Path, _timeout: int) -> Any:
-        return _api().CommandResult(args=args, returncode=0, stdout="not-a-sha\n", stderr="")
-
-
-@pytest.mark.parametrize("runner", [_MissingGitRunner(), _TimeoutRunner(), _MalformedRunner()])
-def test_missing_git_timeout_or_malformed_output_fails_closed(
-    tmp_path: Path,
-    runner: Any,
-) -> None:
+def test_missing_git_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     api = _api()
     repo = _init_repo(tmp_path)
+    empty_path = tmp_path / "empty-path"
+    empty_path.mkdir()
+    monkeypatch.setenv("PATH", str(empty_path))
     with pytest.raises(api.RepositoryIntelligenceError):
-        api.RepositoryScanner(config=_config(), command_runner=runner).scan(repo, commit="HEAD")
+        api.RepositoryScanner(config=_config()).scan(repo, commit="HEAD")
+
+
+def test_git_timeout_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    fake_bin = tmp_path / "timeout-bin"
+    fake_bin.mkdir()
+    fake_git = fake_bin / "git"
+    fake_git.write_text("#!/bin/sh\nsleep 30\n")
+    fake_git.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
+    with pytest.raises(api.RepositoryIntelligenceError, match="timed out"):
+        api.RepositoryScanner(config=_config(command_timeout_seconds=1)).scan(repo, commit="HEAD")
+
+
+def test_malformed_git_output_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    api = _api()
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    repo = _init_repo(tmp_path)
+    original = scanner.SubprocessCommandRunner.run
+
+    def malformed(
+        self: Any,
+        args: tuple[str, ...],
+        cwd: Path,
+        timeout: int,
+        *,
+        cancellation: Any = None,
+    ) -> Any:
+        if args[1] == "rev-parse" and "--show-object-format" in args:
+            return api.CommandResult(
+                args=args,
+                returncode=0,
+                stdout="not-a-sha\n",
+                stderr="",
+            )
+        return original(self, args, cwd, timeout, cancellation=cancellation)
+
+    monkeypatch.setattr(scanner.SubprocessCommandRunner, "run", malformed)
+    with pytest.raises(api.RepositoryIntelligenceError):
+        api.RepositoryScanner(config=_config()).scan(repo, commit="HEAD")
 
 
 def test_invalid_repository_fails_closed(tmp_path: Path) -> None:
@@ -1490,12 +1591,9 @@ def test_invalid_repository_fails_closed(tmp_path: Path) -> None:
 def test_cancellation_is_visible_and_never_silently_partial(tmp_path: Path) -> None:
     api = _api()
     repo = _init_repo(tmp_path)
-
-    class Cancelled:
-        def cancelled(self) -> bool:
-            return True
-
-    snapshot = api.RepositoryScanner(config=_config(), cancellation=Cancelled()).scan(
+    cancellation = api.CancellationSignal()
+    cancellation.cancel()
+    snapshot = api.RepositoryScanner(config=_config(), cancellation=cancellation).scan(
         repo, commit="HEAD"
     )
     assert snapshot.disposition == "BLOCKED"
@@ -1511,14 +1609,8 @@ def test_cancellation_terminates_bounded_enumeration_and_preserves_repository(
     before_index = (repo / ".git" / "index").read_bytes()
     before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
 
-    class CancelDuringTree:
-        calls = 0
-
-        def cancelled(self) -> bool:
-            self.calls += 1
-            return self.calls > 1
-
-    snapshot = api.RepositoryScanner(config=_config(), cancellation=CancelDuringTree()).scan(
+    cancellation = api.CancellationSignal(cancel_after_checks=2)
+    snapshot = api.RepositoryScanner(config=_config(), cancellation=cancellation).scan(
         repo, commit="HEAD"
     )
     assert snapshot.disposition == "BLOCKED"
@@ -1546,17 +1638,22 @@ def test_cancellation_terminates_an_ordinary_bounded_git_command(
     fake_git.chmod(0o755)
     monkeypatch.setenv("PATH", f"{fake_bin}:/usr/bin:/bin")
 
-    class CancelSoon:
-        def __init__(self) -> None:
-            self.started = time.monotonic()
+    cancellation = _api().CancellationSignal()
 
-        def cancelled(self) -> bool:
-            return child_pid_path.exists() and time.monotonic() - self.started > 0.2
+    def cancel_after_start() -> None:
+        deadline = time.monotonic() + 2
+        while not child_pid_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        time.sleep(0.2)
+        cancellation.cancel()
 
+    cancellation_thread = threading.Thread(target=cancel_after_start, daemon=True)
+    cancellation_thread.start()
     started = time.monotonic()
     result = scanner.SubprocessCommandRunner().run(
-        ("git", "version"), tmp_path, 10, cancellation=CancelSoon()
+        ("git", "version"), tmp_path, 10, cancellation=cancellation
     )
+    cancellation_thread.join(timeout=1)
     assert time.monotonic() - started < 4
     assert result.returncode == 126
     assert result.timed_out is False
@@ -1581,13 +1678,9 @@ def test_cancellation_during_adapter_blocks_snapshot_finalization(
     before_head = _git(repo, "rev-parse", "HEAD")
     before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
 
-    class CancellationAfterAdapter:
-        started = time.monotonic()
-
-        def cancelled(self) -> bool:
-            return time.monotonic() - self.started > 0.2
-
-    cancellation = CancellationAfterAdapter()
+    cancellation = api.CancellationSignal()
+    timer = threading.Timer(0.2, cancellation.cancel)
+    timer.start()
 
     def hanging_worker(_connection: Any, _adapter: Any, _context: Any) -> None:
         os.setsid()
@@ -1598,6 +1691,7 @@ def test_cancellation_during_adapter_blocks_snapshot_finalization(
         config=_config(),
         cancellation=cancellation,
     ).scan(repo, commit="HEAD")
+    timer.join(timeout=1)
     assert snapshot.disposition == "BLOCKED"
     assert any(item.code == "SCAN.CANCELLED" and item.blocking for item in snapshot.findings)
     assert _git(repo, "rev-parse", "HEAD") == before_head
@@ -1612,18 +1706,11 @@ def test_governance_cancellation_terminates_bounded_command_and_preserves_reposi
     before_head = _git(repo, "rev-parse", "HEAD")
     before_index = (repo / ".git" / "index").read_bytes()
 
-    class CancelInsideCommand:
-        calls = 0
-
-        def cancelled(self) -> bool:
-            self.calls += 1
-            return self.calls > 1
-
     collector = api.GovernanceCollector(
         repository="example/fixture",
-        clock=_FixedClock(),
-        id_provider=_FixedIds(),
-        cancellation=CancelInsideCommand(),
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
+        cancellation=api.CancellationSignal(cancel_after_checks=2),
     )
     with pytest.raises(api.RepositoryIntelligenceError, match="cancelled"):
         collector.observe(repo, ref="main")
@@ -1666,15 +1753,15 @@ def test_digest_bearing_artifacts_are_self_verified_before_reuse(tmp_path: Path)
         api.GovernanceCollector(
             repository="example/fixture",
             snapshot=tampered_snapshot,
-            clock=_FixedClock(),
-            id_provider=_FixedIds(),
+            clock=_fixed_clock(),
+            id_provider=_fixed_ids(),
         )
 
     observation = api.GovernanceCollector(
         repository="example/fixture",
         snapshot=snapshot,
-        clock=_FixedClock(),
-        id_provider=_FixedIds(),
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
     ).observe(repo, ref="main")
     tampered_observation = replace(observation, disposition="COMPLETE")
     assert tampered_observation.digest_is_valid() is False
@@ -1691,8 +1778,8 @@ def test_snapshot_and_observation_references_form_a_narrow_lifecycle_seam(
     observation = api.GovernanceCollector(
         repository="example/fixture",
         snapshot=snapshot,
-        clock=_FixedClock(),
-        id_provider=_FixedIds(),
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
     ).observe(repo, ref="main")
     reference = snapshot.assessment_reference(observation)
     assert reference == {
@@ -1712,8 +1799,8 @@ def test_snapshot_rejects_governance_observation_from_another_repository(
     snapshot = _scan(_init_repo(tmp_path))
     observation = api.GovernanceCollector(
         repository="different/repository",
-        clock=_FixedClock(),
-        id_provider=_FixedIds(),
+        clock=_fixed_clock(),
+        id_provider=_fixed_ids(),
     ).observe(tmp_path / "fixture-repo", ref="main")
     with pytest.raises(ValueError, match="repositories do not match"):
         snapshot.assessment_reference(observation)

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -367,6 +367,44 @@ def test_api_data_generated_client_migration_and_contract_sync_are_inventory_ite
     )
 
 
+def test_database_privacy_and_observability_subcategories_are_explicit(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "schema.sql", "create table item(id integer);\n")
+    _write(repo, "privacy.yaml", "retention_days: 30\n")
+    _write(repo, "prometheus.yml", "scrape_configs: []\n")
+    _commit(repo, "required audit subcategories")
+    snapshot = _scan(repo)
+    assert any(
+        item.path == "schema.sql" and item.kind == "DATABASE_SCHEMA_SIGNAL"
+        for item in snapshot.inventory["apis_data"].items
+    )
+    assert any(
+        item.path == "privacy.yaml" and item.kind == "PRIVACY_CONTROL_SIGNAL"
+        for item in snapshot.inventory["security_privacy"].items
+    )
+    assert any(
+        item.path == "prometheus.yml" and item.kind == "OBSERVABILITY_CONFIG_SIGNAL"
+        for item in snapshot.inventory["observability_operations"].items
+    )
+
+
+def test_unhandled_required_subcategory_is_blocked_not_silently_absent(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "data-model.yaml", "entities: []\n")
+    _commit(repo, "unhandled data declaration")
+    snapshot = _scan(repo)
+    assert snapshot.disposition == "BLOCKED"
+    assert snapshot.inventory["apis_data"].status == "BLOCKED"
+    assert any(
+        item.code == "AUDIT.UNSUPPORTED_SUBCATEGORY" and "data-model.yaml" in item.evidence_refs
+        for item in snapshot.findings
+    )
+
+
 def test_integration_declarations_and_codeowners_are_evidence_backed(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     _write(
@@ -996,13 +1034,43 @@ class _ExtraFieldRemote(_FakeRemote):
         return payload
 
 
+class _ExtraNestedFieldRemote(_FakeRemote):
+    def collect(self, repository: str, ref: str, **bounds: Any) -> dict[str, Any]:
+        payload = super().collect(repository, ref, **bounds)
+        payload["query_provenance"][0]["truncated"] = True
+        return payload
+
+
+def _sealed_remote(remote: Any) -> Any:
+    api = _api()
+    bounds = {
+        "timeout_seconds": 30,
+        "max_output_bytes": 8_000_000,
+        "max_items": 20_000,
+        "cancellation": None,
+    }
+    delay_seconds = 30.0 if isinstance(remote, _HangingRemote) else 0.0
+    permission_denied = isinstance(remote, _DeniedRemote)
+    payload = (
+        _FakeRemote().collect("example/fixture", "main", **bounds)
+        if delay_seconds or permission_denied
+        else remote.collect("example/fixture", "main", **bounds)
+    )
+    return api.RecordedRemoteProvider(
+        payload,
+        api_version=remote.api_version,
+        delay_seconds=delay_seconds,
+        permission_denied=permission_denied,
+    )
+
+
 def _observe(repo: Path, remote: Any = None) -> Any:
     api = _api()
     return api.GovernanceCollector(
         repository="example/fixture",
         clock=_FixedClock(),
         id_provider=_FixedIds(),
-        remote_provider=remote,
+        remote_provider=_sealed_remote(remote) if remote is not None else None,
     ).observe(repo, ref="main")
 
 
@@ -1058,7 +1126,7 @@ def test_branch_divergence_and_additional_worktrees_are_mutable_observations(
 def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path: Path) -> None:
     observation = _observe(_init_repo(tmp_path), _FakeRemote())
     payload = observation.canonical_bytes().decode()
-    assert observation.tool_identity == "fake-github-readonly/1.0"
+    assert observation.tool_identity == "recorded-remote-payload/1.0.0"
     assert observation.api_query_version == "github-rest/2026-03-10"
     assert observation.query_provenance[0].surface == "remote_branches"
     assert observation.query_provenance[0].cursor == "branches-page-1"
@@ -1081,6 +1149,37 @@ def test_remote_metadata_records_tool_query_cursor_and_redacts_secrets(tmp_path:
     assert "pass-json-secret" not in payload
     assert "[REDACTED_URL]" in payload
     assert "[REDACTED]" in payload
+
+
+def test_arbitrary_remote_provider_is_rejected_before_it_can_mutate_repository(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    marker = repo / "remote-provider-mutation.txt"
+
+    class MutatingRemote:
+        tool_identity = "untrusted"
+        api_version = "untrusted"
+
+        def collect(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            marker.write_text("mutated")
+            return {}
+
+    with pytest.raises(api.RepositorySecurityError, match="sealed data-only provider"):
+        api.GovernanceCollector(
+            repository="example/fixture",
+            clock=_FixedClock(),
+            id_provider=_FixedIds(),
+            remote_provider=MutatingRemote(),
+        )
+    assert not marker.exists()
+
+
+def test_recorded_remote_provider_cannot_be_replaced_with_instance_code() -> None:
+    provider = _sealed_remote(_FakeRemote())
+    with pytest.raises(AttributeError):
+        provider.collect = lambda *_args, **_kwargs: {}  # type: ignore[method-assign]
 
 
 def test_unproven_remote_pagination_is_blocked_not_complete(tmp_path: Path) -> None:
@@ -1123,7 +1222,7 @@ def test_remote_provider_timeout_is_bounded_and_visible(tmp_path: Path) -> None:
         repository="example/fixture",
         clock=_FixedClock(),
         id_provider=_FixedIds(),
-        remote_provider=_HangingRemote(),
+        remote_provider=_sealed_remote(_HangingRemote()),
         command_timeout_seconds=1,
     ).observe(repo, ref="main")
     assert time.monotonic() - started < 4
@@ -1137,7 +1236,7 @@ def test_remote_numeric_payload_cannot_bypass_parent_byte_bound(tmp_path: Path) 
         repository="example/fixture",
         clock=_FixedClock(),
         id_provider=_FixedIds(),
-        remote_provider=_HugeNumericRemote(),
+        remote_provider=_sealed_remote(_HugeNumericRemote()),
         max_output_bytes=2_048,
     ).observe(_init_repo(tmp_path), ref="main")
     assert observation.disposition == "BLOCKED"
@@ -1152,6 +1251,7 @@ def test_remote_numeric_payload_cannot_bypass_parent_byte_bound(tmp_path: Path) 
         _DuplicateRemote(),
         _CoerciblePrimitiveRemote(),
         _ExtraFieldRemote(),
+        _ExtraNestedFieldRemote(),
     ],
 )
 def test_remote_identity_mismatch_or_duplicate_inventory_fails_closed(
@@ -1176,7 +1276,7 @@ def test_remote_provider_cancellation_terminates_the_isolated_process() -> None:
         repository="example/fixture",
         clock=_FixedClock(),
         id_provider=_FixedIds(),
-        remote_provider=_HangingRemote(),
+        remote_provider=_sealed_remote(_HangingRemote()),
         command_timeout_seconds=10,
         cancellation=CancelSoon(),
     )
@@ -1214,7 +1314,7 @@ def test_observation_input_digest_binds_freshness_and_collector_budgets(tmp_path
             repository="example/fixture",
             clock=_FixedClock(),
             id_provider=_FixedIds(),
-            remote_provider=_AgeSensitiveRemote(),
+            remote_provider=_sealed_remote(_AgeSensitiveRemote()),
             max_remote_age_seconds=max_age,
         ).observe(repo, ref="main")
 
@@ -1554,6 +1654,32 @@ def test_artifact_maps_cannot_be_mutated_after_digest_binding(tmp_path: Path) ->
         observation.governance["branch_protection"] = "changed"  # type: ignore[index]
     assert snapshot.snapshot_digest in snapshot.canonical_bytes().decode()
     assert observation.observation_output_digest in observation.canonical_bytes().decode()
+
+
+def test_digest_bearing_artifacts_are_self_verified_before_reuse(tmp_path: Path) -> None:
+    api = _api()
+    repo = _init_repo(tmp_path)
+    snapshot = _scan(repo)
+    tampered_snapshot = replace(snapshot, scanner_version="tampered")
+    assert tampered_snapshot.digest_is_valid() is False
+    with pytest.raises(api.RepositorySecurityError, match="snapshot digest"):
+        api.GovernanceCollector(
+            repository="example/fixture",
+            snapshot=tampered_snapshot,
+            clock=_FixedClock(),
+            id_provider=_FixedIds(),
+        )
+
+    observation = api.GovernanceCollector(
+        repository="example/fixture",
+        snapshot=snapshot,
+        clock=_FixedClock(),
+        id_provider=_FixedIds(),
+    ).observe(repo, ref="main")
+    tampered_observation = replace(observation, disposition="COMPLETE")
+    assert tampered_observation.digest_is_valid() is False
+    with pytest.raises(ValueError, match="observation digest"):
+        snapshot.assessment_reference(tampered_observation)
 
 
 def test_snapshot_and_observation_references_form_a_narrow_lifecycle_seam(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -644,7 +644,8 @@ def test_governance_digest_rejects_in_place_module_attribute_before_use(
     governance = importlib.import_module("pmpe.repository.governance")
     attributes = dict(governance._SEALED_GOVERNANCE_MODULE_ATTRIBUTE_NAMES)
     assert "uuid4" in attributes["uuid"]
-    assert "_sealed_multiprocessing_context" in governance._SEALED_GOVERNANCE_EXTERNAL_GLOBAL_NAMES
+    for helper_name in ("_sealed_fork_event", "_sealed_fork_pipe", "_sealed_fork_process"):
+        assert helper_name in governance._SEALED_GOVERNANCE_EXTERNAL_GLOBAL_NAMES
     callback_ran = False
     original_uuid4 = governance.uuid.uuid4
 

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -364,9 +364,16 @@ def test_implementation_digest_binds_loaded_runtime_code_and_source_identity(
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(yaml_module, "safe_load", lambda value: value)
         assert scanner._implementation_digest() != original
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(yaml_module, "load", lambda value, **_kwargs: value)
+        assert scanner._implementation_digest() != original
     rfc8785_module = importlib.import_module("rfc8785")
     with monkeypatch.context() as runtime_patch:
         runtime_patch.setattr(rfc8785_module, "dumps", lambda value: b"changed")
+        assert scanner._implementation_digest() != original
+    rfc8785_impl = importlib.import_module("rfc8785._impl")
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(rfc8785_impl, "_serialize_str", lambda value, sink: None)
         assert scanner._implementation_digest() != original
     runtime_digest = scanner._module_runtime_digest("repository.scanner")
     with monkeypatch.context() as runtime_patch:
@@ -1071,6 +1078,31 @@ def test_unproven_github_relationships_and_scopes_are_not_verified(
         item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
     )
     assert any(item.code == "WORKFLOW.STRUCTURE_UNPROVEN" for item in snapshot.findings)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "yes: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+        "on: [push]\njobs:\n  ignored: {}\njobs:\n  test:\n"
+        "    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n",
+    ],
+)
+def test_ambiguous_or_duplicate_github_workflow_keys_are_not_verified(
+    tmp_path: Path,
+    content: str,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, ".github/workflows/ci.yml", content)
+    _commit(repo, "ambiguous github workflow")
+    snapshot = _scan(repo)
+    assert not any(
+        item.kind == "CI_WORKFLOW" for item in snapshot.inventory["delivery_environments"].items
+    )
+    assert any(
+        item.code in {"WORKFLOW.MALFORMED", "WORKFLOW.STRUCTURE_UNPROVEN"}
+        for item in snapshot.findings
+    )
 
 
 def test_supported_github_needs_graph_and_matrix_objects_are_verified(tmp_path: Path) -> None:
@@ -2592,6 +2624,26 @@ def test_recorded_remote_provider_checks_cancellation_before_deserialization(
             max_items=100,
             cancellation=cancellation,
         )
+
+
+def test_recorded_remote_provider_is_immutable_and_self_verifying() -> None:
+    api = _api()
+    provider = api.RecordedRemoteProvider({"safe": True}, api_version="fixture/1")
+    original_provenance = provider.collection_provenance
+
+    for attribute, value in (
+        ("_payload", b'{"changed":true}'),
+        ("_collection_provenance", {}),
+        ("api_version", "fixture/2"),
+    ):
+        with pytest.raises(AttributeError, match="immutable"):
+            setattr(provider, attribute, value)
+
+    assert provider.collection_provenance == original_provenance
+
+    object.__setattr__(provider, "_payload", b'{"changed":true}')
+    with pytest.raises(api.RepositorySecurityError, match="provenance integrity"):
+        _ = provider.collection_provenance
 
 
 def test_unsealed_parent_collaborators_are_rejected_before_execution(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #64

## Outcome

Adds deterministic, read-only repository intelligence that gives later PEOS lifecycle stages exact-SHA repository evidence without confusing mutable governance facts with commit-stable truth.

## Problem

The existing `EngineeringRun.record_assessment` seam accepts an arbitrary summary and the repository had no canonical scanner, adapter registry, evidence model, or safe mutable-governance observation. Later architecture work therefore lacked a trusted repository input.

## Scope

- `RepositorySnapshot` over immutable Git objects at one resolved commit;
- separate, time-bound `GovernanceObservation` for worktree, index, branches, worktrees, PRs, issues, and governance metadata;
- versioned Python, Node/web, Docker/Compose, GitHub Actions, schema/API, topology, and PMPE adapters;
- all Phase 0 audit categories represented as observed, not observed, partial, unsupported, or blocked;
- digest-bound file, detector, adapter, command, configuration, tree, tooling, snapshot, and observation provenance;
- centralized fail-closed redaction;
- bounded scans, symlink containment, binary handling, cancellation, and visible partial results;
- narrow `pmpe repository scan` CLI and lifecycle assessment-reference seam.

## Non-goals

- no architecture generation or recommendation;
- no implementation or test-plan generation for the scanned repository;
- no project-code execution;
- no production-service access;
- no remote mutation;
- no replacement of the legacy assessment path yet.

## Decisions and trade-offs

- Exact snapshots read commit/tree/blob objects only. Dirty state and remote governance are intentionally excluded.
- Remote observations require an injected read-only provider; unavailable facts remain explicit rather than inferred.
- Heuristic boundary and risk signals carry confidence and are not promoted to proven defects.
- Unknown ecosystems, containment failures, unreadable objects, and redaction failures fail closed.
- Artifact outputs must be outside the scanned repository, preserving the scan's read-only guarantee.

## RED evidence

- RED commit: `87cef479d0271e5ac8b3e2cc4daac952d3a5052d`
- 41 tests collected before implementation.
- Expected first failure: `issue #64 repository-intelligence API is not implemented`.
- No implementation file existed in the RED commit.

## Implementation sequence

- GREEN implementation: `86f6db6aab487e00b8edddb0dbe6836fe7a01c59`
- evidence-classification hardening: `97484db48e0d89b007a25185b32c1f8204cac215`
- published history was not amended, rebased, squashed, or force-pushed.

## Acceptance and test evidence

- 44 focused issue #64 unit/integration/E2E cases pass.
- 387 issue #62/#76/#63 schema, intake/compiler, and semantic-validation cases pass.
- full repository collection: 946 tests; 945 pass locally under Python 3.14, with one pre-existing macOS-only `/tmp` versus `/private/tmp` path-normalization assertion. Generated socket tests pass when run with loopback permission. Supported Linux 3.11/3.12 CI remains authoritative.
- Ruff 0.16.1 format and lint: pass.
- strict MyPy over all 115 source files: pass.
- Bandit high-severity scan: pass.
- project dependency audit: no known vulnerabilities.
- backend strict types and Ruff: pass; backend locked dependency audit: no known vulnerabilities. One Python 3.14-only deep-JSON diagnostic wording assertion remains outside the supported 3.11 CI runtime and outside this diff.
- wheel build and package inventory include all repository-intelligence modules and CLI.
- `git diff --check`: pass.
- secret-shape scan: only deliberate planted redaction fixtures and detector patterns; no credential introduced.
- frontend path simulation: `NOT APPLICABLE — no frontend-affecting paths changed`.
- exact `origin/main` dry scan: complete, byte-canonical, and left the dirty worktree unchanged.

## Security, privacy, and risks

- commands are subprocess-list invocations from explicit read-only Git allowlists; no shell or project code is executed;
- global/system Git configuration and prompting are disabled for scans, preventing credential-helper access;
- paths are repository-relative, symlink escapes are refused, and outputs inside the scanned repository are refused;
- evidence is sanitized before artifact construction; a redactor failure prevents artifact creation;
- secrets, raw credential output, production data, and environment-secret values are not collected;
- mutable observations are explicitly labeled time-bound and reproducible only from recorded inputs;
- stack and risk detections can be incomplete by design, but omissions become visible partial/unsupported findings rather than silent success.

## Rollback

Revert this PR's merge commit. The new API and CLI are additive; the existing engineering assessment path is not replaced, and no stored repository or production state is migrated.

## Evidence and review

The frozen candidate is `97484db48e0d89b007a25185b32c1f8204cac215`. A fresh read-only complete-diff review will be recorded against the exact remote head. Model review is advisory evidence under the solo-maintainer policy, not independent human approval.

## Deferred work

Architecture compilation remains issue #66. Documentation issue #77 may proceed after this merge. Neither is part of this PR.
