### PR TITLE
Fix repository intelligence edge cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,25 +256,18 @@ jobs:
 
   build-smoke:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: build wheel
         run: |
           pip install build
-          PYTHONPATH=src python -c "import pmpe.repository.scanner as scanner; assert scanner._implementation_digest().startswith('sha256:')"
           python -m build --wheel
       - name: install wheel and smoke the CLI
         run: |
           pip install dist/*.whl ruff
-          cd /tmp
-          python -I -c "import pmpe.repository.scanner as scanner; assert scanner._implementation_digest().startswith('sha256:')"
-          cd "$GITHUB_WORKSPACE"
           pmpe validate examples/taskflow_mvp_spec.yaml
           pmpe contract validate examples/v2-demo/contract.json
       - name: full pipeline smoke (golden spec)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,18 +256,25 @@ jobs:
 
   build-smoke:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
       - name: build wheel
         run: |
           pip install build
+          PYTHONPATH=src python -c "import pmpe.repository.scanner as scanner; assert scanner._implementation_digest().startswith('sha256:')"
           python -m build --wheel
       - name: install wheel and smoke the CLI
         run: |
           pip install dist/*.whl ruff
+          cd /tmp
+          python -I -c "import pmpe.repository.scanner as scanner; assert scanner._implementation_digest().startswith('sha256:')"
+          cd "$GITHUB_WORKSPACE"
           pmpe validate examples/taskflow_mvp_spec.yaml
           pmpe contract validate examples/v2-demo/contract.json
       - name: full pipeline smoke (golden spec)

--- a/.github/workflows/repository-intelligence-wheel.yml
+++ b/.github/workflows/repository-intelligence-wheel.yml
@@ -1,0 +1,37 @@
+name: Repository Intelligence Distribution
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/repository-intelligence-wheel.yml"
+      - "pyproject.toml"
+      - "src/pmpe/cli/repository_cmd.py"
+      - "src/pmpe/repository/**"
+
+permissions:
+  contents: read
+
+jobs:
+  imports:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install source-tree runtime dependencies
+        run: pip install build .
+      - name: source-tree import and provenance smoke
+        run: |
+          PYTHONPATH=src python -c "import pmpe.repository.scanner as scanner; assert scanner._implementation_digest().startswith('sha256:')"
+      - name: build and install wheel
+        run: |
+          python -m build --wheel
+          pip install --force-reinstall dist/*.whl
+      - name: installed-wheel import and provenance smoke
+        working-directory: /tmp
+        run: |
+          python -I -c "import pmpe.repository.scanner as scanner; assert scanner._implementation_digest().startswith('sha256:')"

--- a/src/pmpe/cli/repository_cmd.py
+++ b/src/pmpe/cli/repository_cmd.py
@@ -245,11 +245,14 @@ def _cmd_scan(args: argparse.Namespace) -> int:
         observation = None
         if governance_path is not None:
             clock = RecordedUtcClock(args.observed_at) if args.observed_at else None
-            ids = RecordedObservationIds(args.observation_id) if args.observation_id else None
+            try:
+                ids = RecordedObservationIds(args.observation_id) if args.observation_id else None
+            except ValueError as exc:
+                raise RepositoryIntelligenceError(str(exc)) from exc
             observation = observe_governance(
                 requested,
                 repository=args.repository,
-                ref=args.default_branch or args.commit,
+                ref=snapshot.commit_sha,
                 snapshot=snapshot,
                 clock=clock,
                 id_provider=ids,

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -1696,7 +1696,7 @@ class GovernanceCollector:
                 full_ref, sha = line.rsplit(" ", 1)
             except ValueError as exc:
                 raise RepositoryIntelligenceError("local branch output is malformed") from exc
-            if not _valid_branch_ref(full_ref):
+            if not full_ref.startswith("refs/heads/") or full_ref == "refs/heads/":
                 raise RepositoryIntelligenceError("local branch reference is malformed")
             name = full_ref.removeprefix("refs/heads/")
             ahead = behind = 0

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -61,7 +61,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.17.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.18.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -1707,7 +1707,7 @@ class GovernanceCollector:
                     "rev-list",
                     "--left-right",
                     "--count",
-                    f"{reference_commit}...{name}",
+                    f"{reference_commit}...refs/heads/{name}",
                 ),
             )
             if comparison.returncode == 0 and not comparison.timed_out:

--- a/src/pmpe/repository/governance.py
+++ b/src/pmpe/repository/governance.py
@@ -61,7 +61,7 @@ from pmpe.repository.scanner import (
     _wait_for_exit_without_reaping,
 )
 
-GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.18.0"
+GOVERNANCE_COLLECTOR_VERSION = "repository-governance/4.19.0"
 GOVERNANCE_IMPLEMENTATION_MODULES = (
     "repository.governance",
     "repository.models",
@@ -136,7 +136,7 @@ def _valid_branch_ref(value: str) -> bool:
     name = value.removeprefix(prefix)
     return (
         name != "HEAD"
-        and _valid_ref(name)
+        and (name == "@" or _valid_ref(name))
         and all(
             part and not part.startswith(".") and not part.endswith((".", ".lock"))
             for part in name.split("/")
@@ -1679,9 +1679,7 @@ class GovernanceCollector:
         return names
 
     def _branches(self, root: Path, reference_commit: str) -> tuple[BranchObservation, ...]:
-        raw = self._run(
-            root, "for-each-ref", "--format=%(refname:short) %(objectname)", "refs/heads"
-        )
+        raw = self._run(root, "for-each-ref", "--format=%(refname) %(objectname)", "refs/heads")
         branches: list[BranchObservation] = []
         lines = raw.splitlines()
         if len(lines) > self.max_branches:
@@ -1695,9 +1693,12 @@ class GovernanceCollector:
             lines = lines[: self.max_branches]
         for line in lines:
             try:
-                name, sha = line.rsplit(" ", 1)
+                full_ref, sha = line.rsplit(" ", 1)
             except ValueError as exc:
                 raise RepositoryIntelligenceError("local branch output is malformed") from exc
+            if not _valid_branch_ref(full_ref):
+                raise RepositoryIntelligenceError("local branch reference is malformed")
+            name = full_ref.removeprefix("refs/heads/")
             ahead = behind = 0
             status = "OBSERVED"
             comparison = self._execute(
@@ -1707,7 +1708,7 @@ class GovernanceCollector:
                     "rev-list",
                     "--left-right",
                     "--count",
-                    f"{reference_commit}...refs/heads/{name}",
+                    f"{reference_commit}...{full_ref}",
                 ),
             )
             if comparison.returncode == 0 and not comparison.timed_out:

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -65,7 +65,7 @@ from pmpe.repository.redaction import (
     assert_distinct_identities_preserved,
 )
 
-SCANNER_VERSION = "repository-scanner/2.22.0"
+SCANNER_VERSION = "repository-scanner/2.23.0"
 _MAX_SCAN_BUDGETS = {
     "max_files": 100_000,
     "max_directories": 50_000,
@@ -204,6 +204,7 @@ _RUNTIME_CONFIGURED_CALLABLE_ATTRIBUTES = MappingProxyType(
         ),
     }
 )
+_SEALED_MODULE_REGISTRY_PROCESS_IDENTITY = id(sys.modules)
 _OBJECT_FORMAT_LENGTH = {"sha1": 40, "sha256": 64}
 
 
@@ -430,7 +431,7 @@ class TreeListingResult:
 class SubprocessCommandRunner:
     """Allowlisted local Git reader; it never invokes shells or project code."""
 
-    identity = "git-readonly-subprocess/1.8.0"
+    identity = "git-readonly-subprocess/1.9.0"
     __slots__ = ()
     _allowed = {"rev-parse", "ls-tree", "cat-file", "version"}
 
@@ -467,6 +468,7 @@ class SubprocessCommandRunner:
         timeout: int,
         *,
         cancellation: Cancellation | None = None,
+        max_output_bytes: int = 8_000_000,
     ) -> CommandResult:
         if cancellation is not None and type(cancellation) is not CancellationSignal:
             raise RepositorySecurityError("Git cancellation requires the sealed signal")
@@ -497,7 +499,7 @@ class SubprocessCommandRunner:
                     if not chunk:
                         break
                     payload.extend(chunk)
-                    if len(payload) > 8_000_000:
+                    if len(payload) > max_output_bytes:
                         timed_out = True
                         break
         except BaseException:
@@ -729,9 +731,13 @@ def _runtime_code_evidence(target: Any) -> list[dict[str, Any]]:
     if inspect.ismethod(target):
         target = target.__func__
     if inspect.isfunction(target):
+        namespace_binding = _runtime_function_namespace_binding(target)
         return [
             {
                 "qualname": target.__qualname__,
+                "declared_module": target.__module__,
+                "global_namespace": target.__globals__["__name__"],
+                "global_namespace_binding": namespace_binding,
                 "code": _code_object_evidence(target.__code__),
                 "defaults": _stable_code_constant(target.__defaults__),
                 "keyword_defaults": _stable_code_constant(
@@ -778,6 +784,71 @@ def _runtime_code_evidence(target: Any) -> list[dict[str, Any]]:
     if callable(target):
         return _runtime_code_evidence(target.__class__)
     return []
+
+
+def _code_global_names(code: CodeType) -> tuple[str, ...]:
+    names = set(code.co_names)
+    for constant in code.co_consts:
+        if isinstance(constant, CodeType):
+            names.update(_code_global_names(constant))
+    return tuple(sorted(names))
+
+
+def _namespace_value(namespace: Mapping[str, Any], name: str) -> tuple[bool, Any]:
+    if name in namespace:
+        return True, namespace[name]
+    builtins_value = namespace.get("__builtins__")
+    if type(builtins_value) is ModuleType:
+        builtins_namespace: Mapping[str, Any] = vars(builtins_value)
+    elif type(builtins_value) is dict:
+        builtins_namespace = builtins_value
+    else:
+        builtins_namespace = {}
+    return (True, builtins_namespace[name]) if name in builtins_namespace else (False, None)
+
+
+def _runtime_function_namespace_binding(target: Any) -> str:
+    """Bind executable globals while allowing equivalent loader-created namespaces."""
+
+    module_registry = sys.modules
+    global_namespace_name = target.__globals__.get("__name__")
+    if (
+        type(module_registry) is not dict
+        or id(module_registry) != _SEALED_MODULE_REGISTRY_PROCESS_IDENTITY
+    ):
+        raise RepositorySecurityError("runtime module registry changed")
+    if not isinstance(global_namespace_name, str):
+        raise RepositorySecurityError("runtime function global namespace is unavailable")
+    defining_module = module_registry.get(global_namespace_name)
+    if type(defining_module) is ModuleType:
+        registered_namespace = vars(defining_module)
+        if target.__globals__ is registered_namespace:
+            return "registered-module"
+        for name in _code_global_names(target.__code__):
+            candidate_present, candidate = _namespace_value(target.__globals__, name)
+            registered_present, registered = _namespace_value(registered_namespace, name)
+            if candidate_present != registered_present or (
+                candidate_present and candidate is not registered
+            ):
+                raise RepositorySecurityError("runtime function global namespace changed")
+        return "registered-module-equivalent-globals"
+    if (
+        global_namespace_name.startswith("namedtuple_")
+        and target.__module__ == global_namespace_name
+        and set(target.__globals__) == {"__builtins__", "__name__", "_tuple_new"}
+    ):
+        return "stdlib-namedtuple-factory"
+    builtins_module = module_registry.get("builtins")
+    if type(builtins_module) is ModuleType:
+        builtins_namespace = vars(builtins_module)
+        for name in _code_global_names(target.__code__):
+            candidate_present, candidate = _namespace_value(target.__globals__, name)
+            builtin_present, builtin = _namespace_value(builtins_namespace, name)
+            if candidate_present and (not builtin_present or candidate is not builtin):
+                break
+        else:
+            return "isolated-builtin-only-namespace"
+    raise RepositorySecurityError("runtime function global namespace is unregistered")
 
 
 def _runtime_value_evidence(value: Any, *, depth: int = 0) -> Any:
@@ -1182,6 +1253,7 @@ def _implementation_module_evidence(
 ) -> list[dict[str, str]]:
     """Bind import-time source, current source, and loaded runtime code fail closed."""
 
+    _assert_digest_helper_sealed()
     evidence: list[dict[str, str]] = []
     try:
         for name in paths:
@@ -1207,6 +1279,7 @@ def _implementation_module_evidence(
 def _implementation_source_evidence(label: str, target: Any) -> dict[str, str]:
     """Bind an injected output-affecting implementation without persisting its state."""
 
+    _assert_digest_helper_sealed()
     implementation = target if inspect.isfunction(target) else target.__class__
     try:
         source_path_value = inspect.getsourcefile(implementation)
@@ -1434,6 +1507,23 @@ def _stop_isolated_process(process: Any) -> None:
 
 def _sha256(payload: bytes) -> str:
     return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+_SEALED_SHA256_PROCESS_IDENTITY = (
+    id(_sha256),
+    id(_sha256.__code__),
+    id(_sha256.__globals__),
+)
+
+
+def _assert_digest_helper_sealed() -> None:
+    current_hash = _sha256
+    if (
+        id(current_hash),
+        id(current_hash.__code__),
+        id(current_hash.__globals__),
+    ) != _SEALED_SHA256_PROCESS_IDENTITY:
+        raise RepositorySecurityError("scanner digest helper binding changed")
 
 
 def _text(value: str | bytes) -> str:
@@ -1682,7 +1772,7 @@ def _direct_imported_global_names(source_path: Path) -> tuple[str, ...]:
 
 
 def _external_global_binding_state_digest(names: tuple[str, ...]) -> str:
-    """Bind non-executable imported values; executable imports are identity-sealed."""
+    """Bind imported values and executable code to defining global namespaces."""
 
     evidence: list[dict[str, Any]] = []
     for name in names:
@@ -1692,17 +1782,21 @@ def _external_global_binding_state_digest(names: tuple[str, ...]) -> str:
         evidence.append(
             {
                 "binding": name,
-                "state": (
-                    {"guard": "identity"}
-                    if type(target) is ModuleType or callable(target)
-                    else _module_attribute_value_evidence("scanner-imported-global", name, target)
-                ),
+                "state": _module_attribute_value_evidence("scanner-imported-global", name, target),
             }
         )
     return canonical_digest(evidence)
 
 
-_MULTIPROCESSING_CONTEXT_MEMBER_NAMES = ("Event", "Pipe", "Process")
+_MULTIPROCESSING_CONTEXT_MEMBER_NAMES = (
+    "Condition",
+    "Event",
+    "Lock",
+    "Pipe",
+    "Process",
+    "Semaphore",
+    "get_context",
+)
 _MULTIPROCESSING_IMPLEMENTATION_MODULES = (
     multiprocessing,
     multiprocessing_connection,
@@ -1757,6 +1851,7 @@ def _multiprocessing_module_identities() -> tuple[tuple[str, int], ...]:
 
 def _multiprocessing_primitive_identities() -> tuple[tuple[str, int], ...]:
     return (
+        ("multiprocessing.get_context", id(multiprocessing.get_context)),
         ("connection.Pipe", id(multiprocessing_connection.Pipe)),
         ("context.ForkProcess", id(multiprocessing_context.ForkProcess)),
         ("synchronize.Event", id(multiprocessing_synchronize.Event)),
@@ -1773,11 +1868,7 @@ def _multiprocessing_context_instance_identities(
     """Bind context-instance shadows without inspecting hostile values."""
 
     instance_state = vars(context)
-    return tuple(
-        (name, id(instance_state[name]))
-        for name in _MULTIPROCESSING_CONTEXT_MEMBER_NAMES
-        if name in instance_state
-    )
+    return tuple((name, id(value)) for name, value in sorted(instance_state.items()))
 
 
 _SEALED_MULTIPROCESSING_CONTEXT_INSTANCE_IDENTITIES = _multiprocessing_context_instance_identities(
@@ -1799,7 +1890,7 @@ _SEALED_MULTIPROCESSING_CONTEXT_STATE_DIGEST = _multiprocessing_context_state_di
 def _assert_multiprocessing_context_sealed(*, verify_state: bool = True) -> None:
     """Reject replacement of the fork context or any primitive it constructs."""
 
-    current_context = multiprocessing.get_context("fork")
+    current_context = _SEALED_MULTIPROCESSING_CONTEXT
     current_identities = (
         ("context-global", id(_SEALED_MULTIPROCESSING_CONTEXT)),
         ("resolved-context", id(current_context)),
@@ -1861,6 +1952,7 @@ _SEALED_SCANNER_EXTERNAL_GLOBAL_STATE_DIGEST = _external_global_binding_state_di
 def _assert_scanner_import_bindings_sealed(*, verify_state: bool = False) -> None:
     """Reject replaced or mutated output-affecting imported modules before use."""
 
+    _assert_digest_helper_sealed()
     current_identities = tuple(
         (
             name,
@@ -1891,7 +1983,10 @@ def _assert_scanner_import_bindings_sealed(*, verify_state: bool = False) -> Non
         _external_global_binding_state_digest(_SEALED_SCANNER_EXTERNAL_GLOBAL_NAMES)
         != _SEALED_SCANNER_EXTERNAL_GLOBAL_STATE_DIGEST
     ):
-        raise RepositorySecurityError("scanner imported global binding state changed")
+        raise RepositorySecurityError(
+            "scanner imported global binding state changed in redaction or "
+            "implementation dependency"
+        )
 
 
 def _snapshot_identity_groups(
@@ -2226,12 +2321,21 @@ class RepositoryScanner:
         self._commands += 1
         try:
             if isinstance(runner, SubprocessCommandRunner):
-                result = runner.run(
-                    args,
-                    root,
-                    self.config.command_timeout_seconds,
-                    cancellation=cancellation,
-                )
+                if args[1:3] == ("cat-file", "blob"):
+                    result = runner.run(
+                        args,
+                        root,
+                        self.config.command_timeout_seconds,
+                        cancellation=cancellation,
+                        max_output_bytes=self.config.max_file_bytes,
+                    )
+                else:
+                    result = runner.run(
+                        args,
+                        root,
+                        self.config.command_timeout_seconds,
+                        cancellation=cancellation,
+                    )
             else:
                 result = runner.run(args, root, self.config.command_timeout_seconds)
         except (FileNotFoundError, OSError) as exc:

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -871,13 +871,25 @@ def _runtime_function_namespace_binding(target: Any) -> str:
             if candidate_scope == registered_scope == "builtin" and candidate is not registered:
                 raise RepositorySecurityError("runtime function global namespace changed")
             if candidate_scope != registered_scope or candidate is not registered:
+                candidate_evidence = _shallow_runtime_value_evidence(candidate)
+                registered_evidence = _shallow_runtime_value_evidence(registered)
+                if (
+                    candidate_evidence == registered_evidence
+                    and _is_runtime_semantic_constant(
+                        candidate, module_name="runtime-function-global"
+                    )
+                    and _is_runtime_semantic_constant(
+                        registered, module_name="runtime-function-global"
+                    )
+                ):
+                    continue
                 namespace_differences.append(
                     {
                         "name": name,
                         "candidate_scope": candidate_scope,
-                        "candidate": _shallow_runtime_value_evidence(candidate),
+                        "candidate": candidate_evidence,
                         "registered_scope": registered_scope,
-                        "registered": _shallow_runtime_value_evidence(registered),
+                        "registered": registered_evidence,
                     }
                 )
         if namespace_differences:

--- a/src/pmpe/repository/scanner.py
+++ b/src/pmpe/repository/scanner.py
@@ -794,9 +794,9 @@ def _code_global_names(code: CodeType) -> tuple[str, ...]:
     return tuple(sorted(names))
 
 
-def _namespace_value(namespace: Mapping[str, Any], name: str) -> tuple[bool, Any]:
+def _namespace_value(namespace: Mapping[str, Any], name: str) -> tuple[str, Any]:
     if name in namespace:
-        return True, namespace[name]
+        return "global", namespace[name]
     builtins_value = namespace.get("__builtins__")
     if type(builtins_value) is ModuleType:
         builtins_namespace: Mapping[str, Any] = vars(builtins_value)
@@ -804,7 +804,34 @@ def _namespace_value(namespace: Mapping[str, Any], name: str) -> tuple[bool, Any
         builtins_namespace = builtins_value
     else:
         builtins_namespace = {}
-    return (True, builtins_namespace[name]) if name in builtins_namespace else (False, None)
+    return (
+        ("builtin", builtins_namespace[name]) if name in builtins_namespace else ("missing", None)
+    )
+
+
+def _shallow_runtime_value_evidence(value: Any) -> Any:
+    if inspect.ismethod(value):
+        value = value.__func__
+    if inspect.isfunction(value):
+        return {
+            "type": "function",
+            "module": value.__module__,
+            "qualname": value.__qualname__,
+            "code": _code_object_evidence(value.__code__),
+            "defaults": _stable_code_constant(value.__defaults__),
+            "keyword_defaults": _stable_code_constant(
+                tuple(sorted((value.__kwdefaults__ or {}).items()))
+            ),
+        }
+    if type(value) is ModuleType:
+        return {"type": "module", "module": value.__name__}
+    if _is_runtime_semantic_constant(value, module_name="runtime-function-global"):
+        return {"type": "constant", "value": _runtime_value_evidence(value)}
+    return {
+        "type": f"{type(value).__module__}.{type(value).__qualname__}",
+        "module": str(getattr(value, "__module__", type(value).__module__)),
+        "qualname": str(getattr(value, "__qualname__", type(value).__qualname__)),
+    }
 
 
 def _runtime_function_namespace_binding(target: Any) -> str:
@@ -824,14 +851,38 @@ def _runtime_function_namespace_binding(target: Any) -> str:
         registered_namespace = vars(defining_module)
         if target.__globals__ is registered_namespace:
             return "registered-module"
+        namespace_differences: list[dict[str, Any]] = []
         for name in _code_global_names(target.__code__):
-            candidate_present, candidate = _namespace_value(target.__globals__, name)
-            registered_present, registered = _namespace_value(registered_namespace, name)
-            if candidate_present != registered_present or (
-                candidate_present and candidate is not registered
+            candidate_scope, candidate = _namespace_value(target.__globals__, name)
+            registered_scope, registered = _namespace_value(registered_namespace, name)
+            if candidate_scope == registered_scope == "missing":
+                continue
+            if (
+                candidate_scope != "missing"
+                and registered_scope != "missing"
+                and candidate is registered
             ):
+                continue
+            if candidate_scope != registered_scope and "builtin" in {
+                candidate_scope,
+                registered_scope,
+            }:
                 raise RepositorySecurityError("runtime function global namespace changed")
-        return "registered-module-equivalent-globals"
+            if candidate_scope == registered_scope == "builtin" and candidate is not registered:
+                raise RepositorySecurityError("runtime function global namespace changed")
+            if candidate_scope != registered_scope or candidate is not registered:
+                namespace_differences.append(
+                    {
+                        "name": name,
+                        "candidate_scope": candidate_scope,
+                        "candidate": _shallow_runtime_value_evidence(candidate),
+                        "registered_scope": registered_scope,
+                        "registered": _shallow_runtime_value_evidence(registered),
+                    }
+                )
+        if namespace_differences:
+            return "registered-module-loader-globals:" + canonical_digest(namespace_differences)
+        return "registered-module"
     if (
         global_namespace_name.startswith("namedtuple_")
         and target.__module__ == global_namespace_name
@@ -842,9 +893,11 @@ def _runtime_function_namespace_binding(target: Any) -> str:
     if type(builtins_module) is ModuleType:
         builtins_namespace = vars(builtins_module)
         for name in _code_global_names(target.__code__):
-            candidate_present, candidate = _namespace_value(target.__globals__, name)
-            builtin_present, builtin = _namespace_value(builtins_namespace, name)
-            if candidate_present and (not builtin_present or candidate is not builtin):
+            candidate_scope, candidate = _namespace_value(target.__globals__, name)
+            builtin_scope, builtin = _namespace_value(builtins_namespace, name)
+            if candidate_scope != "missing" and (
+                builtin_scope == "missing" or candidate is not builtin
+            ):
                 break
         else:
             return "isolated-builtin-only-namespace"

--- a/tests/e2e/test_repository_intelligence_cli.py
+++ b/tests/e2e/test_repository_intelligence_cli.py
@@ -76,6 +76,82 @@ def test_repository_scan_cli_writes_artifacts_outside_scanned_repo(
     assert output["governance_observation_id"] == "OBS-CLI-001"
 
 
+def test_repository_scan_cli_reports_malformed_observation_id_without_traceback(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _repo(tmp_path)
+    output_parent = tmp_path / "evidence"
+    output_parent.mkdir()
+
+    code = main(
+        [
+            "repository",
+            "scan",
+            "--repo",
+            str(repo),
+            "--repository",
+            "example/cli-fixture",
+            "--snapshot-out",
+            str(output_parent / "snapshot.json"),
+            "--governance-out",
+            str(output_parent / "governance.json"),
+            "--observation-id",
+            "not-an-observation-id",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert captured.err.startswith("repository intelligence blocked: ")
+    assert "recorded observation ID must be a safe opaque identifier" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_repository_scan_cli_governance_binds_to_requested_commit(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _git(repo, "switch", "-q", "-c", "feature")
+    (repo / "feature.txt").write_text("feature\n")
+    _git(repo, "add", "feature.txt")
+    _git(repo, "commit", "-q", "-m", "feature")
+    feature_sha = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "switch", "-q", "main")
+    output_parent = tmp_path / "evidence"
+    output_parent.mkdir()
+    snapshot_path = output_parent / "snapshot.json"
+    governance_path = output_parent / "governance.json"
+
+    code = main(
+        [
+            "repository",
+            "scan",
+            "--repo",
+            str(repo),
+            "--repository",
+            "example/cli-fixture",
+            "--commit",
+            feature_sha,
+            "--default-branch",
+            "main",
+            "--snapshot-out",
+            str(snapshot_path),
+            "--governance-out",
+            str(governance_path),
+            "--observed-at",
+            "2026-08-01T00:00:00Z",
+            "--observation-id",
+            "OBS-CLI-FEATURE",
+        ]
+    )
+
+    assert code == 3
+    assert json.loads(snapshot_path.read_text())["commit_sha"] == feature_sha
+    assert json.loads(governance_path.read_text())["commit_sha"] == feature_sha
+
+
 def test_repository_scan_cli_refuses_to_create_unpinned_output_parents(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     missing_parent = tmp_path / "untrusted-parent"

--- a/tests/e2e/test_repository_intelligence_cli.py
+++ b/tests/e2e/test_repository_intelligence_cli.py
@@ -149,7 +149,7 @@ def test_repository_scan_cli_governance_binds_to_requested_commit(
 
     assert code == 3
     assert json.loads(snapshot_path.read_text())["commit_sha"] == feature_sha
-    assert json.loads(governance_path.read_text())["commit_sha"] == feature_sha
+    assert json.loads(governance_path.read_text())["repository_snapshot_commit"] == feature_sha
 
 
 def test_repository_scan_cli_refuses_to_create_unpinned_output_parents(tmp_path: Path) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -2912,7 +2912,9 @@ def test_branch_tag_name_collision_uses_full_ref_for_divergence(tmp_path: Path) 
 
     assert collision.status == "OBSERVED"
     assert (collision.ahead, collision.behind) == (1, 1)
-    assert not any(item.fact == "local_branch_divergence:collision" for item in observation.unknowns)
+    assert not any(
+        item.fact == "local_branch_divergence:collision" for item in observation.unknowns
+    )
 
 
 def test_malformed_worktree_record_is_blocked_without_placeholder_facts(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -8,6 +8,7 @@ import os
 import re
 import signal
 import subprocess
+import sys
 import threading
 import time
 from dataclasses import asdict, replace
@@ -470,6 +471,53 @@ def test_implementation_digest_rejects_replaced_output_module_before_use(
     assert callback_ran is False
 
 
+def test_implementation_digest_rejects_forged_scanner_helper_global_namespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    callback_ran = False
+    original_hash = scanner._sha256
+    forged_globals = dict(original_hash.__globals__)
+
+    class HashlibProxy:
+        def sha256(self, _payload: bytes) -> Any:
+            nonlocal callback_ran
+            callback_ran = True
+            return scanner.hashlib.sha256(b"forged")
+
+    forged_globals["hashlib"] = HashlibProxy()
+    forged_hash = FunctionType(
+        original_hash.__code__,
+        forged_globals,
+        name=original_hash.__name__,
+        argdefs=original_hash.__defaults__,
+        closure=original_hash.__closure__,
+    )
+    monkeypatch.setattr(scanner, "_sha256", forged_hash)
+
+    with pytest.raises(scanner.RepositorySecurityError, match="digest helper binding changed"):
+        scanner._implementation_digest()
+    assert callback_ran is False
+
+
+def test_runtime_code_evidence_rejects_registered_function_with_copied_globals() -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    models = importlib.import_module("pmpe.repository.models")
+    original_fields = models.fields
+    forged_fields = FunctionType(
+        original_fields.__code__,
+        dict(original_fields.__globals__),
+        name=original_fields.__name__,
+        argdefs=original_fields.__defaults__,
+        closure=original_fields.__closure__,
+    )
+
+    with pytest.raises(
+        scanner.RepositorySecurityError, match="runtime function global namespace changed"
+    ):
+        scanner._runtime_code_evidence(forged_fields)
+
+
 def test_implementation_digest_seals_every_direct_module_attribute_before_use(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -547,6 +595,20 @@ def test_implementation_digest_seals_returned_multiprocessing_context_members(
         runtime_patch.setattr(scanner.multiprocessing_connection, "Pipe", pipe_proxy)
         with pytest.raises(scanner.RepositorySecurityError, match="runtime or context"):
             scanner._sealed_fork_pipe(duplex=False)
+        assert callback_ran is False
+
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setitem(vars(context), "Lock", pipe_proxy)
+        with pytest.raises(
+            scanner.RepositorySecurityError, match="runtime or context instance changed"
+        ):
+            scanner._sealed_fork_event()
+        assert callback_ran is False
+
+    with monkeypatch.context() as runtime_patch:
+        runtime_patch.setattr(scanner.multiprocessing, "get_context", pipe_proxy)
+        with pytest.raises(scanner.RepositorySecurityError, match="runtime or context"):
+            scanner._sealed_fork_event()
         assert callback_ran is False
 
     replacement_context = type(context)()
@@ -2768,6 +2830,22 @@ def test_branch_divergence_and_additional_worktrees_are_mutable_observations(
     assert "local_branches" not in _scan(repo).as_dict()
 
 
+def test_branch_named_at_is_compared_as_a_fully_qualified_local_ref(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "switch", "-q", "-c", "@")
+    _write(repo, "at-branch.txt", "at branch\n")
+    _commit(repo, "at branch")
+    _git(repo, "switch", "-q", "main")
+    _write(repo, "main-branch.txt", "main branch\n")
+    _commit(repo, "main branch")
+
+    observation = _observe(repo)
+    at_branch = next(item for item in observation.local_branches if item.name == "@")
+
+    assert at_branch.status == "OBSERVED"
+    assert (at_branch.ahead, at_branch.behind) == (1, 1)
+
+
 def test_malformed_worktree_record_is_blocked_without_placeholder_facts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3886,6 +3964,42 @@ def test_git_timeout_is_bounded_and_visible(tmp_path: Path) -> None:
     result = scanner.SubprocessCommandRunner().run(("git", "version"), tmp_path, 0)
     assert result.timed_out
     assert result.returncode == 124
+
+
+def test_tracked_blob_within_configured_file_budget_is_not_cut_off_at_eight_megabytes(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path, mixed=False)
+    _write(repo, "large.bin", b"x" * 8_100_000)
+    commit_sha = _commit(repo, "large tracked blob")
+
+    snapshot = _scan(
+        repo,
+        max_file_bytes=10_000_000,
+        max_total_bytes=20_000_000,
+    )
+
+    assert snapshot.commit_sha == commit_sha
+    assert not any(item.timed_out for item in snapshot.command_provenance)
+
+
+def test_repository_intelligence_source_tree_import_computes_provenance() -> None:
+    source_root = Path(__file__).resolve().parents[2] / "src"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import pmpe.repository.scanner as scanner; "
+                "assert scanner._implementation_digest().startswith('sha256:')"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(source_root)},
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_caller_path_cannot_select_the_git_executable(

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -2893,6 +2893,28 @@ def test_branch_named_at_is_compared_as_a_fully_qualified_local_ref(tmp_path: Pa
     assert (at_branch.ahead, at_branch.behind) == (1, 1)
 
 
+def test_branch_tag_name_collision_uses_full_ref_for_divergence(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "switch", "-q", "-c", "collision")
+    _write(repo, "collision-branch.txt", "branch\n")
+    _commit(repo, "collision branch")
+    _git(repo, "tag", "collision")
+    _git(repo, "switch", "-q", "main")
+    _write(repo, "main-after-collision.txt", "main\n")
+    _commit(repo, "main after collision")
+
+    assert (
+        _git(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads/collision")
+        == "heads/collision"
+    )
+    observation = _observe(repo)
+    collision = next(item for item in observation.local_branches if item.name == "collision")
+
+    assert collision.status == "OBSERVED"
+    assert (collision.ahead, collision.behind) == (1, 1)
+    assert not any(item.fact == "local_branch_divergence:collision" for item in observation.unknowns)
+
+
 def test_malformed_worktree_record_is_blocked_without_placeholder_facts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -524,6 +524,25 @@ def test_runtime_code_evidence_rejects_registered_function_with_copied_globals()
         scanner._runtime_code_evidence(forged_fields)
 
 
+def test_runtime_code_evidence_normalizes_equivalent_copied_builtin_global() -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    models = importlib.import_module("pmpe.repository.models")
+    original_fields = models.fields
+    copied_globals = dict(original_fields.__globals__)
+    copied_globals["getattr"] = getattr
+    copied_fields = FunctionType(
+        original_fields.__code__,
+        copied_globals,
+        name=original_fields.__name__,
+        argdefs=original_fields.__defaults__,
+        closure=original_fields.__closure__,
+    )
+
+    assert scanner._runtime_code_evidence(copied_fields) == scanner._runtime_code_evidence(
+        original_fields
+    )
+
+
 def test_implementation_digest_seals_every_direct_module_attribute_before_use(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -543,6 +543,28 @@ def test_runtime_code_evidence_normalizes_equivalent_copied_builtin_global() -> 
     )
 
 
+def test_runtime_code_evidence_normalizes_equivalent_loader_created_global() -> None:
+    scanner = importlib.import_module("pmpe.repository.scanner")
+    models = importlib.import_module("pmpe.repository.models")
+    original_fields = models.fields
+    copied_globals = dict(original_fields.__globals__)
+    copied_fields_name = bytes(copied_globals["_FIELDS"], "utf-8").decode("utf-8")
+    assert copied_fields_name == copied_globals["_FIELDS"]
+    assert copied_fields_name is not copied_globals["_FIELDS"]
+    copied_globals["_FIELDS"] = copied_fields_name
+    copied_fields = FunctionType(
+        original_fields.__code__,
+        copied_globals,
+        name=original_fields.__name__,
+        argdefs=original_fields.__defaults__,
+        closure=original_fields.__closure__,
+    )
+
+    assert scanner._runtime_code_evidence(copied_fields) == scanner._runtime_code_evidence(
+        original_fields
+    )
+
+
 def test_implementation_digest_seals_every_direct_module_attribute_before_use(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_repository_intelligence.py
+++ b/tests/unit/test_repository_intelligence.py
@@ -504,9 +504,15 @@ def test_runtime_code_evidence_rejects_registered_function_with_copied_globals()
     scanner = importlib.import_module("pmpe.repository.scanner")
     models = importlib.import_module("pmpe.repository.models")
     original_fields = models.fields
+    forged_globals = dict(original_fields.__globals__)
+    builtins_value = forged_globals["__builtins__"]
+    assert isinstance(builtins_value, dict)
+    forged_builtins = dict(builtins_value)
+    forged_builtins["getattr"] = lambda *_args, **_kwargs: None
+    forged_globals["__builtins__"] = forged_builtins
     forged_fields = FunctionType(
         original_fields.__code__,
-        dict(original_fields.__globals__),
+        forged_globals,
         name=original_fields.__name__,
         argdefs=original_fields.__defaults__,
         closure=original_fields.__closure__,


### PR DESCRIPTION
## Summary

Fix the remaining technically implementable repository-intelligence edge cases deferred from PR #86.

- qualify and preserve full local branch refs for unambiguous divergence checks while reporting separate display names;
- convert malformed observation IDs to the controlled `repository intelligence blocked:` CLI path;
- bind governance evaluation to the scanned commit rather than the default branch;
- honor configured tracked-blob limits above 8 MB;
- harden scanner runtime provenance against helper, module-registry, multiprocessing, and copied-global substitution;
- prove source-tree and installed-wheel provenance on Python 3.11 and 3.12.

Refs #87

## Red-first evidence

Genuine published test-only commit: `20237f01f9d830e5657c8e3e6683d8243d003145`.

Focused RED result: 7 failed, 1 passed. The failures cover branch `@` qualification, controlled malformed-ID handling, commit-bound governance, configured blob budgets, scanner helper substitution, copied globals, and multiprocessing provenance. The passing guard proved that source-tree import could compute provenance before hardening.

A later audit found that `6abe73d1f539ae6579c8b1c7c77c586f15129b61` was not RED against its committed parent, so it is explicitly not counted as red-first evidence. Published history was preserved.

Focused test-only RED loader correction: `c20b7cb67c06b61c79dba2c9c63c5b6c3f5cd3ab`.

That commit reproducibly failed because a distinct-but-semantically-identical loader-created global changed provenance. `69c86541a2344ef5a75d227d0cc6d91a160e95d8` normalizes only bounded semantic equivalence; non-equivalent differences remain digest-bound and forged builtins still fail closed.

## Formal review correction

The first formal Codex review of `69c86541a2344ef5a75d227d0cc6d91a160e95d8` found that a branch/tag short-name collision could produce `heads/<name>` and therefore an invalid reconstructed branch ref.

- genuine planted RED commit: `24390050b051435bbd520866fde983e49c7471fd`;
- focused full-ref/display-name correction: `dfe48748901c6f2437eb28a344d5180fbf3ec595`;
- compatibility follow-up preserving valid credential-shaped branch names for the existing redaction guard: `5bae959089ea0e4021986e61b5e453313bd7e6c1`.

Published history was not rewritten.

## Validation

Final exact head: `5bae959089ea0e4021986e61b5e453313bd7e6c1`.

- focused repository-intelligence regressions: 10 passed;
- branch/tag collision, branch `@`, general divergence, and redaction-collision tests: passed;
- complete repository-intelligence unit, integration, and E2E suites: passed;
- Ruff format and lint: passed (185 files);
- mypy strict: passed (114 source files);
- Bandit high-severity gate: passed;
- frontend workflow classifier: 39 passed;
- full CI run `30759902750`: all jobs passed, including Python 3.11/3.12 suites, dependency/security audit, build smoke, backend, frontend routing, preview, and browser E2E;
- distribution run `30759902740`: Python 3.11 and 3.12 both passed source-tree and installed-wheel provenance smoke.

Scope: 6 files, 503 additions, 32 deletions.