### PR TITLE
fix(review): admit exact-head Codex PR review evidence

### DIFF
--- a/docs/PR-REVIEW-AGENT.md
+++ b/docs/PR-REVIEW-AGENT.md
@@ -19,10 +19,12 @@ the normal governed correction loop and receive a new review.
 ## Codex evidence policy
 
 The gate uses no external reviewer credential. It re-observes the current PR
-head and accepts a clean result only from the Codex bot when its GitHub-visible
-comment identifies the current exact SHA and no current non-outdated Codex
-P1/P2 thread exists. GitHub may represent a clean result as a conversation
-comment rather than a pull-request review; it is recorded truthfully as
+head and accepts a clean result only from the Codex bot when either its
+GitHub-visible conversation comment identifies the current exact SHA or its
+authenticated pull-request review is bound to that exact SHA. It paginates both
+evidence surfaces and rejects any current exact-head Codex review body or
+non-outdated review thread containing P0/P1/P2. GitHub may represent a clean
+result as a conversation comment or a pull-request review; it is recorded truthfully as
 `CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD`. Missing, stale, owner-authored,
 trigger-only, or finding-bearing evidence fails closed.
 

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -139,12 +139,14 @@ def _has_exact_bot_review(reviews: list[dict[str, Any]], expected: str) -> bool:
 
     Findings are independently rejected from the complete current thread set below.
     """
-    blockers = ("P0 Badge", "P1 Badge", "P2 Badge")
-    return any(
-        (review.get("user") or {}).get("login") == BOT
-        and review.get("commit_id") == expected
-        and not any(badge in (review.get("body") or "") for badge in blockers)
+    exact = [
+        review
         for review in reviews
+        if (review.get("user") or {}).get("login") == BOT and review.get("commit_id") == expected
+    ]
+    blockers = ("P0 Badge", "P1 Badge", "P2 Badge")
+    return bool(exact) and not any(
+        any(badge in (review.get("body") or "") for badge in blockers) for review in exact
     )
 
 

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -144,9 +144,17 @@ def _has_exact_bot_review(reviews: list[dict[str, Any]], expected: str) -> bool:
         for review in reviews
         if (review.get("user") or {}).get("login") == BOT and review.get("commit_id") == expected
     ]
+    return bool(exact) and not _has_exact_bot_review_blocker(reviews, expected)
+
+
+def _has_exact_bot_review_blocker(reviews: list[dict[str, Any]], expected: str) -> bool:
+    """A top-level finding blocks even when separate clean evidence exists."""
     blockers = ("P0 Badge", "P1 Badge", "P2 Badge")
-    return bool(exact) and not any(
-        any(badge in (review.get("body") or "") for badge in blockers) for review in exact
+    return any(
+        (review.get("user") or {}).get("login") == BOT
+        and review.get("commit_id") == expected
+        and any(badge in (review.get("body") or "") for badge in blockers)
+        for review in reviews
     )
 
 
@@ -160,13 +168,16 @@ def main() -> int:
         if pr["head"]["sha"] != expected:
             raise SystemExit("current PR head changed during Codex evidence verification")
         comments = _all_issue_comments(repository, number)
+        reviews = _all_reviews(repository, number)
         clean_comment = any(
             comment["user"]["login"] == BOT
             and "Codex Review: Didn't find any major issues." in comment["body"]
             and _comment_matches_exact_head(repository, expected, comment["body"])
             for comment in comments
         )
-        clean = clean_comment or _has_exact_bot_review(_all_reviews(repository, number), expected)
+        clean = (clean_comment or _has_exact_bot_review(reviews, expected)) and not (
+            _has_exact_bot_review_blocker(reviews, expected)
+        )
         if clean:
             break
         if time.monotonic() >= deadline:

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -184,7 +184,14 @@ def main() -> int:
             raise SystemExit("missing clean exact-head Codex advisory evidence")
         time.sleep(10)
     threads = _all_review_threads(repository, number)
-    if _has_current_blocker(threads):
+    # A top-level review has no review thread. Re-fetch it after GraphQL
+    # pagination so a finding submitted during that scan cannot race admission.
+    final_pr = _gh("api", f"repos/{repository}/pulls/{number}")
+    if final_pr["head"]["sha"] != expected:
+        raise SystemExit("current PR head changed during Codex evidence verification")
+    if _has_current_blocker(threads) or _has_exact_bot_review_blocker(
+        _all_reviews(repository, number), expected
+    ):
         raise SystemExit("current Codex P0/P1/P2 finding blocks admission")
     print(f"CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD {expected}")
     return 0

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -158,6 +158,19 @@ def _has_exact_bot_review_blocker(reviews: list[dict[str, Any]], expected: str) 
     )
 
 
+def _review_snapshot_ids(reviews: list[dict[str, Any]]) -> tuple[str, ...]:
+    """Give a deterministic identity to every REST review in an observation."""
+    return tuple(
+        sorted(
+            str(
+                review.get("id")
+                or f"{review.get('commit_id')}:{review.get('submitted_at')}:{review.get('body')}"
+            )
+            for review in reviews
+        )
+    )
+
+
 def main() -> int:
     expected = os.environ["EXPECTED_HEAD"]
     number = os.environ["PR_NUMBER"]
@@ -183,15 +196,22 @@ def main() -> int:
         if time.monotonic() >= deadline:
             raise SystemExit("missing clean exact-head Codex advisory evidence")
         time.sleep(10)
-    threads = _all_review_threads(repository, number)
-    # A top-level review has no review thread. Re-fetch it after GraphQL
-    # pagination so a finding submitted during that scan cannot race admission.
+    # Reviews discovered while threads are being paginated can contain inline
+    # blockers absent from the first thread scan. Retry until both surfaces
+    # share one stable review set.
+    while True:
+        threads = _all_review_threads(repository, number)
+        final_reviews = _all_reviews(repository, number)
+        if _review_snapshot_ids(reviews) == _review_snapshot_ids(final_reviews):
+            reviews = final_reviews
+            break
+        reviews = final_reviews
+
+    # A top-level review has no review thread, so inspect its final stable set.
     final_pr = _gh("api", f"repos/{repository}/pulls/{number}")
     if final_pr["head"]["sha"] != expected:
         raise SystemExit("current PR head changed during Codex evidence verification")
-    if _has_current_blocker(threads) or _has_exact_bot_review_blocker(
-        _all_reviews(repository, number), expected
-    ):
+    if _has_current_blocker(threads) or _has_exact_bot_review_blocker(reviews, expected):
         raise SystemExit("current Codex P0/P1/P2 finding blocks admission")
     print(f"CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD {expected}")
     return 0

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -139,8 +139,11 @@ def _has_exact_bot_review(reviews: list[dict[str, Any]], expected: str) -> bool:
 
     Findings are independently rejected from the complete current thread set below.
     """
+    blockers = ("P0 Badge", "P1 Badge", "P2 Badge")
     return any(
-        review.get("user", {}).get("login") == BOT and review.get("commit_id") == expected
+        (review.get("user") or {}).get("login") == BOT
+        and review.get("commit_id") == expected
+        and not any(badge in (review.get("body") or "") for badge in blockers)
         for review in reviews
     )
 

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -32,6 +32,21 @@ def _all_issue_comments(repository: str, number: str) -> list[dict[str, Any]]:
         page += 1
 
 
+def _all_reviews(repository: str, number: str) -> list[dict[str, Any]]:
+    """Fetch every REST page: exact-head Codex reviews are authoritative evidence."""
+    reviews: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        current = _gh(
+            "api",
+            f"repos/{repository}/pulls/{number}/reviews?per_page=100&page={page}",
+        )
+        reviews.extend(current)
+        if len(current) < 100:
+            return reviews
+        page += 1
+
+
 def _all_thread_comments(thread: dict[str, Any]) -> list[dict[str, Any]]:
     """Fetch all comments in one review thread before treating it as clean."""
     comments = list(thread["comments"]["nodes"])
@@ -119,6 +134,17 @@ def _comment_matches_exact_head(repository: str, expected: str, body: str) -> bo
     return resolved["sha"] == expected
 
 
+def _has_exact_bot_review(reviews: list[dict[str, Any]], expected: str) -> bool:
+    """A GitHub PR review is clean evidence when it is bot-authored and exact-head bound.
+
+    Findings are independently rejected from the complete current thread set below.
+    """
+    return any(
+        review.get("user", {}).get("login") == BOT and review.get("commit_id") == expected
+        for review in reviews
+    )
+
+
 def main() -> int:
     expected = os.environ["EXPECTED_HEAD"]
     number = os.environ["PR_NUMBER"]
@@ -129,12 +155,13 @@ def main() -> int:
         if pr["head"]["sha"] != expected:
             raise SystemExit("current PR head changed during Codex evidence verification")
         comments = _all_issue_comments(repository, number)
-        clean = any(
+        clean_comment = any(
             comment["user"]["login"] == BOT
             and "Codex Review: Didn't find any major issues." in comment["body"]
             and _comment_matches_exact_head(repository, expected, comment["body"])
             for comment in comments
         )
+        clean = clean_comment or _has_exact_bot_review(_all_reviews(repository, number), expected)
         if clean:
             break
         if time.monotonic() >= deadline:

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -170,6 +170,23 @@ def test_any_exact_head_bot_review_with_a_blocker_rejects_the_evidence_set(verif
     assert not verifier_module._has_exact_bot_review(reviews, expected)
 
 
+def test_exact_head_review_body_blocker_is_detected_independently_of_clean_evidence(
+    verifier_module,
+) -> None:
+    expected = "a" * 40
+
+    assert verifier_module._has_exact_bot_review_blocker(
+        [
+            {
+                "user": {"login": verifier_module.BOT},
+                "commit_id": expected,
+                "body": "![P2 Badge] must block even with a clean comment",
+            }
+        ],
+        expected,
+    )
+
+
 def test_all_review_threads_finds_blocker_on_later_graphql_page(
     monkeypatch: pytest.MonkeyPatch, verifier_module
 ) -> None:

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -187,6 +187,36 @@ def test_exact_head_review_body_blocker_is_detected_independently_of_clean_evide
     )
 
 
+def test_main_rechecks_review_bodies_after_thread_pagination(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    """A late top-level finding must not race past the thread scan."""
+    expected = "a" * 40
+    clean_review = {
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "body": "",
+    }
+    late_blocker = {
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "body": "![P1 Badge] submitted during thread pagination",
+    }
+    review_snapshots = iter([[clean_review], [clean_review, late_blocker]])
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+    monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: next(review_snapshots))
+    monkeypatch.setattr(verifier_module, "_all_review_threads", lambda *_args: [])
+
+    with pytest.raises(SystemExit, match="current Codex P0/P1/P2 finding blocks admission"):
+        verifier_module.main()
+
+
 def test_all_review_threads_finds_blocker_on_later_graphql_page(
     monkeypatch: pytest.MonkeyPatch, verifier_module
 ) -> None:

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -202,7 +202,9 @@ def test_main_rechecks_review_bodies_after_thread_pagination(
         "commit_id": expected,
         "body": "![P1 Badge] submitted during thread pagination",
     }
-    review_snapshots = iter([[clean_review], [clean_review, late_blocker]])
+    review_snapshots = iter(
+        [[clean_review], [clean_review, late_blocker], [clean_review, late_blocker]]
+    )
 
     monkeypatch.setenv("EXPECTED_HEAD", expected)
     monkeypatch.setenv("PR_NUMBER", "99")
@@ -212,6 +214,59 @@ def test_main_rechecks_review_bodies_after_thread_pagination(
     monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
     monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: next(review_snapshots))
     monkeypatch.setattr(verifier_module, "_all_review_threads", lambda *_args: [])
+
+    with pytest.raises(SystemExit, match="current Codex P0/P1/P2 finding blocks admission"):
+        verifier_module.main()
+
+
+def test_main_retries_thread_scan_when_review_set_changes(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    """An inline finding in a newly observed review requires a fresh thread scan."""
+    expected = "a" * 40
+    clean_review = {
+        "id": 1,
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "body": "",
+    }
+    late_inline_review = {
+        "id": 2,
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "body": "",
+    }
+    blocker_thread = {
+        "isOutdated": False,
+        "isResolved": False,
+        "comments": {
+            "nodes": [
+                {
+                    "author": {"login": verifier_module.BOT},
+                    "body": "![P1 Badge] submitted after the first thread scan",
+                }
+            ]
+        },
+    }
+    review_snapshots = iter(
+        [
+            [clean_review],
+            [clean_review, late_inline_review],
+            [clean_review, late_inline_review],
+        ]
+    )
+    thread_snapshots = iter([[], [blocker_thread]])
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+    monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: next(review_snapshots))
+    monkeypatch.setattr(
+        verifier_module, "_all_review_threads", lambda *_args: next(thread_snapshots)
+    )
 
     with pytest.raises(SystemExit, match="current Codex P0/P1/P2 finding blocks admission"):
         verifier_module.main()

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -129,6 +129,33 @@ def test_exact_bot_review_is_clean_evidence_only_for_the_current_head(verifier_m
     )
 
 
+def test_finding_bearing_top_level_bot_review_is_not_clean_evidence(verifier_module) -> None:
+    expected = "a" * 40
+
+    assert not verifier_module._has_exact_bot_review(
+        [
+            {
+                "user": {"login": verifier_module.BOT},
+                "commit_id": expected,
+                "body": "![P1 Badge] blocks admission",
+            }
+        ],
+        expected,
+    )
+
+
+def test_deleted_review_author_cannot_crash_exact_review_scan(verifier_module) -> None:
+    expected = "a" * 40
+
+    assert verifier_module._has_exact_bot_review(
+        [
+            {"user": None, "commit_id": expected, "body": ""},
+            {"user": {"login": verifier_module.BOT}, "commit_id": expected, "body": ""},
+        ],
+        expected,
+    )
+
+
 def test_all_review_threads_finds_blocker_on_later_graphql_page(
     monkeypatch: pytest.MonkeyPatch, verifier_module
 ) -> None:

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -156,6 +156,20 @@ def test_deleted_review_author_cannot_crash_exact_review_scan(verifier_module) -
     )
 
 
+def test_any_exact_head_bot_review_with_a_blocker_rejects_the_evidence_set(verifier_module) -> None:
+    expected = "a" * 40
+    reviews = [
+        {"user": {"login": verifier_module.BOT}, "commit_id": expected, "body": ""},
+        {
+            "user": {"login": verifier_module.BOT},
+            "commit_id": expected,
+            "body": "![P1 Badge] conflicting blocker",
+        },
+    ]
+
+    assert not verifier_module._has_exact_bot_review(reviews, expected)
+
+
 def test_all_review_threads_finds_blocker_on_later_graphql_page(
     monkeypatch: pytest.MonkeyPatch, verifier_module
 ) -> None:

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -94,6 +94,41 @@ def test_all_issue_comments_finds_exact_codex_evidence_on_later_rest_page(
     ]
 
 
+def test_all_reviews_finds_exact_codex_review_on_later_rest_page(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    calls: list[tuple[str, ...]] = []
+    first_page = [{"id": index} for index in range(100)]
+    exact_review = {"user": {"login": verifier_module.BOT}, "commit_id": "a" * 40}
+
+    def fake_gh(*args: str):
+        calls.append(args)
+        if args[-1].endswith("page=1"):
+            return first_page
+        if args[-1].endswith("page=2"):
+            return [exact_review]
+        raise AssertionError(args)
+
+    monkeypatch.setattr(verifier_module, "_gh", fake_gh)
+
+    assert verifier_module._all_reviews("owner/repo", "99") == first_page + [exact_review]
+    assert [call[-1] for call in calls] == [
+        "repos/owner/repo/pulls/99/reviews?per_page=100&page=1",
+        "repos/owner/repo/pulls/99/reviews?per_page=100&page=2",
+    ]
+
+
+def test_exact_bot_review_is_clean_evidence_only_for_the_current_head(verifier_module) -> None:
+    expected = "a" * 40
+
+    assert verifier_module._has_exact_bot_review(
+        [{"user": {"login": verifier_module.BOT}, "commit_id": expected}], expected
+    )
+    assert not verifier_module._has_exact_bot_review(
+        [{"user": {"login": verifier_module.BOT}, "commit_id": "b" * 40}], expected
+    )
+
+
 def test_all_review_threads_finds_blocker_on_later_graphql_page(
     monkeypatch: pytest.MonkeyPatch, verifier_module
 ) -> None:


### PR DESCRIPTION
Refs #98

Follow-up acceptance correction for the trusted Codex-only review gate. GitHub exposes authenticated Codex advice as exact-SHA PR review records, not necessarily as a synthetic clean conversation comment. The verifier now paginates those review records and accepts only an exact-head bot review, while retaining current P0/P1/P2 thread blocking and all existing trusted-base, immutable-candidate safeguards.

RED: tests cover later-page review discovery and reject a wrong-head review.