### PR TITLE
Migrate PR Review Agent to Codex-only exact-head review gate

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -48,4 +48,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          CODEX_EVIDENCE_WAIT_SECONDS: 180
         run: python scripts/verify_codex_review.py

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -48,5 +48,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          CODEX_EVIDENCE_WAIT_SECONDS: 180
+          CODEX_EVIDENCE_WAIT_SECONDS: 300
         run: python scripts/verify_codex_review.py

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -43,23 +43,9 @@ jobs:
           CURRENT_HEAD="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)"
           test "$CURRENT_HEAD" = "$EXPECTED_HEAD"
 
-      - name: Verify reviewer credential
+      - name: Verify Codex exact-head evidence
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        run: |
-          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
-            echo "::error title=PR Review Agent unavailable::CLAUDE_CODE_OAUTH_TOKEN is required"
-            exit 1
-          fi
-
-      - name: Run Claude Code PR review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          prompt: >-
-            /review-pr. Review only immutable candidate
-            ${{ github.event.pull_request.head.sha }} for PR #${{ github.event.pull_request.number }}.
-            Do not publish or mutate repository or PR state; this exact-SHA
-            check and retained GitHub job log are the review evidence.
-          claude_args: '--max-turns 30 --allowedTools "Read,Glob,Grep,LS"'
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: python scripts/verify_codex_review.py

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,7 +1,9 @@
 name: PR Review Agent
 
 on:
-  pull_request:
+  # This event always evaluates this workflow from the protected base branch.
+  # Candidate code is evidence data, never executable review control-plane code.
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
@@ -21,18 +23,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Checkout PR branch
+      - name: Checkout trusted verifier revision
         uses: actions/checkout@v4
         with:
-          # Never let a moving branch name change the candidate under review.
-          ref: ${{ github.event.pull_request.head.sha }}
+          # Never execute files supplied by the candidate being admitted.
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
 
-      - name: Bind review to exact PR head
+      - name: Bind review to trusted verifier revision
         env:
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
-          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
+          test "$(git rev-parse HEAD)" != "$EXPECTED_HEAD"
 
       - name: Verify current PR head before review
         env:

--- a/docs/PR-REVIEW-AGENT.md
+++ b/docs/PR-REVIEW-AGENT.md
@@ -33,7 +33,4 @@ review evidence.
 
 ## Operator recovery
 
-An administrator restores service by updating the configured secret or the
-reviewer's service capacity, then causes one substantive synchronized candidate
-run or marks the candidate ready for review. Do not treat rerunning an old
-workflow, a comment, or a reaction as review evidence for a newer head.
+An administrator restores or verifies Codex GitHub integration availability/service capacity, then must retry or re-enter the exact-head review cycle by causing one substantive synchronized candidate run or marking the candidate ready for review. No reviewer secret or external credential is required. Do not treat rerunning an old workflow, a comment, or a reaction as review evidence for a newer head.

--- a/docs/PR-REVIEW-AGENT.md
+++ b/docs/PR-REVIEW-AGENT.md
@@ -1,9 +1,8 @@
 # PR Review Agent
 
-The repository's automated advisory reviewer is **Claude Code** running as
-`claude[bot]` through `anthropics/claude-code-action@v1`. It is not a human or
-formal approval, and it never satisfies a required independent human/formal
-review.
+The repository's automated advisory reviewer is the existing **Codex GitHub
+integration** (`chatgpt-codex-connector[bot]`). It is not a human or formal
+approval.
 
 ## Trigger and identity
 
@@ -17,15 +16,15 @@ records, lessons, or fixes to the candidate branch. The exact-SHA check and
 retained GitHub job log are automated advisory evidence; accepted fixes use
 the normal governed correction loop and receive a new review.
 
-## Credential and failure policy
+## Codex evidence policy
 
-Repository administrators must configure the Actions secret
-`CLAUDE_CODE_OAUTH_TOKEN` with a supported Claude Code OAuth credential. The
-workflow deliberately runs a credential preflight before invoking the reviewer:
-absent or expired credentials, quota exhaustion, and reviewer-service failures
-leave the `PR Review Agent / review` check failed and visible in GitHub. A
-skipped, failed, missing, stale, or wrong-SHA result is not review evidence and
-must block merge admission.
+The gate uses no external reviewer credential. It re-observes the current PR
+head and accepts a clean result only from the Codex bot when its GitHub-visible
+comment identifies the current exact SHA and no current non-outdated Codex
+P1/P2 thread exists. GitHub may represent a clean result as a conversation
+comment rather than a pull-request review; it is recorded truthfully as
+`CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD`. Missing, stale, owner-authored,
+trigger-only, or finding-bearing evidence fails closed.
 
 Draft pull requests are not reviewed. A synchronize event is a new candidate
 and requires a fresh successful exact-head review. Review comments, reactions,

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -1,0 +1,68 @@
+"""Fail closed unless GitHub exposes a clean Codex advisory result for this PR head."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+BOT = "chatgpt-codex-connector[bot]"
+
+
+def _gh(*args: str) -> Any:
+    result = subprocess.run(["gh", *args], check=True, capture_output=True, text=True)
+    return json.loads(result.stdout)
+
+
+def main() -> int:
+    expected = os.environ["EXPECTED_HEAD"]
+    number = os.environ["PR_NUMBER"]
+    repository = os.environ["GITHUB_REPOSITORY"]
+    pr = _gh("api", f"repos/{repository}/pulls/{number}")
+    if pr["head"]["sha"] != expected:
+        raise SystemExit("current PR head changed during Codex evidence verification")
+    comments = _gh("api", f"repos/{repository}/issues/{number}/comments")
+    marker = f"**Reviewed commit:** `{expected[:10]}`"
+    clean = any(
+        comment["user"]["login"] == BOT
+        and "Codex Review: Didn't find any major issues." in comment["body"]
+        and marker in comment["body"]
+        for comment in comments
+    )
+    if not clean:
+        raise SystemExit("missing clean exact-head Codex advisory evidence")
+    query = (
+        "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name)"
+        "{pullRequest(number:$number){reviewThreads(first:100){nodes{isOutdated comments(first:20)"
+        "{nodes{author{login} body}}}}}}}"
+    )
+    threads = _gh(
+        "api",
+        "graphql",
+        "-f",
+        f"query={query}",
+        "-F",
+        f"owner={repository.split('/', 1)[0]}",
+        "-F",
+        f"name={repository.split('/', 1)[1]}",
+        "-F",
+        f"number={number}",
+    )["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    for thread in threads:
+        if thread["isOutdated"]:
+            continue
+        for comment in thread["comments"]["nodes"]:
+            if (
+                comment["author"]
+                and comment["author"]["login"] == BOT
+                and any(badge in comment["body"] for badge in ("P1 Badge", "P2 Badge"))
+            ):
+                raise SystemExit("current Codex P1/P2 finding blocks admission")
+    print(f"CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD {expected}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -65,7 +65,7 @@ def _all_review_threads(repository: str, number: str) -> list[dict[str, Any]]:
     query = (
         "query($owner:String!,$name:String!,$number:Int!,$after:String){repository("
         "owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,"
-        "after:$after){nodes{id isOutdated comments(first:100){nodes{author{login} body}"
+        "after:$after){nodes{id isOutdated isResolved comments(first:100){nodes{author{login} body}"
         "pageInfo{hasNextPage endCursor}}}pageInfo{hasNextPage endCursor}}}}}"
     )
     while True:
@@ -94,6 +94,20 @@ def _all_review_threads(repository: str, number: str) -> list[dict[str, Any]]:
         cursor = page_info["endCursor"]
 
 
+def _has_current_blocker(threads: list[dict[str, Any]]) -> bool:
+    for thread in threads:
+        if thread["isOutdated"] or thread["isResolved"]:
+            continue
+        for comment in thread["comments"]["nodes"]:
+            if (
+                comment["author"]
+                and comment["author"]["login"] == BOT
+                and any(badge in comment["body"] for badge in ("P0 Badge", "P1 Badge", "P2 Badge"))
+            ):
+                return True
+    return False
+
+
 def main() -> int:
     expected = os.environ["EXPECTED_HEAD"]
     number = os.environ["PR_NUMBER"]
@@ -117,16 +131,8 @@ def main() -> int:
             raise SystemExit("missing clean exact-head Codex advisory evidence")
         time.sleep(10)
     threads = _all_review_threads(repository, number)
-    for thread in threads:
-        if thread["isOutdated"]:
-            continue
-        for comment in thread["comments"]["nodes"]:
-            if (
-                comment["author"]
-                and comment["author"]["login"] == BOT
-                and any(badge in comment["body"] for badge in ("P1 Badge", "P2 Badge"))
-            ):
-                raise SystemExit("current Codex P1/P2 finding blocks admission")
+    if _has_current_blocker(threads):
+        raise SystemExit("current Codex P0/P1/P2 finding blocks admission")
     print(f"CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD {expected}")
     return 0
 

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -6,6 +6,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from typing import Any
 
 BOT = "chatgpt-codex-connector[bot]"
@@ -20,19 +21,24 @@ def main() -> int:
     expected = os.environ["EXPECTED_HEAD"]
     number = os.environ["PR_NUMBER"]
     repository = os.environ["GITHUB_REPOSITORY"]
-    pr = _gh("api", f"repos/{repository}/pulls/{number}")
-    if pr["head"]["sha"] != expected:
-        raise SystemExit("current PR head changed during Codex evidence verification")
-    comments = _gh("api", f"repos/{repository}/issues/{number}/comments")
     marker = f"**Reviewed commit:** `{expected[:10]}`"
-    clean = any(
-        comment["user"]["login"] == BOT
-        and "Codex Review: Didn't find any major issues." in comment["body"]
-        and marker in comment["body"]
-        for comment in comments
-    )
-    if not clean:
-        raise SystemExit("missing clean exact-head Codex advisory evidence")
+    deadline = time.monotonic() + int(os.environ.get("CODEX_EVIDENCE_WAIT_SECONDS", "0"))
+    while True:
+        pr = _gh("api", f"repos/{repository}/pulls/{number}")
+        if pr["head"]["sha"] != expected:
+            raise SystemExit("current PR head changed during Codex evidence verification")
+        comments = _gh("api", f"repos/{repository}/issues/{number}/comments")
+        clean = any(
+            comment["user"]["login"] == BOT
+            and "Codex Review: Didn't find any major issues." in comment["body"]
+            and marker in comment["body"]
+            for comment in comments
+        )
+        if clean:
+            break
+        if time.monotonic() >= deadline:
+            raise SystemExit("missing clean exact-head Codex advisory evidence")
+        time.sleep(10)
     query = (
         "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name)"
         "{pullRequest(number:$number){reviewThreads(first:100){nodes{isOutdated comments(first:20)"

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -17,6 +17,83 @@ def _gh(*args: str) -> Any:
     return json.loads(result.stdout)
 
 
+def _all_issue_comments(repository: str, number: str) -> list[dict[str, Any]]:
+    """Fetch every REST page: Codex's clean advisory can be on any page."""
+    comments: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        current = _gh(
+            "api",
+            f"repos/{repository}/issues/{number}/comments?per_page=100&page={page}",
+        )
+        comments.extend(current)
+        if len(current) < 100:
+            return comments
+        page += 1
+
+
+def _all_thread_comments(thread: dict[str, Any]) -> list[dict[str, Any]]:
+    """Fetch all comments in one review thread before treating it as clean."""
+    comments = list(thread["comments"]["nodes"])
+    page_info = thread["comments"].get("pageInfo", {"hasNextPage": False})
+    while page_info["hasNextPage"]:
+        query = (
+            "query($id:ID!,$after:String){node(id:$id){... on PullRequestReviewThread"
+            "{comments(first:100,after:$after){nodes{author{login} body}"
+            "pageInfo{hasNextPage endCursor}}}}}"
+        )
+        result = _gh(
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"id={thread['id']}",
+            "-F",
+            f"after={page_info['endCursor']}",
+        )["data"]["node"]["comments"]
+        comments.extend(result["nodes"])
+        page_info = result["pageInfo"]
+    return comments
+
+
+def _all_review_threads(repository: str, number: str) -> list[dict[str, Any]]:
+    """Follow GraphQL cursors so later Codex blockers cannot be hidden."""
+    owner, name = repository.split("/", 1)
+    cursor: str | None = None
+    threads: list[dict[str, Any]] = []
+    query = (
+        "query($owner:String!,$name:String!,$number:Int!,$after:String){repository("
+        "owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,"
+        "after:$after){nodes{id isOutdated comments(first:100){nodes{author{login} body}"
+        "pageInfo{hasNextPage endCursor}}}pageInfo{hasNextPage endCursor}}}}}"
+    )
+    while True:
+        args = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"number={number}",
+        ]
+        if cursor is not None:
+            args.extend(("-F", f"after={cursor}"))
+        result = _gh(*args)["data"]["repository"]["pullRequest"]["reviewThreads"]
+        for raw_thread in result["nodes"]:
+            thread = dict(raw_thread)
+            thread["comments"] = {"nodes": _all_thread_comments(raw_thread)}
+            threads.append(thread)
+        page_info = result["pageInfo"]
+        if not page_info["hasNextPage"]:
+            return threads
+        cursor = page_info["endCursor"]
+
+
 def main() -> int:
     expected = os.environ["EXPECTED_HEAD"]
     number = os.environ["PR_NUMBER"]
@@ -27,7 +104,7 @@ def main() -> int:
         pr = _gh("api", f"repos/{repository}/pulls/{number}")
         if pr["head"]["sha"] != expected:
             raise SystemExit("current PR head changed during Codex evidence verification")
-        comments = _gh("api", f"repos/{repository}/issues/{number}/comments")
+        comments = _all_issue_comments(repository, number)
         clean = any(
             comment["user"]["login"] == BOT
             and "Codex Review: Didn't find any major issues." in comment["body"]
@@ -39,23 +116,7 @@ def main() -> int:
         if time.monotonic() >= deadline:
             raise SystemExit("missing clean exact-head Codex advisory evidence")
         time.sleep(10)
-    query = (
-        "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name)"
-        "{pullRequest(number:$number){reviewThreads(first:100){nodes{isOutdated comments(first:20)"
-        "{nodes{author{login} body}}}}}}}"
-    )
-    threads = _gh(
-        "api",
-        "graphql",
-        "-f",
-        f"query={query}",
-        "-F",
-        f"owner={repository.split('/', 1)[0]}",
-        "-F",
-        f"name={repository.split('/', 1)[1]}",
-        "-F",
-        f"number={number}",
-    )["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    threads = _all_review_threads(repository, number)
     for thread in threads:
         if thread["isOutdated"]:
             continue

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -108,11 +108,21 @@ def _has_current_blocker(threads: list[dict[str, Any]]) -> bool:
     return False
 
 
+def _comment_matches_exact_head(repository: str, expected: str, body: str) -> bool:
+    """Accept a short reviewed SHA only when GitHub resolves it to this full head."""
+    if f"**Reviewed commit:** `{expected}`" in body:
+        return True
+    short = expected[:10]
+    if f"**Reviewed commit:** `{short}`" not in body:
+        return False
+    resolved = _gh("api", f"repos/{repository}/commits/{short}")
+    return resolved["sha"] == expected
+
+
 def main() -> int:
     expected = os.environ["EXPECTED_HEAD"]
     number = os.environ["PR_NUMBER"]
     repository = os.environ["GITHUB_REPOSITORY"]
-    marker = f"**Reviewed commit:** `{expected[:10]}`"
     deadline = time.monotonic() + int(os.environ.get("CODEX_EVIDENCE_WAIT_SECONDS", "0"))
     while True:
         pr = _gh("api", f"repos/{repository}/pulls/{number}")
@@ -122,7 +132,7 @@ def main() -> int:
         clean = any(
             comment["user"]["login"] == BOT
             and "Codex Review: Didn't find any major issues." in comment["body"]
-            and marker in comment["body"]
+            and _comment_matches_exact_head(repository, expected, comment["body"])
             for comment in comments
         )
         if clean:

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -187,3 +187,35 @@ def test_current_codex_p0_thread_blocks_admission(verifier_module) -> None:
     }
 
     assert verifier_module._has_current_blocker([current_p0])
+
+
+def test_short_clean_marker_must_resolve_uniquely_to_the_full_head(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    expected = "a" * 40
+
+    def fake_gh(*args: str):
+        assert args == ("api", "repos/owner/repo/commits/aaaaaaaaaa")
+        return {"sha": expected}
+
+    monkeypatch.setattr(verifier_module, "_gh", fake_gh)
+
+    assert verifier_module._comment_matches_exact_head(
+        "owner/repo", expected, "**Reviewed commit:** `aaaaaaaaaa`"
+    )
+
+
+def test_short_clean_marker_for_a_different_full_head_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    expected = "a" * 40
+
+    monkeypatch.setattr(
+        verifier_module,
+        "_gh",
+        lambda *_args: {"sha": "a" * 10 + "b" * 30},
+    )
+
+    assert not verifier_module._comment_matches_exact_head(
+        "owner/repo", expected, "**Reviewed commit:** `aaaaaaaaaa`"
+    )

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -13,7 +13,7 @@ def test_workflow_is_codex_only_and_runs_the_exact_head_evidence_gate() -> None:
     assert "CLAUDE_CODE_OAUTH_TOKEN" not in workflow
     assert "Verify Codex exact-head evidence" in workflow
     assert "scripts/verify_codex_review.py" in workflow
-    assert "CODEX_EVIDENCE_WAIT_SECONDS: 180" in workflow
+    assert "CODEX_EVIDENCE_WAIT_SECONDS: 300" in workflow
     assert "contents: read" in workflow
     assert "pull-requests: read" in workflow
     assert "issues: read" in workflow
@@ -37,6 +37,17 @@ def test_gate_waits_boundedly_for_asynchronous_codex_evidence() -> None:
     assert "CODEX_EVIDENCE_WAIT_SECONDS" in verifier
     assert "time.monotonic()" in verifier
     assert "time.sleep(10)" in verifier
+
+
+def test_operator_recovery_is_codex_only_and_reenters_the_exact_head_cycle() -> None:
+    documentation = (
+        Path(__file__).resolve().parents[2] / "docs" / "PR-REVIEW-AGENT.md"
+    ).read_text()
+
+    assert "Codex GitHub integration availability/service capacity" in documentation
+    assert "retry or re-enter the exact-head review cycle" in documentation
+    assert "no reviewer secret or external credential is required" in documentation.lower()
+    assert "updating the configured secret" not in documentation
 
 
 @pytest.fixture()

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -1,4 +1,7 @@
+import importlib.util
 from pathlib import Path
+
+import pytest
 
 WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "pr-review.yml"
 
@@ -34,3 +37,119 @@ def test_gate_waits_boundedly_for_asynchronous_codex_evidence() -> None:
     assert "CODEX_EVIDENCE_WAIT_SECONDS" in verifier
     assert "time.monotonic()" in verifier
     assert "time.sleep(10)" in verifier
+
+
+@pytest.fixture()
+def verifier_module():
+    path = Path(__file__).resolve().parents[2] / "scripts" / "verify_codex_review.py"
+    spec = importlib.util.spec_from_file_location("verify_codex_review", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_all_issue_comments_finds_exact_codex_evidence_on_later_rest_page(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    calls: list[tuple[str, ...]] = []
+    first_page = [{"id": index} for index in range(100)]
+    exact_bot_comment = {"user": {"login": verifier_module.BOT}, "body": "review"}
+
+    def fake_gh(*args: str):
+        calls.append(args)
+        if args[-1].endswith("page=1"):
+            return first_page
+        if args[-1].endswith("page=2"):
+            return [exact_bot_comment]
+        raise AssertionError(args)
+
+    monkeypatch.setattr(verifier_module, "_gh", fake_gh)
+
+    assert verifier_module._all_issue_comments("owner/repo", "99") == first_page + [
+        exact_bot_comment
+    ]
+    assert [call[-1] for call in calls] == [
+        "repos/owner/repo/issues/99/comments?per_page=100&page=1",
+        "repos/owner/repo/issues/99/comments?per_page=100&page=2",
+    ]
+
+
+def test_all_review_threads_finds_blocker_on_later_graphql_page(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    calls: list[tuple[str, ...]] = []
+    first_page = {
+        "nodes": [{"id": "thread-a", "isOutdated": False, "comments": {"nodes": []}}],
+        "pageInfo": {"hasNextPage": True, "endCursor": "cursor-a"},
+    }
+    p1_thread = {
+        "id": "thread-b",
+        "isOutdated": False,
+        "comments": {
+            "nodes": [
+                {
+                    "author": {"login": verifier_module.BOT},
+                    "body": "![P1 Badge] blocker",
+                }
+            ]
+        },
+    }
+    second_page = {
+        "nodes": [p1_thread],
+        "pageInfo": {"hasNextPage": False, "endCursor": None},
+    }
+
+    def fake_gh(*args: str):
+        calls.append(args)
+        return {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": second_page if "after=cursor-a" in args else first_page
+                    }
+                }
+            }
+        }
+
+    monkeypatch.setattr(verifier_module, "_gh", fake_gh)
+
+    threads = verifier_module._all_review_threads("owner/repo", "99")
+
+    assert threads == first_page["nodes"] + second_page["nodes"]
+    assert any("after=cursor-a" in call for call in calls)
+
+
+def test_all_thread_comments_finds_blocker_on_later_graphql_page(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    first_page = [{"author": None, "body": "informational"} for _ in range(100)]
+    blocker = {
+        "author": {"login": verifier_module.BOT},
+        "body": "![P2 Badge] must block admission",
+    }
+    thread = {
+        "id": "thread-a",
+        "comments": {
+            "nodes": first_page,
+            "pageInfo": {"hasNextPage": True, "endCursor": "cursor-a"},
+        },
+    }
+
+    def fake_gh(*args: str):
+        assert "id=thread-a" in args
+        assert "after=cursor-a" in args
+        return {
+            "data": {
+                "node": {
+                    "comments": {
+                        "nodes": [blocker],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        }
+
+    monkeypatch.setattr(verifier_module, "_gh", fake_gh)
+
+    assert verifier_module._all_thread_comments(thread) == first_page + [blocker]

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "pr-review.yml"
+
+
+def test_workflow_is_codex_only_and_runs_the_exact_head_evidence_gate() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert "anthropics/claude-code-action" not in workflow
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in workflow
+    assert "Verify Codex exact-head evidence" in workflow
+    assert "scripts/verify_codex_review.py" in workflow
+    assert "contents: read" in workflow
+    assert "pull-requests: read" in workflow
+    assert "issues: read" in workflow
+
+
+def test_workflow_supersedes_stale_verifiers_and_does_not_mutate_candidates() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert "group: pr-review-${{ github.event.pull_request.number }}" in workflow
+    assert "cancel-in-progress: true" in workflow
+    assert 'test "$CURRENT_HEAD" = "$EXPECTED_HEAD"' in workflow
+    assert "contents: write" not in workflow
+    assert "commit_files" not in workflow

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -153,3 +153,37 @@ def test_all_thread_comments_finds_blocker_on_later_graphql_page(
     monkeypatch.setattr(verifier_module, "_gh", fake_gh)
 
     assert verifier_module._all_thread_comments(thread) == first_page + [blocker]
+
+
+def test_resolved_current_codex_thread_does_not_block_admission(verifier_module) -> None:
+    resolved_p1 = {
+        "isOutdated": False,
+        "isResolved": True,
+        "comments": {
+            "nodes": [
+                {
+                    "author": {"login": verifier_module.BOT},
+                    "body": "![P1 Badge] already remediated",
+                }
+            ]
+        },
+    }
+
+    assert not verifier_module._has_current_blocker([resolved_p1])
+
+
+def test_current_codex_p0_thread_blocks_admission(verifier_module) -> None:
+    current_p0 = {
+        "isOutdated": False,
+        "isResolved": False,
+        "comments": {
+            "nodes": [
+                {
+                    "author": {"login": verifier_module.BOT},
+                    "body": "![P0 Badge] release blocker",
+                }
+            ]
+        },
+    }
+
+    assert verifier_module._has_current_blocker([current_p0])

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -29,6 +29,14 @@ def test_workflow_supersedes_stale_verifiers_and_does_not_mutate_candidates() ->
     assert "commit_files" not in workflow
 
 
+def test_workflow_executes_the_verifier_from_trusted_base_not_candidate_code() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert "pull_request_target:" in workflow
+    assert "ref: ${{ github.event.repository.default_branch }}" in workflow
+    assert "ref: ${{ github.event.pull_request.head.sha }}" not in workflow
+
+
 def test_gate_waits_boundedly_for_asynchronous_codex_evidence() -> None:
     verifier = (
         Path(__file__).resolve().parents[2] / "scripts" / "verify_codex_review.py"

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -10,6 +10,7 @@ def test_workflow_is_codex_only_and_runs_the_exact_head_evidence_gate() -> None:
     assert "CLAUDE_CODE_OAUTH_TOKEN" not in workflow
     assert "Verify Codex exact-head evidence" in workflow
     assert "scripts/verify_codex_review.py" in workflow
+    assert "CODEX_EVIDENCE_WAIT_SECONDS: 180" in workflow
     assert "contents: read" in workflow
     assert "pull-requests: read" in workflow
     assert "issues: read" in workflow
@@ -23,3 +24,13 @@ def test_workflow_supersedes_stale_verifiers_and_does_not_mutate_candidates() ->
     assert 'test "$CURRENT_HEAD" = "$EXPECTED_HEAD"' in workflow
     assert "contents: write" not in workflow
     assert "commit_files" not in workflow
+
+
+def test_gate_waits_boundedly_for_asynchronous_codex_evidence() -> None:
+    verifier = (
+        Path(__file__).resolve().parents[2] / "scripts" / "verify_codex_review.py"
+    ).read_text()
+
+    assert "CODEX_EVIDENCE_WAIT_SECONDS" in verifier
+    assert "time.monotonic()" in verifier
+    assert "time.sleep(10)" in verifier

--- a/tests/unit/test_pr_review_agent_workflow.py
+++ b/tests/unit/test_pr_review_agent_workflow.py
@@ -18,11 +18,13 @@ def test_review_agent_only_reviews_exact_non_draft_candidates() -> None:
 
     assert "types: [opened, synchronize, reopened, ready_for_review]" in workflow
     assert "contents: read" in workflow
-    assert "ref: ${{ github.event.pull_request.head.sha }}" in workflow
+    assert "pull_request_target:" in workflow
+    assert "ref: ${{ github.event.repository.default_branch }}" in workflow
+    assert "ref: ${{ github.event.pull_request.head.sha }}" not in workflow
     assert "group: pr-review-${{ github.event.pull_request.number }}" in workflow
     assert "cancel-in-progress: true" in workflow
     assert "EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}" in workflow
-    assert 'test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"' in workflow
+    assert 'test "$(git rev-parse HEAD)" != "$EXPECTED_HEAD"' in workflow
 
 
 def test_review_agent_cannot_mutate_the_candidate_or_publish_for_a_stale_head() -> None:

--- a/tests/unit/test_pr_review_agent_workflow.py
+++ b/tests/unit/test_pr_review_agent_workflow.py
@@ -3,12 +3,13 @@ from pathlib import Path
 WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "pr-review.yml"
 
 
-def test_review_agent_fails_before_invocation_when_oauth_credential_is_missing() -> None:
+def test_review_agent_fails_closed_without_exact_head_codex_evidence() -> None:
     workflow = WORKFLOW.read_text()
 
-    assert "Verify reviewer credential" in workflow
-    assert "CLAUDE_CODE_OAUTH_TOKEN is required" in workflow
-    assert "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}" in workflow
+    assert "Verify Codex exact-head evidence" in workflow
+    assert "scripts/verify_codex_review.py" in workflow
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in workflow
+    assert "anthropics/claude-code-action" not in workflow
     assert "if: github.event.pull_request.draft == false" in workflow
 
 
@@ -33,7 +34,7 @@ def test_review_agent_cannot_mutate_the_candidate_or_publish_for_a_stale_head() 
     assert "Verify current PR head before review" in workflow
     assert 'test "$CURRENT_HEAD" = "$EXPECTED_HEAD"' in workflow
     assert "mcp__github_file_ops__commit_files" not in workflow
-    assert "Read,Glob,Grep,LS" in workflow
+    assert "Verify Codex exact-head evidence" in workflow
 
 
 def test_review_command_proposes_fixes_without_committing_to_the_candidate() -> None:


### PR DESCRIPTION
Refs #98

Parent: #95
Umbrella: #60

Migrates the read-only PR Review Agent from Claude credentials/action to exact-head GitHub-visible Codex advisory evidence. Includes fail-closed checks for bot identity, reviewed SHA, and current P1/P2 threads.