### PR TITLE
Normalize support workflow formatting

### DIFF
--- a/src/pmpe/evals/support_corpus.py
+++ b/src/pmpe/evals/support_corpus.py
@@ -465,9 +465,7 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
             policy for policy in case.policies if policy.priority == highest_priority
         )
         selected_actions = {policy.action for policy in selected_policies}
-        selected_action = (
-            "escalate" if len(selected_actions) > 1 else next(iter(selected_actions))
-        )
+        selected_action = "escalate" if len(selected_actions) > 1 else next(iter(selected_actions))
         if selected_action != "escalate" and any(
             policy.human_question for policy in selected_policies
         ):
@@ -478,6 +476,8 @@ def validate_support_corpus(corpus: SupportCorpus) -> None:
             or {policy.rule_id for policy in selected_policies} != rule_refs
         ):
             raise CorpusValidationError("oracle does not match the selected visible decision")
+
+
 def _canonical_bytes(payload: object) -> bytes:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     return (encoded + "\n").encode()

--- a/src/pmpe/workflows/locking.py
+++ b/src/pmpe/workflows/locking.py
@@ -35,7 +35,9 @@ def _lock(handle: BinaryIO) -> None:
         while True:
             try:
                 msvcrt.locking(  # type: ignore[attr-defined]
-                    handle.fileno(), msvcrt.LK_NBLCK, 1  # type: ignore[attr-defined]
+                    handle.fileno(),
+                    msvcrt.LK_NBLCK,  # type: ignore[attr-defined]
+                    1,
                 )
                 break
             except OSError as exc:


### PR DESCRIPTION
Closes #116

## Scope
- Apply Ruff formatting to the two files reported by the merged-main gate
- Preserve Windows lock type-check suppression on the formatted attribute line
- No runtime behavior change

## Evidence
- 86 focused MVP tests pass
- `ruff check .` passes
- `ruff format --check .` passes for all 215 files
- strict mypy passes for workflows/evals
- high-severity Bandit scan passes
