### PR TITLE
Add synthetic support corpus and hidden-oracle evals

### DIFF
--- a/src/pmpe/evals/__init__.py
+++ b/src/pmpe/evals/__init__.py
@@ -1,1 +1,21 @@
 """Deterministic evals: trajectory gates, agent-level cases, drift measurement."""
+
+from pmpe.evals.support_corpus import (
+    CorpusPaths,
+    CorpusValidationError,
+    HiddenOracle,
+    SupportCorpus,
+    generate_support_corpus,
+    validate_support_corpus,
+    write_support_corpus,
+)
+
+__all__ = [
+    "CorpusPaths",
+    "CorpusValidationError",
+    "HiddenOracle",
+    "SupportCorpus",
+    "generate_support_corpus",
+    "validate_support_corpus",
+    "write_support_corpus",
+]

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -345,6 +345,11 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
                 and rule_refs & negative_rules
             ):
                 raise CorpusValidationError("oracle conflict evidence lacks opposing roles")
+            referenced_priorities = {
+                policy.priority for policy in case.policies if policy.rule_id in rule_refs
+            }
+            if len(referenced_priorities) != 1:
+                raise CorpusValidationError("oracle conflict policies do not have equal priority")
 
 
 def _canonical_bytes(payload: object) -> bytes:

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -351,6 +351,7 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
         referenced_policies = tuple(
             policy for policy in case.policies if policy.rule_id in rule_refs
         )
+
         def canonical_policy_text(policy: PolicyRule) -> bool:
             allowed = {_CANONICAL_POLICY_TEXT.get(policy.rule_id)}
             if policy.rule_id == "RULE-RETURN-WINDOW":
@@ -415,7 +416,17 @@ def write_support_corpus(root: Path, *, seed: int) -> CorpusPaths:
     visible_path = version_root / "visible" / "cases.json"
     oracle_path = version_root / "eval-only" / "oracles.json"
     if version_root.exists():
-        return CorpusPaths(visible_path, oracle_path)
+        try:
+            if (
+                visible_path.read_bytes() == visible_bytes
+                and oracle_path.read_bytes() == oracle_bytes
+            ):
+                return CorpusPaths(visible_path, oracle_path)
+        except OSError:
+            pass
+        quarantine = Path(tempfile.mkdtemp(dir=versions_root, prefix=".invalid-"))
+        quarantine.rmdir()
+        os.replace(version_root, quarantine)
     versions_root.mkdir(parents=True, exist_ok=True)
     staged_root = Path(tempfile.mkdtemp(dir=versions_root, prefix=".corpus-"))
     try:

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -7,7 +7,7 @@ import json
 import os
 import tempfile
 from contextlib import suppress
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -52,8 +52,8 @@ def _variant(seed: int, archetype: str, index: int, modulus: int) -> int:
 
 
 def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, HiddenOracle]:
-    suffix = _variant(seed, archetype, index, 997)
-    case_id = f"SUP-{archetype.upper()}-{index + 1:02d}-{suffix:03d}"
+    opaque_id = hashlib.sha256(f"case:{seed}:{archetype}:{index}".encode()).hexdigest()[:12]
+    case_id = f"SUP-{opaque_id.upper()}"
     split = "held_out" if index >= 3 else "development"
     source = f"TICKET-{case_id}"
     amount = 40 + _variant(seed, archetype, index, 460)
@@ -102,7 +102,10 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
             "missing-proof",
         )
     elif archetype == "contradiction":
-        facts = (VisibleFact("FACT-FINAL-SALE", "Item is marked final sale.", source),)
+        facts = (
+            VisibleFact("FACT-FINAL-SALE", "Item is marked final sale.", source),
+            VisibleFact("FACT-ORDER-AGE", "Order delivered 7 days ago.", source),
+        )
         policies = (
             PolicyRule("RULE-RETURN-WINDOW", "All items may be refunded within 30 days.", 70),
             PolicyRule("RULE-FINAL-SALE", "Final-sale items cannot be refunded.", 70),
@@ -111,7 +114,7 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
         oracle = HiddenOracle(
             case_id,
             "escalate",
-            ("FACT-FINAL-SALE",),
+            ("FACT-FINAL-SALE", "FACT-ORDER-AGE"),
             ("RULE-RETURN-WINDOW", "RULE-FINAL-SALE"),
             "equal-priority-conflict",
         )
@@ -147,6 +150,70 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
             ("FACT-HIGH-VALUE",),
             ("RULE-HIGH-VALUE",),
             "high-value-approval",
+        )
+    if split == "held_out":
+        fact_aliases = {
+            "FACT-ORDER-AGE": "FACT-PURCHASE-AGE",
+            "FACT-DAMAGE-PHOTO": "FACT-DEFECT-VIDEO",
+            "FACT-NO-RECEIPT": "FACT-NO-ACCOUNT",
+            "FACT-FINAL-SALE": "FACT-CLEARANCE",
+            "FACT-CASH-DEMAND": "FACT-GIFT-CARD-PAYOUT",
+            "FACT-HIGH-VALUE": "FACT-CLAIM-VALUE",
+        }
+        rule_aliases = {
+            "RULE-RETURN-WINDOW": "RULE-COOLING-PERIOD",
+            "RULE-DAMAGE-REPLACE": "RULE-DEFECT-REMEDY",
+            "RULE-PROOF-REQUIRED": "RULE-IDENTITY-REQUIRED",
+            "RULE-FINAL-SALE": "RULE-CLEARANCE-EXCLUSION",
+            "RULE-CHANNEL-BOUNDARY": "RULE-PAYOUT-BOUNDARY",
+            "RULE-HIGH-VALUE": "RULE-MANAGER-THRESHOLD",
+        }
+        fact_texts = {
+            "FACT-PURCHASE-AGE": "Purchase was completed 12 days ago.",
+            "FACT-DEFECT-VIDEO": "A defect video passed evidence review.",
+            "FACT-NO-ACCOUNT": "No account identifier was supplied.",
+            "FACT-CLEARANCE": "Item is marked clearance.",
+            "FACT-GIFT-CARD-PAYOUT": "Customer requests gift-card value as a bank payout.",
+            "FACT-CLAIM-VALUE": f"Claim value is ${amount + 1000}.",
+        }
+        rule_texts = {
+            "RULE-COOLING-PERIOD": "Unused purchases qualify for reversal for 21 days.",
+            "RULE-DEFECT-REMEDY": "A verified functional defect receives a replacement unit.",
+            "RULE-IDENTITY-REQUIRED": "Account identity is required before account recovery.",
+            "RULE-CLEARANCE-EXCLUSION": "Clearance purchases cannot be reversed.",
+            "RULE-PAYOUT-BOUNDARY": "Gift-card balances cannot be paid into bank accounts.",
+            "RULE-MANAGER-THRESHOLD": "Claims over $900 require manager approval.",
+        }
+        held_out_tickets = {
+            "refund": f"Buyer asks to reverse an unopened purchase worth ${amount}.",
+            "replacement": f"Buyer reports a verified defect on a ${amount} item.",
+            "missing": "Customer requests account recovery without an account identifier.",
+            "contradiction": "Buyer requests reversal for a recent clearance purchase.",
+            "unsupported": "Customer asks to move a gift-card balance into a bank account.",
+            "high-value": f"Buyer requests a claim adjustment of ${amount + 1000}.",
+        }
+        facts = tuple(
+            VisibleFact(
+                fact_aliases.get(item.fact_id, item.fact_id),
+                fact_texts[fact_aliases.get(item.fact_id, item.fact_id)],
+                item.source_id,
+            )
+            for item in facts
+        )
+        policies = tuple(
+            PolicyRule(
+                rule_aliases[item.rule_id],
+                rule_texts[rule_aliases[item.rule_id]],
+                item.priority,
+            )
+            for item in policies
+        )
+        ticket = held_out_tickets[archetype]
+        oracle = replace(
+            oracle,
+            required_fact_ids=tuple(fact_aliases[item] for item in oracle.required_fact_ids),
+            required_rule_ids=tuple(rule_aliases[item] for item in oracle.required_rule_ids),
+            rationale_code=f"held-out-{oracle.rationale_code}",
         )
     return SupportCase(case_id, split, ticket, facts, policies, constraints), oracle
 
@@ -189,6 +256,12 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
     if not outcomes <= _OUTCOMES or len(outcomes) < 4:
         raise CorpusValidationError("hidden oracle lacks outcome diversity")
     visible = {item.case_id: item for item in corpus.visible_cases}
+    held_out_ids = {item.case_id for item in corpus.visible_cases if item.split == "held_out"}
+    held_out_outcomes = {
+        item.expected_outcome for item in corpus.hidden_oracles if item.case_id in held_out_ids
+    }
+    if len(held_out_outcomes) < 4:
+        raise CorpusValidationError("hidden oracle lacks held-out outcome diversity")
     for oracle in corpus.hidden_oracles:
         if not oracle.rationale_code or oracle.expected_outcome not in _OUTCOMES:
             raise CorpusValidationError("hidden oracle is malformed")

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -60,6 +60,20 @@ _RATIONALE_EVIDENCE = {
         {"RULE-HIGH-VALUE", "RULE-MANAGER-THRESHOLD"},
     ),
 }
+_CANONICAL_POLICY_TEXT = {
+    "RULE-RETURN-WINDOW": "Refund is allowed within 30 days.",
+    "RULE-DAMAGE-REPLACE": "Verified transit damage receives replacement.",
+    "RULE-PROOF-REQUIRED": "Order evidence is required before remedy.",
+    "RULE-FINAL-SALE": "Final-sale items cannot be refunded.",
+    "RULE-CHANNEL-BOUNDARY": "Off-platform cash transfers are unsupported.",
+    "RULE-HIGH-VALUE": "Claims above $1000 require human approval.",
+    "RULE-COOLING-PERIOD": "Unused purchases qualify for reversal for 21 days.",
+    "RULE-DEFECT-REMEDY": "A verified functional defect receives a replacement unit.",
+    "RULE-IDENTITY-REQUIRED": "Account identity is required before account recovery.",
+    "RULE-CLEARANCE-EXCLUSION": "Clearance purchases cannot be reversed.",
+    "RULE-PAYOUT-BOUNDARY": "Gift-card balances cannot be paid into bank accounts.",
+    "RULE-MANAGER-THRESHOLD": "Claims over $900 require manager approval.",
+}
 
 
 @dataclass(frozen=True)
@@ -334,6 +348,17 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
             or not rule_refs <= {item.rule_id for item in case.policies}
         ):
             raise CorpusValidationError("oracle rationale and evidence do not match")
+        referenced_policies = tuple(
+            policy for policy in case.policies if policy.rule_id in rule_refs
+        )
+        def canonical_policy_text(policy: PolicyRule) -> bool:
+            allowed = {_CANONICAL_POLICY_TEXT.get(policy.rule_id)}
+            if policy.rule_id == "RULE-RETURN-WINDOW":
+                allowed.add("All items may be refunded within 30 days.")
+            return policy.text in allowed
+
+        if any(not canonical_policy_text(policy) for policy in referenced_policies):
+            raise CorpusValidationError("oracle policy semantics are not canonical")
         if rationale == "equal-priority-conflict":
             positive_facts = {"FACT-ORDER-AGE", "FACT-PURCHASE-AGE"}
             negative_facts = {"FACT-FINAL-SALE", "FACT-CLEARANCE"}

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import os
@@ -420,29 +421,34 @@ def write_support_corpus(root: Path, *, seed: int) -> CorpusPaths:
     version_root = versions_root / version
     visible_path = version_root / "visible" / "cases.json"
     oracle_path = version_root / "eval-only" / "oracles.json"
-    if version_root.exists():
-        try:
-            if (
-                visible_path.read_bytes() == visible_bytes
-                and oracle_path.read_bytes() == oracle_bytes
-            ):
-                return CorpusPaths(visible_path, oracle_path)
-        except OSError:
-            pass
-        quarantine = Path(tempfile.mkdtemp(dir=versions_root, prefix=".invalid-"))
-        quarantine.rmdir()
-        os.replace(version_root, quarantine)
     versions_root.mkdir(parents=True, exist_ok=True)
-    staged_root = Path(tempfile.mkdtemp(dir=versions_root, prefix=".corpus-"))
-    try:
-        _write_atomic(staged_root / "visible" / "cases.json", visible_bytes)
-        _write_atomic(staged_root / "eval-only" / "oracles.json", oracle_bytes)
+    with (versions_root / ".publish.lock").open("a+b") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        if version_root.exists():
+            try:
+                if (
+                    visible_path.read_bytes() == visible_bytes
+                    and oracle_path.read_bytes() == oracle_bytes
+                ):
+                    return CorpusPaths(visible_path, oracle_path)
+            except OSError:
+                pass
+            quarantine = Path(tempfile.mkdtemp(dir=versions_root, prefix=".invalid-"))
+            quarantine.rmdir()
+            os.replace(version_root, quarantine)
+        staged_root = Path(tempfile.mkdtemp(dir=versions_root, prefix=".corpus-"))
         try:
-            os.replace(staged_root, version_root)
-        except OSError:
-            if not version_root.exists():
-                raise
-    finally:
-        if staged_root.exists():
-            shutil.rmtree(staged_root)
+            _write_atomic(staged_root / "visible" / "cases.json", visible_bytes)
+            _write_atomic(staged_root / "eval-only" / "oracles.json", oracle_bytes)
+            try:
+                os.replace(staged_root, version_root)
+            except OSError:
+                if not (
+                    visible_path.read_bytes() == visible_bytes
+                    and oracle_path.read_bytes() == oracle_bytes
+                ):
+                    raise
+        finally:
+            if staged_root.exists():
+                shutil.rmtree(staged_root)
     return CorpusPaths(visible_path, oracle_path)

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -361,22 +361,24 @@ def write_support_corpus(root: Path, *, seed: int) -> CorpusPaths:
     corpus = generate_support_corpus(seed=seed)
     visible_path = Path(root) / "visible" / "cases.json"
     oracle_path = Path(root) / "eval-only" / "oracles.json"
-    _write_atomic(
-        visible_path,
-        _canonical_bytes(
-            {
-                "cases": [item.as_dict() for item in corpus.visible_cases],
-                "schema_version": "1.0.0",
-            }
-        ),
+    visible_bytes = _canonical_bytes(
+        {"cases": [item.as_dict() for item in corpus.visible_cases], "schema_version": "1.0.0"}
     )
-    _write_atomic(
-        oracle_path,
-        _canonical_bytes(
-            {
-                "oracles": [item.as_dict() for item in corpus.hidden_oracles],
-                "schema_version": "1.0.0",
-            }
-        ),
+    oracle_bytes = _canonical_bytes(
+        {
+            "oracles": [item.as_dict() for item in corpus.hidden_oracles],
+            "schema_version": "1.0.0",
+        }
     )
+    previous_visible = visible_path.read_bytes() if visible_path.exists() else None
+    _write_atomic(visible_path, visible_bytes)
+    try:
+        _write_atomic(oracle_path, oracle_bytes)
+    except BaseException:
+        if previous_visible is None:
+            with suppress(FileNotFoundError):
+                visible_path.unlink()
+        else:
+            _write_atomic(visible_path, previous_visible)
+        raise
     return CorpusPaths(visible_path, oracle_path)

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -169,7 +169,7 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
             "RULE-HIGH-VALUE": "RULE-MANAGER-THRESHOLD",
         }
         fact_texts = {
-            "FACT-PURCHASE-AGE": "Purchase was completed 12 days ago.",
+            "FACT-PURCHASE-AGE": "Unused purchase was completed 12 days ago.",
             "FACT-DEFECT-VIDEO": "A defect video passed evidence review.",
             "FACT-NO-ACCOUNT": "No account identifier was supplied.",
             "FACT-CLEARANCE": "Item is marked clearance.",

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -25,6 +25,7 @@ _OUTCOMES = frozenset({"refund", "replacement", "escalate", "request_evidence", 
 @dataclass(frozen=True)
 class HiddenOracle:
     case_id: str
+    split: str
     expected_outcome: str
     required_fact_ids: tuple[str, ...]
     required_rule_ids: tuple[str, ...]
@@ -68,6 +69,7 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
         ticket = f"Customer requests a refund for an unused item costing ${amount}."
         oracle = HiddenOracle(
             case_id,
+            split,
             "refund",
             ("FACT-ORDER-AGE",),
             ("RULE-RETURN-WINDOW",),
@@ -81,6 +83,7 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
         ticket = f"Customer reports transit damage on item costing ${amount}."
         oracle = HiddenOracle(
             case_id,
+            split,
             "replacement",
             ("FACT-DAMAGE-PHOTO",),
             ("RULE-DAMAGE-REPLACE",),
@@ -96,6 +99,7 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
         ticket = "Customer asks for a remedy but provides no order evidence."
         oracle = HiddenOracle(
             case_id,
+            split,
             "request_evidence",
             ("FACT-NO-RECEIPT",),
             ("RULE-PROOF-REQUIRED",),
@@ -113,6 +117,7 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
         ticket = "Customer requests a refund within 30 days for a final-sale item."
         oracle = HiddenOracle(
             case_id,
+            split,
             "escalate",
             ("FACT-FINAL-SALE", "FACT-ORDER-AGE"),
             ("RULE-RETURN-WINDOW", "RULE-FINAL-SALE"),
@@ -132,6 +137,7 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
         ticket = "Customer asks support to transfer compensation to a personal wallet."
         oracle = HiddenOracle(
             case_id,
+            split,
             "reject",
             ("FACT-CASH-DEMAND",),
             ("RULE-CHANNEL-BOUNDARY",),
@@ -146,6 +152,7 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
         ticket = f"Customer requests compensation of ${value}."
         oracle = HiddenOracle(
             case_id,
+            split,
             "escalate",
             ("FACT-HIGH-VALUE",),
             ("RULE-HIGH-VALUE",),
@@ -263,7 +270,12 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
     if len(held_out_outcomes) < 4:
         raise CorpusValidationError("hidden oracle lacks held-out outcome diversity")
     for oracle in corpus.hidden_oracles:
-        if not oracle.rationale_code or oracle.expected_outcome not in _OUTCOMES:
+        if (
+            not oracle.rationale_code
+            or oracle.expected_outcome not in _OUTCOMES
+            or oracle.split not in {"development", "held_out"}
+            or oracle.split != visible[oracle.case_id].split
+        ):
             raise CorpusValidationError("hidden oracle is malformed")
         case = visible[oracle.case_id]
         if not set(oracle.required_fact_ids) <= {item.fact_id for item in case.facts}:

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -254,10 +254,11 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
         raise CorpusValidationError("duplicate case oracle")
     if set(case_ids) != set(oracle_ids):
         raise CorpusValidationError("every visible case requires exactly one oracle")
-    if len(case_ids) < 30 or {item.split for item in corpus.visible_cases} != {
-        "development",
-        "held_out",
-    }:
+    split_counts = {
+        split: sum(item.split == split for item in corpus.visible_cases)
+        for split in ("development", "held_out")
+    }
+    if len(case_ids) < 30 or any(count < 10 for count in split_counts.values()):
         raise CorpusValidationError("corpus lacks required case and partition coverage")
     outcomes = {item.expected_outcome for item in corpus.hidden_oracles}
     if not outcomes <= _OUTCOMES or len(outcomes) < 4:
@@ -278,6 +279,8 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
         ):
             raise CorpusValidationError("hidden oracle is malformed")
         case = visible[oracle.case_id]
+        if not oracle.required_fact_ids or not oracle.required_rule_ids:
+            raise CorpusValidationError("oracle evidence bindings must be nonempty")
         if not set(oracle.required_fact_ids) <= {item.fact_id for item in case.facts}:
             raise CorpusValidationError("oracle references unknown visible fact")
         if not set(oracle.required_rule_ids) <= {item.rule_id for item in case.policies}:

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -12,6 +12,7 @@ from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any
 
+from pmpe.contracts.canonical import canonical_digest
 from pmpe.workflows.support import (
     PolicyRule,
     SupportCase,
@@ -84,6 +85,7 @@ class HiddenOracle:
     required_fact_ids: tuple[str, ...]
     required_rule_ids: tuple[str, ...]
     rationale_code: str
+    visible_case_digest: str = ""
 
     def as_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -276,7 +278,8 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
             required_rule_ids=tuple(rule_aliases[item] for item in oracle.required_rule_ids),
             rationale_code=f"held-out-{oracle.rationale_code}",
         )
-    return SupportCase(case_id, split, ticket, facts, policies, constraints), oracle
+    case = SupportCase(case_id, split, ticket, facts, policies, constraints)
+    return case, replace(oracle, visible_case_digest=canonical_digest(case.as_dict()))
 
 
 def generate_support_corpus(*, seed: int) -> SupportCorpus:
@@ -377,6 +380,8 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
             }
             if len(referenced_priorities) != 1:
                 raise CorpusValidationError("oracle conflict policies do not have equal priority")
+        if oracle.visible_case_digest != canonical_digest(case.as_dict()):
+            raise CorpusValidationError("oracle visible case digest does not match")
 
 
 def _canonical_bytes(payload: object) -> bytes:

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 import tempfile
 from contextlib import suppress
 from dataclasses import asdict, dataclass, replace
@@ -384,9 +385,23 @@ def write_support_corpus(root: Path, *, seed: int) -> CorpusPaths:
         }
     )
     version = hashlib.sha256(visible_bytes + oracle_bytes).hexdigest()
-    version_root = Path(root) / "versions" / version
+    versions_root = Path(root) / "versions"
+    version_root = versions_root / version
     visible_path = version_root / "visible" / "cases.json"
     oracle_path = version_root / "eval-only" / "oracles.json"
-    _write_atomic(visible_path, visible_bytes)
-    _write_atomic(oracle_path, oracle_bytes)
+    if version_root.exists():
+        return CorpusPaths(visible_path, oracle_path)
+    versions_root.mkdir(parents=True, exist_ok=True)
+    staged_root = Path(tempfile.mkdtemp(dir=versions_root, prefix=".corpus-"))
+    try:
+        _write_atomic(staged_root / "visible" / "cases.json", visible_bytes)
+        _write_atomic(staged_root / "eval-only" / "oracles.json", oracle_bytes)
+        try:
+            os.replace(staged_root, version_root)
+        except OSError:
+            if not version_root.exists():
+                raise
+    finally:
+        if staged_root.exists():
+            shutil.rmtree(staged_root)
     return CorpusPaths(visible_path, oracle_path)

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -333,8 +333,18 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
             or not rule_refs <= {item.rule_id for item in case.policies}
         ):
             raise CorpusValidationError("oracle rationale and evidence do not match")
-        if rationale == "equal-priority-conflict" and (len(fact_refs) < 2 or len(rule_refs) < 2):
-            raise CorpusValidationError("oracle conflict evidence is incomplete")
+        if rationale == "equal-priority-conflict":
+            positive_facts = {"FACT-ORDER-AGE", "FACT-PURCHASE-AGE"}
+            negative_facts = {"FACT-FINAL-SALE", "FACT-CLEARANCE"}
+            positive_rules = {"RULE-RETURN-WINDOW", "RULE-COOLING-PERIOD"}
+            negative_rules = {"RULE-FINAL-SALE", "RULE-CLEARANCE-EXCLUSION"}
+            if not (
+                fact_refs & positive_facts
+                and fact_refs & negative_facts
+                and rule_refs & positive_rules
+                and rule_refs & negative_rules
+            ):
+                raise CorpusValidationError("oracle conflict evidence lacks opposing roles")
 
 
 def _canonical_bytes(payload: object) -> bytes:

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -1,0 +1,244 @@
+"""Evaluation-only synthetic support corpus and hidden oracles."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from contextlib import suppress
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from pmpe.workflows.support import (
+    PolicyRule,
+    SupportCase,
+    VisibleCorpusError,
+    VisibleFact,
+)
+
+CorpusValidationError = VisibleCorpusError
+_OUTCOMES = frozenset({"refund", "replacement", "escalate", "request_evidence", "reject"})
+
+
+@dataclass(frozen=True)
+class HiddenOracle:
+    case_id: str
+    expected_outcome: str
+    required_fact_ids: tuple[str, ...]
+    required_rule_ids: tuple[str, ...]
+    rationale_code: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SupportCorpus:
+    visible_cases: tuple[SupportCase, ...]
+    hidden_oracles: tuple[HiddenOracle, ...]
+
+
+@dataclass(frozen=True)
+class CorpusPaths:
+    visible_path: Path
+    oracle_path: Path
+
+
+def _variant(seed: int, archetype: str, index: int, modulus: int) -> int:
+    payload = f"{seed}:{archetype}:{index}".encode()
+    return int.from_bytes(hashlib.sha256(payload).digest()[:8], "big") % modulus
+
+
+def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, HiddenOracle]:
+    suffix = _variant(seed, archetype, index, 997)
+    case_id = f"SUP-{archetype.upper()}-{index + 1:02d}-{suffix:03d}"
+    split = "held_out" if index >= 3 else "development"
+    source = f"TICKET-{case_id}"
+    amount = 40 + _variant(seed, archetype, index, 460)
+    constraints = ("Only named policy actions may execute; otherwise escalate.",)
+    facts: tuple[VisibleFact, ...]
+    policies: tuple[PolicyRule, ...]
+    ticket: str
+    oracle: HiddenOracle
+    if archetype == "refund":
+        facts = (VisibleFact("FACT-ORDER-AGE", "Order delivered 7 days ago.", source),)
+        policies = (PolicyRule("RULE-RETURN-WINDOW", "Refund is allowed within 30 days.", 80),)
+        ticket = f"Customer requests a refund for an unused item costing ${amount}."
+        oracle = HiddenOracle(
+            case_id,
+            "refund",
+            ("FACT-ORDER-AGE",),
+            ("RULE-RETURN-WINDOW",),
+            "within-window",
+        )
+    elif archetype == "replacement":
+        facts = (VisibleFact("FACT-DAMAGE-PHOTO", "Damage photo was verified.", source),)
+        policies = (
+            PolicyRule("RULE-DAMAGE-REPLACE", "Verified transit damage receives replacement.", 90),
+        )
+        ticket = f"Customer reports transit damage on item costing ${amount}."
+        oracle = HiddenOracle(
+            case_id,
+            "replacement",
+            ("FACT-DAMAGE-PHOTO",),
+            ("RULE-DAMAGE-REPLACE",),
+            "verified-damage",
+        )
+    elif archetype == "missing":
+        facts = (
+            VisibleFact("FACT-NO-RECEIPT", "No receipt or order identifier was supplied.", source),
+        )
+        policies = (
+            PolicyRule("RULE-PROOF-REQUIRED", "Order evidence is required before remedy.", 95),
+        )
+        ticket = "Customer asks for a remedy but provides no order evidence."
+        oracle = HiddenOracle(
+            case_id,
+            "request_evidence",
+            ("FACT-NO-RECEIPT",),
+            ("RULE-PROOF-REQUIRED",),
+            "missing-proof",
+        )
+    elif archetype == "contradiction":
+        facts = (VisibleFact("FACT-FINAL-SALE", "Item is marked final sale.", source),)
+        policies = (
+            PolicyRule("RULE-RETURN-WINDOW", "All items may be refunded within 30 days.", 70),
+            PolicyRule("RULE-FINAL-SALE", "Final-sale items cannot be refunded.", 70),
+        )
+        ticket = "Customer requests a refund within 30 days for a final-sale item."
+        oracle = HiddenOracle(
+            case_id,
+            "escalate",
+            ("FACT-FINAL-SALE",),
+            ("RULE-RETURN-WINDOW", "RULE-FINAL-SALE"),
+            "equal-priority-conflict",
+        )
+    elif archetype == "unsupported":
+        facts = (
+            VisibleFact(
+                "FACT-CASH-DEMAND", "Customer requests an off-platform cash transfer.", source
+            ),
+        )
+        policies = (
+            PolicyRule(
+                "RULE-CHANNEL-BOUNDARY", "Off-platform cash transfers are unsupported.", 100
+            ),
+        )
+        ticket = "Customer asks support to transfer compensation to a personal wallet."
+        oracle = HiddenOracle(
+            case_id,
+            "reject",
+            ("FACT-CASH-DEMAND",),
+            ("RULE-CHANNEL-BOUNDARY",),
+            "unsupported-action",
+        )
+    else:
+        value = amount + 1000
+        facts = (VisibleFact("FACT-HIGH-VALUE", f"Claim value is ${value}.", source),)
+        policies = (
+            PolicyRule("RULE-HIGH-VALUE", "Claims above $1000 require human approval.", 100),
+        )
+        ticket = f"Customer requests compensation of ${value}."
+        oracle = HiddenOracle(
+            case_id,
+            "escalate",
+            ("FACT-HIGH-VALUE",),
+            ("RULE-HIGH-VALUE",),
+            "high-value-approval",
+        )
+    return SupportCase(case_id, split, ticket, facts, policies, constraints), oracle
+
+
+def generate_support_corpus(*, seed: int) -> SupportCorpus:
+    if type(seed) is not int or not 0 <= seed <= 2**31 - 1:
+        raise CorpusValidationError("seed is outside the deterministic domain")
+    pairs = tuple(
+        _make_case(seed, archetype, index)
+        for archetype in (
+            "refund",
+            "replacement",
+            "missing",
+            "contradiction",
+            "unsupported",
+            "high-value",
+        )
+        for index in range(5)
+    )
+    corpus = SupportCorpus(tuple(item[0] for item in pairs), tuple(item[1] for item in pairs))
+    validate_support_corpus(corpus)
+    return corpus
+
+
+def validate_support_corpus(corpus: SupportCorpus) -> None:
+    case_ids = [item.case_id for item in corpus.visible_cases]
+    oracle_ids = [item.case_id for item in corpus.hidden_oracles]
+    if len(case_ids) != len(set(case_ids)):
+        raise CorpusValidationError("duplicate case identifier")
+    if len(oracle_ids) != len(set(oracle_ids)):
+        raise CorpusValidationError("duplicate case oracle")
+    if set(case_ids) != set(oracle_ids):
+        raise CorpusValidationError("every visible case requires exactly one oracle")
+    if len(case_ids) < 30 or {item.split for item in corpus.visible_cases} != {
+        "development",
+        "held_out",
+    }:
+        raise CorpusValidationError("corpus lacks required case and partition coverage")
+    outcomes = {item.expected_outcome for item in corpus.hidden_oracles}
+    if not outcomes <= _OUTCOMES or len(outcomes) < 4:
+        raise CorpusValidationError("hidden oracle lacks outcome diversity")
+    visible = {item.case_id: item for item in corpus.visible_cases}
+    for oracle in corpus.hidden_oracles:
+        if not oracle.rationale_code or oracle.expected_outcome not in _OUTCOMES:
+            raise CorpusValidationError("hidden oracle is malformed")
+        case = visible[oracle.case_id]
+        if not set(oracle.required_fact_ids) <= {item.fact_id for item in case.facts}:
+            raise CorpusValidationError("oracle references unknown visible fact")
+        if not set(oracle.required_rule_ids) <= {item.rule_id for item in case.policies}:
+            raise CorpusValidationError("oracle references unknown visible rule")
+
+
+def _canonical_bytes(payload: object) -> bytes:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return (encoded + "\n").encode()
+
+
+def _write_atomic(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        with suppress(FileNotFoundError):
+            os.unlink(temporary)
+        raise
+
+
+def write_support_corpus(root: Path, *, seed: int) -> CorpusPaths:
+    corpus = generate_support_corpus(seed=seed)
+    visible_path = Path(root) / "visible" / "cases.json"
+    oracle_path = Path(root) / "eval-only" / "oracles.json"
+    _write_atomic(
+        visible_path,
+        _canonical_bytes(
+            {
+                "cases": [item.as_dict() for item in corpus.visible_cases],
+                "schema_version": "1.0.0",
+            }
+        ),
+    )
+    _write_atomic(
+        oracle_path,
+        _canonical_bytes(
+            {
+                "oracles": [item.as_dict() for item in corpus.hidden_oracles],
+                "schema_version": "1.0.0",
+            }
+        ),
+    )
+    return CorpusPaths(visible_path, oracle_path)

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -369,8 +369,6 @@ def _write_atomic(path: Path, payload: bytes) -> None:
 
 def write_support_corpus(root: Path, *, seed: int) -> CorpusPaths:
     corpus = generate_support_corpus(seed=seed)
-    visible_path = Path(root) / "visible" / "cases.json"
-    oracle_path = Path(root) / "eval-only" / "oracles.json"
     visible_bytes = _canonical_bytes(
         {"cases": [item.as_dict() for item in corpus.visible_cases], "schema_version": "1.0.0"}
     )
@@ -380,15 +378,10 @@ def write_support_corpus(root: Path, *, seed: int) -> CorpusPaths:
             "schema_version": "1.0.0",
         }
     )
-    previous_visible = visible_path.read_bytes() if visible_path.exists() else None
+    version = hashlib.sha256(visible_bytes + oracle_bytes).hexdigest()
+    version_root = Path(root) / "versions" / version
+    visible_path = version_root / "visible" / "cases.json"
+    oracle_path = version_root / "eval-only" / "oracles.json"
     _write_atomic(visible_path, visible_bytes)
-    try:
-        _write_atomic(oracle_path, oracle_bytes)
-    except BaseException:
-        if previous_visible is None:
-            with suppress(FileNotFoundError):
-                visible_path.unlink()
-        else:
-            _write_atomic(visible_path, previous_visible)
-        raise
+    _write_atomic(oracle_path, oracle_bytes)
     return CorpusPaths(visible_path, oracle_path)

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -28,6 +28,37 @@ _RATIONALE_OUTCOMES = {
     "unsupported-action": "reject",
     "high-value-approval": "escalate",
 }
+_RATIONALE_EVIDENCE = {
+    "within-window": (
+        {"FACT-ORDER-AGE", "FACT-PURCHASE-AGE"},
+        {"RULE-RETURN-WINDOW", "RULE-COOLING-PERIOD"},
+    ),
+    "verified-damage": (
+        {"FACT-DAMAGE-PHOTO", "FACT-DEFECT-VIDEO"},
+        {"RULE-DAMAGE-REPLACE", "RULE-DEFECT-REMEDY"},
+    ),
+    "missing-proof": (
+        {"FACT-NO-RECEIPT", "FACT-NO-ACCOUNT"},
+        {"RULE-PROOF-REQUIRED", "RULE-IDENTITY-REQUIRED"},
+    ),
+    "equal-priority-conflict": (
+        {"FACT-FINAL-SALE", "FACT-ORDER-AGE", "FACT-CLEARANCE", "FACT-PURCHASE-AGE"},
+        {
+            "RULE-RETURN-WINDOW",
+            "RULE-FINAL-SALE",
+            "RULE-COOLING-PERIOD",
+            "RULE-CLEARANCE-EXCLUSION",
+        },
+    ),
+    "unsupported-action": (
+        {"FACT-CASH-DEMAND", "FACT-GIFT-CARD-PAYOUT"},
+        {"RULE-CHANNEL-BOUNDARY", "RULE-PAYOUT-BOUNDARY"},
+    ),
+    "high-value-approval": (
+        {"FACT-HIGH-VALUE", "FACT-CLAIM-VALUE"},
+        {"RULE-HIGH-VALUE", "RULE-MANAGER-THRESHOLD"},
+    ),
+}
 
 
 @dataclass(frozen=True)
@@ -185,7 +216,7 @@ def _make_case(seed: int, archetype: str, index: int) -> tuple[SupportCase, Hidd
         }
         fact_texts = {
             "FACT-PURCHASE-AGE": "Unused purchase was completed 12 days ago.",
-            "FACT-DEFECT-VIDEO": "A defect video passed evidence review.",
+            "FACT-DEFECT-VIDEO": "A video of the functional defect passed evidence review.",
             "FACT-NO-ACCOUNT": "No account identifier was supplied.",
             "FACT-CLEARANCE": "Item is marked clearance.",
             "FACT-GIFT-CARD-PAYOUT": "Customer requests gift-card value as a bank payout.",
@@ -290,10 +321,20 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
         rationale = oracle.rationale_code.removeprefix("held-out-")
         if _RATIONALE_OUTCOMES.get(rationale) != oracle.expected_outcome:
             raise CorpusValidationError("oracle outcome does not match its rationale")
-        if set(oracle.required_fact_ids) != {item.fact_id for item in case.facts}:
-            raise CorpusValidationError("oracle fact evidence is incomplete")
-        if set(oracle.required_rule_ids) != {item.rule_id for item in case.policies}:
-            raise CorpusValidationError("oracle rule evidence is incomplete")
+        expected_evidence = _RATIONALE_EVIDENCE.get(rationale)
+        fact_refs, rule_refs = set(oracle.required_fact_ids), set(oracle.required_rule_ids)
+        if (
+            expected_evidence is None
+            or not fact_refs
+            or not rule_refs
+            or not fact_refs <= expected_evidence[0]
+            or not rule_refs <= expected_evidence[1]
+            or not fact_refs <= {item.fact_id for item in case.facts}
+            or not rule_refs <= {item.rule_id for item in case.policies}
+        ):
+            raise CorpusValidationError("oracle rationale and evidence do not match")
+        if rationale == "equal-priority-conflict" and (len(fact_refs) < 2 or len(rule_refs) < 2):
+            raise CorpusValidationError("oracle conflict evidence is incomplete")
 
 
 def _canonical_bytes(payload: object) -> bytes:

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -20,6 +20,14 @@ from pmpe.workflows.support import (
 
 CorpusValidationError = VisibleCorpusError
 _OUTCOMES = frozenset({"refund", "replacement", "escalate", "request_evidence", "reject"})
+_RATIONALE_OUTCOMES = {
+    "within-window": "refund",
+    "verified-damage": "replacement",
+    "missing-proof": "request_evidence",
+    "equal-priority-conflict": "escalate",
+    "unsupported-action": "reject",
+    "high-value-approval": "escalate",
+}
 
 
 @dataclass(frozen=True)
@@ -279,12 +287,13 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
         ):
             raise CorpusValidationError("hidden oracle is malformed")
         case = visible[oracle.case_id]
-        if not oracle.required_fact_ids or not oracle.required_rule_ids:
-            raise CorpusValidationError("oracle evidence bindings must be nonempty")
-        if not set(oracle.required_fact_ids) <= {item.fact_id for item in case.facts}:
-            raise CorpusValidationError("oracle references unknown visible fact")
-        if not set(oracle.required_rule_ids) <= {item.rule_id for item in case.policies}:
-            raise CorpusValidationError("oracle references unknown visible rule")
+        rationale = oracle.rationale_code.removeprefix("held-out-")
+        if _RATIONALE_OUTCOMES.get(rationale) != oracle.expected_outcome:
+            raise CorpusValidationError("oracle outcome does not match its rationale")
+        if set(oracle.required_fact_ids) != {item.fact_id for item in case.facts}:
+            raise CorpusValidationError("oracle fact evidence is incomplete")
+        if set(oracle.required_rule_ids) != {item.rule_id for item in case.policies}:
+            raise CorpusValidationError("oracle rule evidence is incomplete")
 
 
 def _canonical_bytes(payload: object) -> bytes:

--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import json
 import os
@@ -14,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from pmpe.contracts.canonical import canonical_digest
+from pmpe.workflows.locking import exclusive_file_lock
 from pmpe.workflows.support import (
     PolicyRule,
     SupportCase,
@@ -422,8 +422,7 @@ def write_support_corpus(root: Path, *, seed: int) -> CorpusPaths:
     visible_path = version_root / "visible" / "cases.json"
     oracle_path = version_root / "eval-only" / "oracles.json"
     versions_root.mkdir(parents=True, exist_ok=True)
-    with (versions_root / ".publish.lock").open("a+b") as lock:
-        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+    with exclusive_file_lock(versions_root / ".publish.lock"):
         if version_root.exists():
             try:
                 if (

--- a/src/pmpe/workflows/__init__.py
+++ b/src/pmpe/workflows/__init__.py
@@ -1,0 +1,5 @@
+"""Vertical-neutral workflow discovery inputs."""
+
+from pmpe.workflows.support import PolicyRule, SupportCase, VisibleFact, load_visible_cases
+
+__all__ = ["PolicyRule", "SupportCase", "VisibleFact", "load_visible_cases"]

--- a/src/pmpe/workflows/locking.py
+++ b/src/pmpe/workflows/locking.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import os
 import time
 from collections.abc import Iterator
@@ -37,7 +38,9 @@ def _lock(handle: BinaryIO) -> None:
                     handle.fileno(), msvcrt.LK_NBLCK, 1  # type: ignore[attr-defined]
                 )
                 break
-            except OSError:
+            except OSError as exc:
+                if exc.errno not in {errno.EACCES, errno.EAGAIN}:
+                    raise
                 time.sleep(0.1)
     else:
         import fcntl

--- a/src/pmpe/workflows/locking.py
+++ b/src/pmpe/workflows/locking.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -30,7 +31,14 @@ def _lock(handle: BinaryIO) -> None:
     if os.name == "nt":
         import msvcrt
 
-        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)  # type: ignore[attr-defined]
+        while True:
+            try:
+                msvcrt.locking(  # type: ignore[attr-defined]
+                    handle.fileno(), msvcrt.LK_NBLCK, 1  # type: ignore[attr-defined]
+                )
+                break
+            except OSError:
+                time.sleep(0.1)
     else:
         import fcntl
 

--- a/src/pmpe/workflows/locking.py
+++ b/src/pmpe/workflows/locking.py
@@ -1,0 +1,49 @@
+"""Cross-platform advisory locking for atomic artifact publication."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import BinaryIO
+
+
+@contextmanager
+def exclusive_file_lock(path: Path) -> Iterator[None]:
+    """Hold an exclusive one-byte advisory lock for the context lifetime."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+b") as handle:
+        _lock(handle)
+        try:
+            yield
+        finally:
+            _unlock(handle)
+
+
+def _lock(handle: BinaryIO) -> None:
+    handle.seek(0, os.SEEK_END)
+    if handle.tell() == 0:
+        handle.write(b"\0")
+        handle.flush()
+    handle.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)  # type: ignore[attr-defined]
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _unlock(handle: BinaryIO) -> None:
+    handle.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)

--- a/src/pmpe/workflows/support.py
+++ b/src/pmpe/workflows/support.py
@@ -107,14 +107,19 @@ class SupportCase:
 
 
 def _reject_oracle_fields(value: object) -> None:
-    if isinstance(value, dict):
-        if _FORBIDDEN_ORACLE_FIELDS.intersection(value):
-            raise VisibleCorpusError("visible corpus contains hidden oracle field")
-        for item in value.values():
-            _reject_oracle_fields(item)
-    elif isinstance(value, list):
-        for item in value:
-            _reject_oracle_fields(item)
+    stack = [(value, 0)]
+    visited = 0
+    while stack:
+        current, depth = stack.pop()
+        visited += 1
+        if depth > 64 or visited > 100_000:
+            raise VisibleCorpusError("visible corpus nesting or size exceeds limits")
+        if isinstance(current, dict):
+            if _FORBIDDEN_ORACLE_FIELDS.intersection(current):
+                raise VisibleCorpusError("visible corpus contains hidden oracle field")
+            stack.extend((item, depth + 1) for item in current.values())
+        elif isinstance(current, list):
+            stack.extend((item, depth + 1) for item in current)
 
 
 def load_visible_cases(path: Path) -> tuple[SupportCase, ...]:

--- a/src/pmpe/workflows/support.py
+++ b/src/pmpe/workflows/support.py
@@ -37,7 +37,12 @@ def _bounded_identifier(value: object) -> bool:
 
 
 def _bounded_text(value: object, *, maximum: int = 4096) -> bool:
-    return type(value) is str and 0 < len(value.encode("utf-8")) <= maximum and "\0" not in value
+    if type(value) is not str or "\0" in value:
+        return False
+    try:
+        return 0 < len(value.encode("utf-8")) <= maximum
+    except UnicodeEncodeError:
+        return False
 
 
 @dataclass(frozen=True)

--- a/src/pmpe/workflows/support.py
+++ b/src/pmpe/workflows/support.py
@@ -126,7 +126,7 @@ def load_visible_cases(path: Path) -> tuple[SupportCase, ...]:
     """Load only visible inputs and reject embedded evaluation truth."""
     try:
         payload = json.loads(Path(path).read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeError, json.JSONDecodeError, RecursionError) as exc:
         raise VisibleCorpusError("visible corpus is unreadable") from exc
     _reject_oracle_fields(payload)
     if not isinstance(payload, dict) or payload.get("schema_version") != "1.0.0":

--- a/src/pmpe/workflows/support.py
+++ b/src/pmpe/workflows/support.py
@@ -1,0 +1,144 @@
+"""Visible-only customer-support workflow inputs.
+
+This module deliberately has no dependency on ``pmpe.evals``. Production
+discovery code can consume these types without importing hidden oracle data.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+_FORBIDDEN_ORACLE_FIELDS = frozenset(
+    {
+        "expected_outcome",
+        "hidden_oracles",
+        "oracle",
+        "rationale_code",
+        "required_fact_ids",
+        "required_rule_ids",
+    }
+)
+
+
+class VisibleCorpusError(ValueError):
+    """Raised when a visible corpus is malformed or leaks evaluation truth."""
+
+
+def _bounded_identifier(value: object) -> bool:
+    return (
+        type(value) is str
+        and 0 < len(value) <= 128
+        and value[0].isalnum()
+        and all(character.isalnum() or character in "-_.:" for character in value)
+    )
+
+
+def _bounded_text(value: object, *, maximum: int = 4096) -> bool:
+    return type(value) is str and 0 < len(value.encode("utf-8")) <= maximum and "\0" not in value
+
+
+@dataclass(frozen=True)
+class VisibleFact:
+    fact_id: str
+    text: str
+    source_id: str
+
+    def __post_init__(self) -> None:
+        if not (
+            _bounded_identifier(self.fact_id)
+            and _bounded_identifier(self.source_id)
+            and _bounded_text(self.text)
+        ):
+            raise VisibleCorpusError("visible fact is malformed")
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    rule_id: str
+    text: str
+    priority: int
+
+    def __post_init__(self) -> None:
+        if not (
+            _bounded_identifier(self.rule_id)
+            and _bounded_text(self.text)
+            and type(self.priority) is int
+            and 0 <= self.priority <= 100
+        ):
+            raise VisibleCorpusError("policy rule is malformed")
+
+
+@dataclass(frozen=True)
+class SupportCase:
+    case_id: str
+    split: str
+    ticket_text: str
+    facts: tuple[VisibleFact, ...]
+    policies: tuple[PolicyRule, ...]
+    product_constraints: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        fact_ids = [item.fact_id for item in self.facts]
+        rule_ids = [item.rule_id for item in self.policies]
+        if not (
+            _bounded_identifier(self.case_id)
+            and self.split in {"development", "held_out"}
+            and _bounded_text(self.ticket_text)
+            and self.facts
+            and self.policies
+            and all(type(item) is VisibleFact for item in self.facts)
+            and all(type(item) is PolicyRule for item in self.policies)
+            and all(_bounded_text(item, maximum=512) for item in self.product_constraints)
+            and len(fact_ids) == len(set(fact_ids))
+            and len(rule_ids) == len(set(rule_ids))
+        ):
+            raise VisibleCorpusError("support case is malformed or duplicate")
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _reject_oracle_fields(value: object) -> None:
+    if isinstance(value, dict):
+        if _FORBIDDEN_ORACLE_FIELDS.intersection(value):
+            raise VisibleCorpusError("visible corpus contains hidden oracle field")
+        for item in value.values():
+            _reject_oracle_fields(item)
+    elif isinstance(value, list):
+        for item in value:
+            _reject_oracle_fields(item)
+
+
+def load_visible_cases(path: Path) -> tuple[SupportCase, ...]:
+    """Load only visible inputs and reject embedded evaluation truth."""
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise VisibleCorpusError("visible corpus is unreadable") from exc
+    _reject_oracle_fields(payload)
+    if not isinstance(payload, dict) or payload.get("schema_version") != "1.0.0":
+        raise VisibleCorpusError("visible corpus schema is unsupported")
+    raw_cases = payload.get("cases")
+    if not isinstance(raw_cases, list):
+        raise VisibleCorpusError("visible corpus cases are missing")
+    try:
+        cases = tuple(
+            SupportCase(
+                case_id=item["case_id"],
+                split=item["split"],
+                ticket_text=item["ticket_text"],
+                facts=tuple(VisibleFact(**fact) for fact in item["facts"]),
+                policies=tuple(PolicyRule(**rule) for rule in item["policies"]),
+                product_constraints=tuple(item["product_constraints"]),
+            )
+            for item in raw_cases
+        )
+    except (KeyError, TypeError, VisibleCorpusError) as exc:
+        raise VisibleCorpusError("visible corpus case is malformed") from exc
+    case_ids = [item.case_id for item in cases]
+    if not cases or len(case_ids) != len(set(case_ids)):
+        raise VisibleCorpusError("visible corpus contains duplicate case")
+    return cases

--- a/src/pmpe/workflows/support.py
+++ b/src/pmpe/workflows/support.py
@@ -124,6 +124,12 @@ def load_visible_cases(path: Path) -> tuple[SupportCase, ...]:
     raw_cases = payload.get("cases")
     if not isinstance(raw_cases, list):
         raise VisibleCorpusError("visible corpus cases are missing")
+    if any(
+        not isinstance(item, dict)
+        or not isinstance(item.get("product_constraints"), list)
+        for item in raw_cases
+    ):
+        raise VisibleCorpusError("visible corpus product constraints must be an array")
     try:
         cases = tuple(
             SupportCase(

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -318,6 +318,20 @@ def test_validator_rejects_conflict_policy_with_corrupted_direction() -> None:
         validate_support_corpus(SupportCorpus(tuple(cases), corpus.hidden_oracles))
 
 
+def test_validator_binds_oracle_to_complete_visible_case_content() -> None:
+    corpus = generate_support_corpus(seed=9)
+    case = corpus.visible_cases[0]
+    changed = replace(
+        case,
+        facts=(replace(case.facts[0], text="Evidence now contradicts the expected decision."),),
+    )
+
+    with pytest.raises(CorpusValidationError, match="visible case digest"):
+        validate_support_corpus(
+            SupportCorpus((changed, *corpus.visible_cases[1:]), corpus.hidden_oracles)
+        )
+
+
 def test_validator_rejects_coordinated_rationale_and_outcome_rewrite() -> None:
     corpus = generate_support_corpus(seed=9)
     first = replace(
@@ -342,6 +356,7 @@ def test_validator_rejects_trivial_all_escalate_oracle() -> None:
             required_fact_ids=item.required_fact_ids,
             required_rule_ids=item.required_rule_ids,
             rationale_code="manual-review",
+            visible_case_digest=item.visible_case_digest,
         )
         for item in corpus.hidden_oracles
     )

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -106,6 +106,19 @@ def test_validator_rejects_oracle_leakage_into_visible_payload(tmp_path: Path) -
         load_visible_cases(paths.visible_path)
 
 
+def test_visible_loader_bounds_recursive_payloads(tmp_path: Path) -> None:
+    paths = write_support_corpus(tmp_path, seed=8)
+    nested: object = "leaf"
+    for _ in range(70):
+        nested = [nested]
+    payload = json.loads(paths.visible_path.read_text())
+    payload["extra"] = nested
+    paths.visible_path.write_text(json.dumps(payload))
+
+    with pytest.raises(CorpusValidationError, match="nesting or size"):
+        load_visible_cases(paths.visible_path)
+
+
 def test_visible_loader_rejects_scalar_product_constraints(tmp_path: Path) -> None:
     paths = write_support_corpus(tmp_path, seed=8)
     payload = json.loads(paths.visible_path.read_text())

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -241,6 +241,25 @@ def test_validator_rejects_same_side_conflict_evidence() -> None:
         validate_support_corpus(SupportCorpus(corpus.visible_cases, tuple(oracles)))
 
 
+def test_validator_rejects_unequal_priority_conflict() -> None:
+    corpus = generate_support_corpus(seed=9)
+    index = next(
+        index
+        for index, item in enumerate(corpus.visible_cases)
+        if len(item.policies) == 2 and item.split == "development"
+    )
+    case = corpus.visible_cases[index]
+    changed = replace(
+        case,
+        policies=(case.policies[0], replace(case.policies[1], priority=100)),
+    )
+    cases = list(corpus.visible_cases)
+    cases[index] = changed
+
+    with pytest.raises(CorpusValidationError, match="equal priority"):
+        validate_support_corpus(SupportCorpus(tuple(cases), corpus.hidden_oracles))
+
+
 def test_validator_rejects_coordinated_rationale_and_outcome_rewrite() -> None:
     corpus = generate_support_corpus(seed=9)
     first = replace(

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -278,6 +278,23 @@ def test_validator_rejects_unequal_priority_conflict() -> None:
         validate_support_corpus(SupportCorpus(tuple(cases), corpus.hidden_oracles))
 
 
+def test_validator_rejects_conflict_policy_with_corrupted_direction() -> None:
+    corpus = generate_support_corpus(seed=9)
+    index = next(
+        index for index, item in enumerate(corpus.visible_cases) if len(item.policies) == 2
+    )
+    case = corpus.visible_cases[index]
+    changed = replace(
+        case,
+        policies=(replace(case.policies[0], text="Items cannot be refunded."), case.policies[1]),
+    )
+    cases = list(corpus.visible_cases)
+    cases[index] = changed
+
+    with pytest.raises(CorpusValidationError, match="policy semantics"):
+        validate_support_corpus(SupportCorpus(tuple(cases), corpus.hidden_oracles))
+
+
 def test_validator_rejects_coordinated_rationale_and_outcome_rewrite() -> None:
     corpus = generate_support_corpus(seed=9)
     first = replace(

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -126,6 +126,16 @@ def test_validator_rejects_oracle_references_not_present_in_visible_case() -> No
         validate_support_corpus(mutated)
 
 
+def test_validator_rejects_empty_oracle_evidence_bindings() -> None:
+    corpus = generate_support_corpus(seed=9)
+    first = corpus.hidden_oracles[0]
+    invalid = replace(first, required_fact_ids=(), required_rule_ids=())
+    mutated = SupportCorpus(corpus.visible_cases, (invalid, *corpus.hidden_oracles[1:]))
+
+    with pytest.raises(CorpusValidationError, match="bindings must be nonempty"):
+        validate_support_corpus(mutated)
+
+
 def test_validator_rejects_trivial_all_escalate_oracle() -> None:
     corpus = generate_support_corpus(seed=10)
     trivial = tuple(
@@ -179,6 +189,27 @@ def test_validator_rejects_visible_partition_relabeling() -> None:
 
     with pytest.raises(CorpusValidationError, match="hidden oracle is malformed"):
         validate_support_corpus(SupportCorpus(tuple(visible), corpus.hidden_oracles))
+
+
+def test_validator_rejects_undersized_held_out_partition() -> None:
+    corpus = generate_support_corpus(seed=11)
+    held_out_ids = [item.case_id for item in corpus.visible_cases if item.split == "held_out"]
+    retained = set(held_out_ids[:4])
+    visible = tuple(
+        replace(item, split="development")
+        if item.split == "held_out" and item.case_id not in retained
+        else item
+        for item in corpus.visible_cases
+    )
+    oracles = tuple(
+        replace(item, split="development")
+        if item.split == "held_out" and item.case_id not in retained
+        else item
+        for item in corpus.hidden_oracles
+    )
+
+    with pytest.raises(CorpusValidationError, match="partition coverage"):
+        validate_support_corpus(SupportCorpus(visible, oracles))
 
 
 def test_every_oracle_is_grounded_in_visible_facts_and_rules() -> None:

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -106,6 +106,16 @@ def test_validator_rejects_oracle_leakage_into_visible_payload(tmp_path: Path) -
         load_visible_cases(paths.visible_path)
 
 
+def test_visible_loader_rejects_scalar_product_constraints(tmp_path: Path) -> None:
+    paths = write_support_corpus(tmp_path, seed=8)
+    payload = json.loads(paths.visible_path.read_text())
+    payload["cases"][0]["product_constraints"] = "refund"
+    paths.visible_path.write_text(json.dumps(payload))
+
+    with pytest.raises(CorpusValidationError, match="constraints must be an array"):
+        load_visible_cases(paths.visible_path)
+
+
 def test_validator_rejects_oracle_references_not_present_in_visible_case() -> None:
     corpus = generate_support_corpus(seed=9)
     first = corpus.hidden_oracles[0]

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -131,6 +131,29 @@ def test_corpus_version_is_not_visible_until_both_artifacts_exist(
     assert list((tmp_path / "versions").glob("[!.]*")) == []
 
 
+def test_writer_repairs_incomplete_preexisting_version(tmp_path: Path) -> None:
+    corpus = generate_support_corpus(seed=44)
+    visible_bytes = support_corpus_module._canonical_bytes(
+        {"cases": [item.as_dict() for item in corpus.visible_cases], "schema_version": "1.0.0"}
+    )
+    oracle_bytes = support_corpus_module._canonical_bytes(
+        {
+            "oracles": [item.as_dict() for item in corpus.hidden_oracles],
+            "schema_version": "1.0.0",
+        }
+    )
+    version = support_corpus_module.hashlib.sha256(visible_bytes + oracle_bytes).hexdigest()
+    incomplete = tmp_path / "versions" / version / "visible" / "cases.json"
+    incomplete.parent.mkdir(parents=True)
+    incomplete.write_bytes(visible_bytes)
+
+    paths = write_support_corpus(tmp_path, seed=44)
+
+    assert paths.visible_path.read_bytes() == visible_bytes
+    assert paths.oracle_path.read_bytes() == oracle_bytes
+    assert list((tmp_path / "versions").glob(".invalid-*"))
+
+
 def test_visible_loader_cannot_observe_hidden_oracle_fields(tmp_path: Path) -> None:
     paths = write_support_corpus(tmp_path, seed=7)
     visible_bytes = paths.visible_path.read_bytes()

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -58,6 +58,19 @@ def test_held_out_templates_do_not_reuse_development_rule_ids() -> None:
     assert development_rules.isdisjoint(held_out_rules)
 
 
+def test_held_out_conflict_establishes_both_policy_predicates() -> None:
+    corpus = generate_support_corpus(seed=110)
+    conflict = next(
+        case
+        for case in corpus.visible_cases
+        if case.split == "held_out" and len(case.policies) == 2
+    )
+
+    visible_text = " ".join(item.text for item in conflict.facts).casefold()
+    assert "unused" in visible_text
+    assert "clearance" in visible_text
+
+
 def test_generation_and_written_artifacts_are_byte_deterministic(tmp_path: Path) -> None:
     first = write_support_corpus(tmp_path / "first", seed=41)
     second = write_support_corpus(tmp_path / "second", seed=41)

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -31,6 +31,31 @@ def test_generator_produces_held_out_decision_coverage() -> None:
         "reject",
     }
     assert sum(case.split == "held_out" for case in corpus.visible_cases) >= 10
+    assert all(
+        not any(
+            label in case.case_id.casefold()
+            for label in ("refund", "replacement", "missing", "contradiction", "unsupported")
+        )
+        for case in corpus.visible_cases
+    )
+
+
+def test_held_out_templates_do_not_reuse_development_rule_ids() -> None:
+    corpus = generate_support_corpus(seed=110)
+    development_rules = {
+        rule.rule_id
+        for case in corpus.visible_cases
+        if case.split == "development"
+        for rule in case.policies
+    }
+    held_out_rules = {
+        rule.rule_id
+        for case in corpus.visible_cases
+        if case.split == "held_out"
+        for rule in case.policies
+    }
+
+    assert development_rules.isdisjoint(held_out_rules)
 
 
 def test_generation_and_written_artifacts_are_byte_deterministic(tmp_path: Path) -> None:
@@ -93,6 +118,20 @@ def test_validator_rejects_trivial_all_escalate_oracle() -> None:
 
     with pytest.raises(CorpusValidationError, match="outcome diversity"):
         validate_support_corpus(SupportCorpus(corpus.visible_cases, trivial))
+
+
+def test_validator_rejects_all_escalate_held_out_partition() -> None:
+    corpus = generate_support_corpus(seed=10)
+    split_by_id = {item.case_id: item.split for item in corpus.visible_cases}
+    mutated = tuple(
+        replace(item, expected_outcome="escalate")
+        if split_by_id[item.case_id] == "held_out"
+        else item
+        for item in corpus.hidden_oracles
+    )
+
+    with pytest.raises(CorpusValidationError, match="held-out outcome diversity"):
+        validate_support_corpus(SupportCorpus(corpus.visible_cases, mutated))
 
 
 def test_validator_rejects_duplicate_or_mismatched_cases() -> None:

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -100,14 +100,10 @@ def test_validator_rejects_duplicate_or_mismatched_cases() -> None:
 
     with pytest.raises(CorpusValidationError, match="duplicate case"):
         validate_support_corpus(
-            SupportCorpus(
-                (corpus.visible_cases[0], *corpus.visible_cases), corpus.hidden_oracles
-            )
+            SupportCorpus((corpus.visible_cases[0], *corpus.visible_cases), corpus.hidden_oracles)
         )
     with pytest.raises(CorpusValidationError, match="one oracle"):
-        validate_support_corpus(
-            SupportCorpus(corpus.visible_cases, corpus.hidden_oracles[1:])
-        )
+        validate_support_corpus(SupportCorpus(corpus.visible_cases, corpus.hidden_oracles[1:]))
 
 
 def test_every_oracle_is_grounded_in_visible_facts_and_rules() -> None:

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -113,6 +113,24 @@ def test_different_corpora_publish_to_distinct_immutable_versions(tmp_path: Path
     assert first.visible_path.read_bytes() != second.visible_path.read_bytes()
 
 
+def test_corpus_version_is_not_visible_until_both_artifacts_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_write = support_corpus_module._write_atomic
+
+    def fail_oracle(path: Path, payload: bytes) -> None:
+        if path.parent.name == "eval-only":
+            raise OSError("simulated staged oracle failure")
+        real_write(path, payload)
+
+    monkeypatch.setattr(support_corpus_module, "_write_atomic", fail_oracle)
+
+    with pytest.raises(OSError, match="staged oracle"):
+        write_support_corpus(tmp_path, seed=43)
+
+    assert list((tmp_path / "versions").glob("[!.]*")) == []
+
+
 def test_visible_loader_cannot_observe_hidden_oracle_fields(tmp_path: Path) -> None:
     paths = write_support_corpus(tmp_path, seed=7)
     visible_bytes = paths.visible_path.read_bytes()

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -121,6 +121,7 @@ def test_validator_rejects_trivial_all_escalate_oracle() -> None:
     trivial = tuple(
         HiddenOracle(
             case_id=item.case_id,
+            split=item.split,
             expected_outcome="escalate",
             required_fact_ids=item.required_fact_ids,
             required_rule_ids=item.required_rule_ids,
@@ -156,6 +157,18 @@ def test_validator_rejects_duplicate_or_mismatched_cases() -> None:
         )
     with pytest.raises(CorpusValidationError, match="one oracle"):
         validate_support_corpus(SupportCorpus(corpus.visible_cases, corpus.hidden_oracles[1:]))
+
+
+def test_validator_rejects_visible_partition_relabeling() -> None:
+    corpus = generate_support_corpus(seed=11)
+    held_out_index = next(
+        index for index, item in enumerate(corpus.visible_cases) if item.split == "held_out"
+    )
+    visible = list(corpus.visible_cases)
+    visible[held_out_index] = replace(visible[held_out_index], split="development")
+
+    with pytest.raises(CorpusValidationError, match="hidden oracle is malformed"):
+        validate_support_corpus(SupportCorpus(tuple(visible), corpus.hidden_oracles))
 
 
 def test_every_oracle_is_grounded_in_visible_facts_and_rules() -> None:

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -82,7 +82,7 @@ def test_generation_and_written_artifacts_are_byte_deterministic(tmp_path: Path)
     assert generate_support_corpus(seed=41) != generate_support_corpus(seed=42)
 
 
-def test_writer_rolls_back_visible_artifact_if_oracle_publish_fails(
+def test_writer_keeps_prior_version_immutable_if_new_oracle_publish_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     paths = write_support_corpus(tmp_path, seed=41)
@@ -91,7 +91,7 @@ def test_writer_rolls_back_visible_artifact_if_oracle_publish_fails(
     real_write = support_corpus_module._write_atomic
 
     def fail_oracle(path: Path, payload: bytes) -> None:
-        if path == paths.oracle_path:
+        if path.parent.name == "eval-only":
             raise OSError("simulated oracle publish failure")
         real_write(path, payload)
 
@@ -102,6 +102,15 @@ def test_writer_rolls_back_visible_artifact_if_oracle_publish_fails(
 
     assert paths.visible_path.read_bytes() == previous_visible
     assert paths.oracle_path.read_bytes() == previous_oracle
+
+
+def test_different_corpora_publish_to_distinct_immutable_versions(tmp_path: Path) -> None:
+    first = write_support_corpus(tmp_path, seed=41)
+    second = write_support_corpus(tmp_path, seed=42)
+
+    assert first.visible_path.parents[1] != second.visible_path.parents[1]
+    assert first.oracle_path.parents[1] != second.oracle_path.parents[1]
+    assert first.visible_path.read_bytes() != second.visible_path.read_bytes()
 
 
 def test_visible_loader_cannot_observe_hidden_oracle_fields(tmp_path: Path) -> None:

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -205,11 +205,31 @@ def test_validator_rejects_partial_conflict_evidence_or_wrong_outcome() -> None:
     )
     wrong = replace(conflict, expected_outcome="refund")
 
-    for invalid, message in ((partial, "evidence is incomplete"), (wrong, "rationale")):
+    for invalid, message in ((partial, "opposing roles"), (wrong, "rationale")):
         oracles = list(corpus.hidden_oracles)
         oracles[index] = invalid
         with pytest.raises(CorpusValidationError, match=message):
             validate_support_corpus(SupportCorpus(corpus.visible_cases, tuple(oracles)))
+
+
+def test_validator_rejects_same_side_conflict_evidence() -> None:
+    corpus = generate_support_corpus(seed=9)
+    index = next(
+        index
+        for index, item in enumerate(corpus.hidden_oracles)
+        if item.rationale_code == "equal-priority-conflict"
+    )
+    conflict = corpus.hidden_oracles[index]
+    invalid = replace(
+        conflict,
+        required_fact_ids=("FACT-FINAL-SALE",),
+        required_rule_ids=("RULE-FINAL-SALE",),
+    )
+    oracles = list(corpus.hidden_oracles)
+    oracles[index] = invalid
+
+    with pytest.raises(CorpusValidationError, match="opposing roles"):
+        validate_support_corpus(SupportCorpus(corpus.visible_cases, tuple(oracles)))
 
 
 def test_validator_rejects_coordinated_rationale_and_outcome_rewrite() -> None:

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from pmpe.evals.support_corpus import (
+    CorpusValidationError,
+    HiddenOracle,
+    SupportCorpus,
+    generate_support_corpus,
+    validate_support_corpus,
+    write_support_corpus,
+)
+from pmpe.workflows.support import SupportCase, load_visible_cases
+
+
+def test_generator_produces_held_out_decision_coverage() -> None:
+    corpus = generate_support_corpus(seed=110)
+
+    assert len(corpus.visible_cases) >= 30
+    assert len(corpus.visible_cases) == len(corpus.hidden_oracles)
+    assert {case.split for case in corpus.visible_cases} == {"development", "held_out"}
+    assert {oracle.expected_outcome for oracle in corpus.hidden_oracles} == {
+        "refund",
+        "replacement",
+        "escalate",
+        "request_evidence",
+        "reject",
+    }
+    assert sum(case.split == "held_out" for case in corpus.visible_cases) >= 10
+
+
+def test_generation_and_written_artifacts_are_byte_deterministic(tmp_path: Path) -> None:
+    first = write_support_corpus(tmp_path / "first", seed=41)
+    second = write_support_corpus(tmp_path / "second", seed=41)
+
+    assert first.visible_path.read_bytes() == second.visible_path.read_bytes()
+    assert first.oracle_path.read_bytes() == second.oracle_path.read_bytes()
+    assert generate_support_corpus(seed=41) == generate_support_corpus(seed=41)
+    assert generate_support_corpus(seed=41) != generate_support_corpus(seed=42)
+
+
+def test_visible_loader_cannot_observe_hidden_oracle_fields(tmp_path: Path) -> None:
+    paths = write_support_corpus(tmp_path, seed=7)
+    visible_bytes = paths.visible_path.read_bytes()
+    visible_payload = json.loads(visible_bytes)
+    loaded = load_visible_cases(paths.visible_path)
+
+    forbidden = {"expected_outcome", "required_fact_ids", "required_rule_ids", "rationale_code"}
+    assert len(loaded) >= 30
+    assert all(isinstance(case, SupportCase) for case in loaded)
+    assert forbidden.isdisjoint(visible_payload)
+    assert all(forbidden.isdisjoint(item) for item in visible_payload["cases"])
+    assert paths.oracle_path.parent.name == "eval-only"
+    assert paths.oracle_path not in paths.visible_path.parents
+
+
+def test_validator_rejects_oracle_leakage_into_visible_payload(tmp_path: Path) -> None:
+    paths = write_support_corpus(tmp_path, seed=8)
+    payload = json.loads(paths.visible_path.read_text())
+    payload["cases"][0]["expected_outcome"] = "refund"
+    paths.visible_path.write_text(json.dumps(payload))
+
+    with pytest.raises(CorpusValidationError, match="hidden oracle field"):
+        load_visible_cases(paths.visible_path)
+
+
+def test_validator_rejects_oracle_references_not_present_in_visible_case() -> None:
+    corpus = generate_support_corpus(seed=9)
+    first = corpus.hidden_oracles[0]
+    invalid = replace(first, required_rule_ids=("POLICY-NOT-VISIBLE",))
+    mutated = SupportCorpus(corpus.visible_cases, (invalid, *corpus.hidden_oracles[1:]))
+
+    with pytest.raises(CorpusValidationError, match="unknown visible rule"):
+        validate_support_corpus(mutated)
+
+
+def test_validator_rejects_trivial_all_escalate_oracle() -> None:
+    corpus = generate_support_corpus(seed=10)
+    trivial = tuple(
+        HiddenOracle(
+            case_id=item.case_id,
+            expected_outcome="escalate",
+            required_fact_ids=item.required_fact_ids,
+            required_rule_ids=item.required_rule_ids,
+            rationale_code="manual-review",
+        )
+        for item in corpus.hidden_oracles
+    )
+
+    with pytest.raises(CorpusValidationError, match="outcome diversity"):
+        validate_support_corpus(SupportCorpus(corpus.visible_cases, trivial))
+
+
+def test_validator_rejects_duplicate_or_mismatched_cases() -> None:
+    corpus = generate_support_corpus(seed=11)
+
+    with pytest.raises(CorpusValidationError, match="duplicate case"):
+        validate_support_corpus(
+            SupportCorpus(
+                (corpus.visible_cases[0], *corpus.visible_cases), corpus.hidden_oracles
+            )
+        )
+    with pytest.raises(CorpusValidationError, match="one oracle"):
+        validate_support_corpus(
+            SupportCorpus(corpus.visible_cases, corpus.hidden_oracles[1:])
+        )
+
+
+def test_every_oracle_is_grounded_in_visible_facts_and_rules() -> None:
+    corpus = generate_support_corpus(seed=12)
+    validate_support_corpus(corpus)
+    visible = {case.case_id: case for case in corpus.visible_cases}
+
+    for oracle in corpus.hidden_oracles:
+        case = visible[oracle.case_id]
+        assert set(oracle.required_fact_ids) <= {fact.fact_id for fact in case.facts}
+        assert set(oracle.required_rule_ids) <= {rule.rule_id for rule in case.policies}
+        assert oracle.rationale_code

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -132,7 +132,7 @@ def test_validator_rejects_oracle_references_not_present_in_visible_case() -> No
     invalid = replace(first, required_rule_ids=("POLICY-NOT-VISIBLE",))
     mutated = SupportCorpus(corpus.visible_cases, (invalid, *corpus.hidden_oracles[1:]))
 
-    with pytest.raises(CorpusValidationError, match="unknown visible rule"):
+    with pytest.raises(CorpusValidationError, match="rule evidence is incomplete"):
         validate_support_corpus(mutated)
 
 
@@ -142,8 +142,30 @@ def test_validator_rejects_empty_oracle_evidence_bindings() -> None:
     invalid = replace(first, required_fact_ids=(), required_rule_ids=())
     mutated = SupportCorpus(corpus.visible_cases, (invalid, *corpus.hidden_oracles[1:]))
 
-    with pytest.raises(CorpusValidationError, match="bindings must be nonempty"):
+    with pytest.raises(CorpusValidationError, match="fact evidence is incomplete"):
         validate_support_corpus(mutated)
+
+
+def test_validator_rejects_partial_conflict_evidence_or_wrong_outcome() -> None:
+    corpus = generate_support_corpus(seed=9)
+    index = next(
+        index
+        for index, item in enumerate(corpus.hidden_oracles)
+        if item.rationale_code.endswith("equal-priority-conflict")
+    )
+    conflict = corpus.hidden_oracles[index]
+    partial = replace(
+        conflict,
+        required_fact_ids=conflict.required_fact_ids[:1],
+        required_rule_ids=conflict.required_rule_ids[:1],
+    )
+    wrong = replace(conflict, expected_outcome="refund")
+
+    for invalid, message in ((partial, "evidence is incomplete"), (wrong, "rationale")):
+        oracles = list(corpus.hidden_oracles)
+        oracles[index] = invalid
+        with pytest.raises(CorpusValidationError, match=message):
+            validate_support_corpus(SupportCorpus(corpus.visible_cases, tuple(oracles)))
 
 
 def test_validator_rejects_trivial_all_escalate_oracle() -> None:

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -116,6 +116,16 @@ def test_visible_loader_rejects_scalar_product_constraints(tmp_path: Path) -> No
         load_visible_cases(paths.visible_path)
 
 
+def test_visible_loader_normalizes_unpaired_unicode_surrogate(tmp_path: Path) -> None:
+    paths = write_support_corpus(tmp_path, seed=8)
+    payload = json.loads(paths.visible_path.read_text())
+    payload["cases"][0]["ticket_text"] = "\ud800"
+    paths.visible_path.write_text(json.dumps(payload))
+
+    with pytest.raises(CorpusValidationError, match="malformed"):
+        load_visible_cases(paths.visible_path)
+
+
 def test_validator_rejects_oracle_references_not_present_in_visible_case() -> None:
     corpus = generate_support_corpus(seed=9)
     first = corpus.hidden_oracles[0]

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -145,7 +145,7 @@ def test_validator_rejects_oracle_references_not_present_in_visible_case() -> No
     invalid = replace(first, required_rule_ids=("POLICY-NOT-VISIBLE",))
     mutated = SupportCorpus(corpus.visible_cases, (invalid, *corpus.hidden_oracles[1:]))
 
-    with pytest.raises(CorpusValidationError, match="rule evidence is incomplete"):
+    with pytest.raises(CorpusValidationError, match="rationale and evidence"):
         validate_support_corpus(mutated)
 
 
@@ -155,7 +155,7 @@ def test_validator_rejects_empty_oracle_evidence_bindings() -> None:
     invalid = replace(first, required_fact_ids=(), required_rule_ids=())
     mutated = SupportCorpus(corpus.visible_cases, (invalid, *corpus.hidden_oracles[1:]))
 
-    with pytest.raises(CorpusValidationError, match="fact evidence is incomplete"):
+    with pytest.raises(CorpusValidationError, match="rationale and evidence"):
         validate_support_corpus(mutated)
 
 
@@ -179,6 +179,20 @@ def test_validator_rejects_partial_conflict_evidence_or_wrong_outcome() -> None:
         oracles[index] = invalid
         with pytest.raises(CorpusValidationError, match=message):
             validate_support_corpus(SupportCorpus(corpus.visible_cases, tuple(oracles)))
+
+
+def test_validator_rejects_coordinated_rationale_and_outcome_rewrite() -> None:
+    corpus = generate_support_corpus(seed=9)
+    first = replace(
+        corpus.hidden_oracles[0],
+        expected_outcome="reject",
+        rationale_code="unsupported-action",
+    )
+
+    with pytest.raises(CorpusValidationError, match="rationale and evidence"):
+        validate_support_corpus(
+            SupportCorpus(corpus.visible_cases, (first, *corpus.hidden_oracles[1:]))
+        )
 
 
 def test_validator_rejects_trivial_all_escalate_oracle() -> None:

--- a/tests/unit/test_support_synthetic_corpus.py
+++ b/tests/unit/test_support_synthetic_corpus.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+import pmpe.evals.support_corpus as support_corpus_module
 from pmpe.evals.support_corpus import (
     CorpusValidationError,
     HiddenOracle,
@@ -81,6 +82,28 @@ def test_generation_and_written_artifacts_are_byte_deterministic(tmp_path: Path)
     assert generate_support_corpus(seed=41) != generate_support_corpus(seed=42)
 
 
+def test_writer_rolls_back_visible_artifact_if_oracle_publish_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = write_support_corpus(tmp_path, seed=41)
+    previous_visible = paths.visible_path.read_bytes()
+    previous_oracle = paths.oracle_path.read_bytes()
+    real_write = support_corpus_module._write_atomic
+
+    def fail_oracle(path: Path, payload: bytes) -> None:
+        if path == paths.oracle_path:
+            raise OSError("simulated oracle publish failure")
+        real_write(path, payload)
+
+    monkeypatch.setattr(support_corpus_module, "_write_atomic", fail_oracle)
+
+    with pytest.raises(OSError, match="simulated"):
+        write_support_corpus(tmp_path, seed=42)
+
+    assert paths.visible_path.read_bytes() == previous_visible
+    assert paths.oracle_path.read_bytes() == previous_oracle
+
+
 def test_visible_loader_cannot_observe_hidden_oracle_fields(tmp_path: Path) -> None:
     paths = write_support_corpus(tmp_path, seed=7)
     visible_bytes = paths.visible_path.read_bytes()
@@ -117,6 +140,14 @@ def test_visible_loader_bounds_recursive_payloads(tmp_path: Path) -> None:
 
     with pytest.raises(CorpusValidationError, match="nesting or size"):
         load_visible_cases(paths.visible_path)
+
+
+def test_visible_loader_normalizes_decoder_recursion(tmp_path: Path) -> None:
+    path = tmp_path / "deep.json"
+    path.write_text("[" * 10_000 + "0" + "]" * 10_000)
+
+    with pytest.raises(CorpusValidationError, match="unreadable"):
+        load_visible_cases(path)
 
 
 def test_visible_loader_rejects_scalar_product_constraints(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #110

## Product outcome
Creates a deterministic, synthetic customer-support corpus that proves workflow discovery against hidden expected behavior without using private customer data.

## Scope
- 30 versioned cases across refund, replacement, missing evidence, contradictory policy, unsupported action, and high-value approval
- Visible development/held-out inputs physically separated from eval-only hidden oracles
- Stable seeded generation and byte-identical artifact writing
- Corpus validation for grounding, partitions, outcome diversity, duplicates, and oracle leakage
- Mutation tests rejecting hidden-field leakage, invalid references, and trivial all-escalate behavior

## Delivery evidence
- Red contract commit: `12e94682fcf5aa997143fb85a32e40fb2dd95312`
- Implementation commit: `1a1e3a8238bbb8992ec9c4201f33982baf5bc8ab`
- 8 focused tests pass
- Ruff lint/format, strict mypy, and high-severity Bandit pass locally

## Architecture
Visible workflow types do not import the eval package. Hidden truth exists only in the evaluation module and eval-only artifact path; later discovery/compilation consumes visible cases only.

## Release boundary
No real customer data, model call, external action, deployment, or autonomous decision is introduced.