### PR TITLE
Bare-bones contract-to-RELEASE_READY core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install candidate isolation runtime
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap
+          sudo tee /etc/apparmor.d/pmpe-bwrap >/dev/null <<'EOF'
+          abi <abi/4.0>,
+          include <tunables/global>
+          /usr/bin/bwrap flags=(unconfined) {
+            userns,
+          }
+          EOF
+          sudo apparmor_parser -r /etc/apparmor.d/pmpe-bwrap
       - run: pip install -e ".[dev]"
       - name: unit tests
         run: pytest tests/unit -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: install candidate isolation runtime
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
       - run: pip install -e ".[dev]"
       - name: unit tests
         run: pytest tests/unit -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,24 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[dev]"
+      - name: unit tests
+        run: pytest tests/unit -q
+      - name: integration tests
+        run: pytest tests/integration -q
+      - name: end-to-end tests
+        run: pytest tests/e2e -q
+
+  candidate-isolation:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: install candidate isolation runtime
         run: |
           sudo apt-get update
@@ -59,12 +77,13 @@ jobs:
           EOF
           sudo apparmor_parser -r /etc/apparmor.d/pmpe-bwrap
       - run: pip install -e ".[dev]"
-      - name: unit tests
-        run: pytest tests/unit -q
-      - name: integration tests
-        run: pytest tests/integration -q
-      - name: end-to-end tests
-        run: pytest tests/e2e -q
+      - name: prove candidate isolation
+        env:
+          PMPE_TEST_REAL_SANDBOX: "true"
+        run: >-
+          pytest
+          tests/unit/test_candidate_sandbox.py::test_real_candidate_sandbox_has_no_host_credentials_network_or_write_access
+          -q
 
   security:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -11,6 +11,40 @@ The seam between them is a single immutable artifact: the digest-locked contract
 
 ## Production Engineering OS (`pmpe`)
 
+### Bare-bones core (current target)
+
+The current target is deliberately smaller than the historical workflows below:
+
+`PMOS contract → deterministic compile → meaningful RED → Coder → verify → RELEASE_READY`
+
+- It has six states: `VALIDATED`, `BUILDING`, `VERIFYING`, `RELEASE_READY`, `HALTED`, and
+  `STOPPED`.
+- The Coder is the only mandatory LLM worker. A command implementing the `ModelProvider`
+  JSON protocol is the only external adapter.
+- It does not deploy, require AWS, mutate GitHub, or make the release decision.
+- Evidence is plain files under `.pmpe/runs/<id>/events.jsonl` and
+  `.pmpe/blobs/<sha256>`.
+
+Run the deterministic E1 fixture locally:
+
+```bash
+pmpe barebones examples/barebones/e1-contract.json \
+  --workspace /tmp/pmpe-e1-candidate \
+  --run-id e1 \
+  --repository-root /tmp/pmpe-e1-evidence \
+  --provider-command "python examples/barebones/e1-provider.py"
+```
+
+The fixture provider only proves the engine path; replace it with a real command-backed
+`ModelProvider` for product work. The provider receives
+`{"purpose": "code|advisory_review", "request": {...}}` on standard input and must return
+one JSON object containing the same `request_digest`. See
+[the acceptance grammar](docs/acceptance-criteria-grammar.md) and
+[the deletion inventory](docs/barebones-deletion-inventory.md).
+
+The larger workflows documented below are the legacy surface being classified for deletion;
+they are not dependencies of the bare-bones core.
+
 ### Try the verified demo
 
 Prerequisite: Python 3.11 or newer (`python3.12` is used below).

--- a/docs/acceptance-criteria-grammar.md
+++ b/docs/acceptance-criteria-grammar.md
@@ -1,0 +1,124 @@
+# Acceptance-criteria grammar for the bare-bones core
+
+Issue: #140
+
+The compiler accepts a criterion only when it can produce an executable assertion
+without guessing product truth, or when the contract binds a human-authored test.
+
+## Criterion forms
+
+Every acceptance criterion has a stable ID and at least one requirement reference.
+It selects exactly one form.
+
+### Structured Given/When/Then
+
+```json
+{
+  "id": "AC-001",
+  "requirement_refs": ["FR-001"],
+  "given": [{"path": "service.running", "operator": "eq", "value": true}],
+  "when": {"action": "health", "arguments": {}},
+  "then": [{"path": "result.status", "operator": "eq", "value": "ok"}]
+}
+```
+
+`given` and `then` contain data assertions. `when.action` names a template action
+registered by the one composable product template; it is not arbitrary source code.
+
+### Measurable outcome
+
+```json
+{
+  "id": "AC-002",
+  "requirement_refs": ["NFR-001"],
+  "measure": "request.latency_ms.p95",
+  "operator": "lte",
+  "value": 250,
+  "sample": {"minimum": 100}
+}
+```
+
+### Human-authored executable test
+
+```json
+{
+  "id": "AC-003",
+  "requirement_refs": ["SEC-001"],
+  "human_test": {
+    "path": "tests/security/test_config_parser.py",
+    "node_id": "test_operator_input_is_never_executed",
+    "command": ["pytest", "-q", "tests/security/test_config_parser.py::test_operator_input_is_never_executed"]
+  }
+}
+```
+
+The path is repository-relative, must remain under `tests/`, and the command must
+target that exact path and node. The compiler records the file digest. Missing or
+changed files invalidate the plan.
+
+### Explicitly satisfied by the template
+
+```json
+{
+  "id": "AC-004",
+  "requirement_refs": ["FR-HEALTH"],
+  "satisfied_by_template": {
+    "template_version": "barebones-1",
+    "test_id": "template::health"
+  }
+}
+```
+
+This is the only allowed baseline-PASS exception. The referenced test must exist in
+the pinned template and its digest is recorded before scaffolding.
+
+## Operators
+
+The v1 operator set is deliberately closed:
+
+`eq`, `ne`, `lt`, `lte`, `gt`, `gte`, `contains`, `not_contains`, `matches`,
+`is_true`, `is_false`, `is_null`, `not_null`.
+
+No criterion contains Python, shell, JavaScript, SQL, a prompt, or an unregistered
+callable. Extending the operator or action registry requires a failing real contract.
+
+## Compile-time gates
+
+Before entering `BUILDING`, the compiler proves:
+
+1. every requirement ID has at least one implementation task;
+2. every requirement ID has at least one criterion;
+3. every criterion references an existing requirement;
+4. every criterion selects exactly one accepted form;
+5. every structured action and operator is registered;
+6. every human test exists and is digest-bound;
+7. every template-satisfied test exists in the pinned template;
+8. no compiler decision requires an LLM interpretation.
+
+Any failure returns `CONTRACT_INVALID` with the exact requirement or criterion ID.
+
+## Baseline gate
+
+The untouched template runs every compiled or human-authored test.
+
+- An implementation-required criterion must fail as an assertion.
+- Import, collection, syntax, fixture, timeout, and environment errors are invalid RED.
+- A passing test is invalid unless it is explicitly and correctly
+  `satisfied_by_template`.
+- The compiler stores the baseline result and test digest in the evidence chain.
+
+## Hand-validation result
+
+The repository canonical PMOS fixture contains one requirement (`FR-001`) and one
+criterion (`AC-001`). Its prose is recognizably Given/When/Then, but the current
+contract does not identify a registered action or typed output paths. It therefore
+does **not** satisfy this grammar without conversion. This is the intended fail-closed
+result: the existing free-text field is not sufficient to generate executable evidence
+without guessing.
+
+The v2 demo's safe-config criterion also requires the human-test escape hatch because
+"no part of the input is ever executed" cannot be compiled into a finite property
+assertion from prose alone.
+
+These findings confirm that PMOS must emit the structured form or bind a human test
+before E1 can honestly start.

--- a/docs/acceptance-criteria-grammar.md
+++ b/docs/acceptance-criteria-grammar.md
@@ -24,6 +24,8 @@ It selects exactly one form.
 
 `given` and `then` contain data assertions. `when.action` names a template action
 registered by the one composable product template; it is not arbitrary source code.
+The compiler rejects incompatible equality and ordered bounds (for example,
+`gt 5` together with `lte 5`) before building.
 
 ### Measurable outcome
 
@@ -37,6 +39,10 @@ registered by the one composable product template; it is not arbitrary source co
   "sample": {"minimum": 100}
 }
 ```
+
+The template registers each measure name to a deterministic zero-argument action.
+That action must return `{"value": ..., "sample_size": ...}`; verification checks
+both the operator and the minimum sample without an LLM interpretation.
 
 ### Human-authored executable test
 
@@ -54,7 +60,10 @@ registered by the one composable product template; it is not arbitrary source co
 
 The path is repository-relative, must remain under `tests/`, and the command must
 target that exact path and node. The compiler records the file digest. Missing or
-changed files invalidate the plan.
+changed files invalidate the plan. Verification consumes pytest's structured XML
+result and requires that exact node to execute once. A skip, collection error, syntax
+error, fixture error, or runner error is never accepted as a passing or meaningful
+failing assertion.
 
 ### Explicitly satisfied by the template
 
@@ -70,7 +79,8 @@ changed files invalidate the plan.
 ```
 
 This is the only allowed baseline-PASS exception. The referenced test must exist in
-the pinned template and its digest is recorded before scaffolding.
+the pinned template, its digest is recorded before scaffolding, and that exact test
+must execute and pass during both baseline and final verification.
 
 ## Operators
 
@@ -92,7 +102,8 @@ Before entering `BUILDING`, the compiler proves:
 4. every criterion selects exactly one accepted form;
 5. every structured action and operator is registered;
 6. every human test exists and is digest-bound;
-7. every template-satisfied test exists in the pinned template;
+7. every template-satisfied test exists, is digest-bound, and is executable in the
+   pinned template;
 8. no compiler decision requires an LLM interpretation.
 
 Any failure returns `CONTRACT_INVALID` with the exact requirement or criterion ID.
@@ -106,6 +117,8 @@ The untouched template runs every compiled or human-authored test.
 - A passing test is invalid unless it is explicitly and correctly
   `satisfied_by_template`.
 - The compiler stores the baseline result and test digest in the evidence chain.
+- `RELEASE_READY` references a manifest that hashes every regular candidate file,
+  regardless of extension, plus each file's content-addressed blob.
 
 ## Hand-validation result
 

--- a/docs/barebones-deletion-inventory.md
+++ b/docs/barebones-deletion-inventory.md
@@ -1,0 +1,128 @@
+# Bare-bones core deletion inventory
+
+Issue: #140
+
+Status: architecture frozen; inventory only. No item is deleted until its surviving
+consumer and E1 coverage are identified.
+
+## Frozen core
+
+```text
+PMOS contract
+  -> deterministic compile + coverage
+  -> one composable template
+  -> meaningful baseline RED
+  -> Coder
+  -> assertions + evals + local security
+  -> RELEASE_READY or HALTED
+  -> human decision
+```
+
+The primary user is an engineer operating the CLI with an approved PMOS contract.
+The core stops at `RELEASE_READY`. It has one mandatory LLM worker (`Coder`), one
+external adapter (`ModelProvider`), one hash-chained event log, and one content-
+addressed blob directory.
+
+## Current surface
+
+- 32 top-level Python packages under `src/pmpe`.
+- About 51,000 source lines and 94,000 Python source-plus-test lines.
+- 29 lifecycle states, including staging, canary, production, rollback, GitHub PR,
+  review, and multiple pre-build planning states.
+- At least four overlapping evidence implementations: `audit`, `evidence`,
+  `engineering.ledger`, and `quality.test_evidence`.
+- Separate planner, architecture agent, implementation agent, reviewer, fixer,
+  specialist router, repository adapter, deployment adapters, and workflow engines.
+
+This surface is materially larger than the frozen product requires.
+
+## Package decisions
+
+| Existing package | Decision | Frozen-core destination | Reason / precondition |
+|---|---|---|---|
+| `contracts` | KEEP + REDUCE | `contracts` | Keep canonical digest, schema, grammar, compiler, and human-test references. Remove legacy format machinery only after one real PMOS bundle migrates losslessly. |
+| `validation` | MERGE | `contracts` | Contract completeness, contradiction, ownership, and compile-time coverage are one boundary. |
+| `ingestion` | MERGE | `contracts` | Loading and normalization are contract intake, not a separate subsystem. |
+| `admission` | MERGE | `contracts` | Admission is the compiler result: valid, invalid, or human input required. |
+| `testing` | KEEP + REDUCE | `contracts` / `verify` | Retain deterministic assertion compilation and meaningful-RED admission. Delete test-planning abstractions not used by E1. |
+| `stacks` | MERGE → ONE | `template` | Keep one composable scaffold. Remove stack selection after E1 proves the surviving template. |
+| `implementation` | KEEP + REDUCE | `coder` | One bounded Coder interface and workspace. No Test Writer or Repairer role. |
+| `planning` | DELETE / INLINE | compiler proposal input | Planning cannot be an authoritative worker or state. A model proposal may be validated by the compiler. |
+| `agents` | DELETE / INLINE | `coder` | Registry/router are unnecessary with one mandatory worker. |
+| `architecture` | DELETE | none | Architecture generation and taste-grading are not part of the minimum runtime. Keep only ordinary import-boundary tests if E1 needs them. |
+| `orchestration` | KEEP + REWRITE SMALL | `engine` | Replace 29 states with `VALIDATED`, `BUILDING`, `VERIFYING`, `RELEASE_READY`, `HALTED`, `STOPPED`. Preserve proven budget and append-only transition invariants. |
+| `execution` | MERGE | `engine` | Execution kernel is an implementation detail of the one engine. |
+| `policies` | MERGE | `engine` | State, budget, retry, and release rules belong to the engine. |
+| `workflows` | MERGE / DEFER | `engine` | Keep only the contract-to-release-ready path. Product-specific support workflows move out of core. |
+| `audit` | MERGE | `evidence` | Convert semantic claims to events and blobs; retain digest/integrity primitives. |
+| `evidence` | KEEP + REDUCE | `evidence` | One versioned hash-chained `events.jsonl` plus `.pmpe/blobs/<sha256>`. Release bundle is a generated projection. |
+| `artifacts` | MERGE | `evidence` | Blob persistence is evidence storage. No storage interface. |
+| `telemetry` | MERGE | `evidence` | Runtime events are the evidence log; aggregate metrics are derived views. |
+| `engineering` | MERGE + REDUCE | `engine` / `evidence` | Keep candidate digest, bounded work, and finding identity. Remove PR/merge/deployment lifecycle from core. |
+| `quality` | KEEP + REDUCE | `verify` | One verifier result. Tests, deterministic evals, coverage, secret scan, SAST, and dependency scan. Critical/high and credentials block. |
+| `evals` | KEEP + REDUCE | `evals` | Keep E1-E5 and product-declared deterministic evals. Rubric scores remain advisory or are deleted. |
+| `assurance` | MERGE / DELETE | `verify` | Findings are verifier output. Remove separate fixer and review loops. |
+| `review` | DELETE RUNTIME | evidence annotation | One advisory review fires after deterministic PASS and cannot transition state or block. Human owns release. |
+| `repository` | DEFER | outside core | No mandatory GitHub/repository adapter. Retain only if a post-E1 consumer is approved. |
+| `gitops` | DEFER | outside core | Local Git convenience is not necessary to prove contract-to-release-ready. |
+| `deployment` | DELETE FROM CORE | outside repository core | Core stops at `RELEASE_READY`; no deployment flags or provider credentials. |
+| `fullstack` | MOVE / DEFER | product/template fixture | It is a generated-product example, not core orchestration. Use it only if selected as E1. |
+| `guided` | DEFER | product adapter | CLI is the primary v1 interface. A UI must later consume the same engine. |
+| `personal` | MOVE OUT OF CORE | separate product | Personal execution workflows are not Production Engineering OS runtime responsibilities. |
+| `demo` | KEEP AS FIXTURE | E1 fixture | Replace synthetic success claims with one real contract run. |
+| `repository`, `guided`, `personal`, `fullstack` dependencies in CLI | REMOVE FROM DEFAULT PATH | thin CLI | Default CLI exposes compile, run, status, evidence, and serve only. |
+| `domain` | KEEP + REDUCE | shared types | Retain only types used by the frozen core. |
+| `cli` | KEEP + REDUCE | `cli` | Thin calls over the compiler and engine; no alternate business logic. |
+
+## State inventory
+
+| Frozen state | Absorbs existing states |
+|---|---|
+| `VALIDATED` | contract received/approved, repository analysed, architecture/test/implementation planned |
+| `BUILDING` | draft PR open, implementation and repair in progress |
+| `VERIFYING` | verification failed, review required/failed |
+| `RELEASE_READY` | PR ready; no merge or deployment implication |
+| `HALTED` | contract invalid, product input required, blocked, budget exceeded, repeated finding |
+| `STOPPED` | explicit human cancellation |
+
+`TESTS_FAILING` is an event/invariant, not a state. `RELEASED`, PR merge, staging,
+canary, production, live observation, and rollback are outside the core.
+
+## Evidence inventory
+
+The surviving storage is:
+
+```text
+.pmpe/runs/<run-id>/events.jsonl
+.pmpe/blobs/<sha256>
+```
+
+Each event contains `schema_version`, `sequence`, `previous_digest`, `event_digest`,
+`run_id`, `state`, `event_type`, `subject_digest`, and referenced blob digests.
+Contract, plan, candidate diff, verifier results, findings, and advisory review bodies
+are blobs. Status, explanation, and the release evidence bundle are deterministic
+projections over the event chain.
+
+## Deletion order
+
+1. Freeze the current default branch and retain compatibility tests.
+2. Define and validate the acceptance-criteria grammar against one real PMOS contract.
+3. Add compile-time task/test coverage and the human-authored test reference.
+4. Prove meaningful RED on the untouched template, including the explicit
+   `satisfied_by_template` exception.
+5. Establish the two-file evidence format and migrate one E1 run.
+6. Introduce the six-state engine using existing budget and transition invariants.
+7. Route the CLI E1 path through compiler → template → Coder → verify.
+8. Pass E1, then E2-E5.
+9. Delete or move packages only when no surviving E1-E5 import or compatibility
+   obligation depends on them.
+10. Reopen backlog items only when a failing eval demonstrates the need.
+
+## Stop conditions
+
+- If the real PMOS contract cannot express most acceptance criteria without guessing,
+  stop and revise the grammar before changing runtime code.
+- If a deletion breaks an E1-E5 requirement, restore the smallest necessary primitive,
+  not its previous subsystem.
+- No new adapter, worker, lifecycle state, evidence type, or template is admitted
+  without a second real consumer or a failing eval.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,6 +24,20 @@ On Debian/Ubuntu, install the isolation runtime with:
 sudo apt-get install bubblewrap util-linux
 ```
 
+Ubuntu 24.04 restricts unprivileged user namespaces through AppArmor. Give only
+Bubblewrap permission to create the namespace used by the runner:
+
+```bash
+sudo tee /etc/apparmor.d/pmpe-bwrap >/dev/null <<'EOF'
+abi <abi/4.0>,
+include <tunables/global>
+/usr/bin/bwrap flags=(unconfined) {
+  userns,
+}
+EOF
+sudo apparmor_parser -r /etc/apparmor.d/pmpe-bwrap
+```
+
 Verify the install:
 
 ```bash

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,6 +4,8 @@
 
 - Python ≥ 3.11
 - git (used for the per-run build workspaces)
+- Linux `bubblewrap` and `prlimit` for the bare-bones contract runner. Generated
+  code is never executed without this local OS isolation boundary.
 - Optional but recommended: `ruff` (format/lint gates on generated code run when it
   is present and are recorded as skipped when it is not)
 
@@ -14,6 +16,12 @@ git clone https://github.com/Abhillashjadhav/production-engineering-os
 cd production-engineering-os
 python3 -m venv .venv && . .venv/bin/activate
 pip install -e ".[dev]"     # runtime-only: pip install -e .
+```
+
+On Debian/Ubuntu, install the isolation runtime with:
+
+```bash
+sudo apt-get install bubblewrap util-linux
 ```
 
 Verify the install:

--- a/examples/barebones/e1-contract.json
+++ b/examples/barebones/e1-contract.json
@@ -1,0 +1,34 @@
+{
+  "contract_id": "PMOS-E1",
+  "contract_version": 1,
+  "functional_requirements": {
+    "FR-001": {
+      "statement": "The generated product reports that its health is ok."
+    }
+  },
+  "acceptance_criteria": {
+    "AC-001": {
+      "requirement_refs": [
+        "FR-001"
+      ],
+      "given": [
+        {
+          "path": "service.running",
+          "operator": "eq",
+          "value": true
+        }
+      ],
+      "when": {
+        "action": "health",
+        "arguments": {}
+      },
+      "then": [
+        {
+          "path": "result.status",
+          "operator": "eq",
+          "value": "ok"
+        }
+      ]
+    }
+  }
+}

--- a/examples/barebones/e1-provider.py
+++ b/examples/barebones/e1-provider.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Deterministic E1 fixture, not a production model provider."""
+
+import json
+import sys
+
+message = json.load(sys.stdin)
+request = message["request"]
+if message["purpose"] == "code":
+    response = {
+        "request_digest": request["request_digest"],
+        "files": {
+            "product.py": (
+                '"""E1 health product."""\n\n'
+                "def health() -> dict[str, str]:\n"
+                '    return {"status": "ok"}\n'
+            )
+        },
+    }
+else:
+    response = {
+        "request_digest": request["request_digest"],
+        "summary": "Deterministic evidence passed; human may release.",
+    }
+json.dump(response, sys.stdout)

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -1,0 +1,582 @@
+"""Minimal contract-to-RELEASE_READY runtime with no deployment dependency."""
+
+from __future__ import annotations
+
+import json
+import operator as comparison
+import re
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from pmpe.contracts.acceptance import (
+    AcceptanceBuildPlan,
+    CompiledCriterion,
+    Operator,
+    PropertyAssertion,
+    compile_acceptance_plan,
+)
+from pmpe.contracts.canonical import canonical_digest
+from pmpe.evidence.ledger import EvidenceLedger
+from pmpe.model_provider import ModelProvider
+
+
+class RunState(StrEnum):
+    VALIDATED = "VALIDATED"
+    BUILDING = "BUILDING"
+    VERIFYING = "VERIFYING"
+    RELEASE_READY = "RELEASE_READY"
+    HALTED = "HALTED"
+    STOPPED = "STOPPED"
+
+
+@dataclass(frozen=True)
+class Template:
+    version: str
+    files: Mapping[str, str]
+    actions: Mapping[str, str]
+    context: Mapping[str, Any]
+    test_ids: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class BudgetCaps:
+    max_attempts: int = 3
+    max_model_calls: int = 8
+    max_model_output_bytes: int = 1_000_000
+
+
+@dataclass(frozen=True)
+class Finding:
+    code: str
+    subject_id: str
+    message: str
+    files: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RunResult:
+    run_id: str
+    state: RunState
+    cause: str
+    attempts: int
+    model_calls: int
+    elapsed_ms: int
+    evidence_path: Path
+    annotation: Mapping[str, Any] = field(default_factory=dict)
+
+
+class ContractInvalidError(ValueError):
+    """The baseline proves that an admitted contract or template is not runnable."""
+
+
+_SAFE_RELATIVE = re.compile(r"[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\Z")
+_MODULE_TARGET = re.compile(r"([A-Za-z_][A-Za-z0-9_.]*):([A-Za-z_][A-Za-z0-9_]*)\Z")
+_CREDENTIAL = re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|AKIA[0-9A-Z]{16}")
+_HIGH_RISK_CODE = re.compile(r"\b(?:eval|exec)\s*\(")
+
+
+def default_template() -> Template:
+    """The one v1 template; products compose behavior inside this single skeleton."""
+
+    return Template(
+        version="barebones-1",
+        files={
+            "product.py": (
+                '"""Product behavior generated from a PMOS contract."""\n\n'
+                "def health() -> dict[str, str]:\n"
+                '    return {"status": "not_implemented"}\n'
+            )
+        },
+        actions={"health": "product:health"},
+        context={"service": {"running": True}},
+    )
+
+
+def _safe_path(root: Path, relative: str) -> Path:
+    if not _SAFE_RELATIVE.fullmatch(relative) or ".." in Path(relative).parts:
+        raise ValueError(f"unsafe candidate path: {relative}")
+    target = (root / relative).resolve()
+    if not target.is_relative_to(root.resolve()):
+        raise ValueError(f"candidate path escapes workspace: {relative}")
+    return target
+
+
+def _write_files(root: Path, files: Mapping[str, str]) -> tuple[str, ...]:
+    changed: list[str] = []
+    for relative, content in sorted(files.items()):
+        if not isinstance(relative, str) or not isinstance(content, str):
+            raise ValueError("candidate files must map safe paths to UTF-8 text")
+        target = _safe_path(root, relative)
+        before = target.read_text() if target.is_file() else None
+        if before == content:
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+        changed.append(relative)
+    return tuple(changed)
+
+
+def _path(value: Any, dotted_path: str) -> Any:
+    current = value
+    for part in dotted_path.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            raise KeyError(dotted_path)
+        current = current[part]
+    return current
+
+
+def _assertion_passes(assertion: PropertyAssertion, value: Any) -> bool:
+    try:
+        actual = _path(value, assertion.path)
+    except KeyError:
+        actual = None
+    binary: dict[Operator, Callable[[Any, Any], bool]] = {
+        Operator.EQ: comparison.eq,
+        Operator.NE: comparison.ne,
+        Operator.LT: comparison.lt,
+        Operator.LTE: comparison.le,
+        Operator.GT: comparison.gt,
+        Operator.GTE: comparison.ge,
+        Operator.CONTAINS: lambda left, right: right in left,
+        Operator.NOT_CONTAINS: lambda left, right: right not in left,
+        Operator.MATCHES: lambda left, right: bool(re.search(str(right), str(left))),
+    }
+    if assertion.operator in binary:
+        try:
+            return binary[assertion.operator](actual, assertion.value)
+        except (TypeError, re.error):
+            return False
+    unary = {
+        Operator.IS_TRUE: actual is True,
+        Operator.IS_FALSE: actual is False,
+        Operator.IS_NULL: actual is None,
+        Operator.NOT_NULL: actual is not None,
+    }
+    return unary[assertion.operator]
+
+
+def _run_action(workspace: Path, target: str, arguments: Mapping[str, Any]) -> Any:
+    match = _MODULE_TARGET.fullmatch(target)
+    if match is None:
+        raise ContractInvalidError(f"invalid template action target: {target}")
+    module, function = match.groups()
+    module_path = workspace / (module.replace(".", "/") + ".py")
+    runner = (
+        "import importlib.util,json,sys;"
+        "s=importlib.util.spec_from_file_location('candidate',sys.argv[1]);"
+        "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"
+        f"v=getattr(m,{function!r})(**json.loads(sys.argv[2]));"
+        "print(json.dumps(v,sort_keys=True,separators=(',',':')))"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-I", "-c", runner, str(module_path), json.dumps(arguments)],
+        cwd=workspace,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+        env={"PYTHONPATH": str(workspace)},
+    )
+    if completed.returncode != 0:
+        raise ContractInvalidError("action failed before an assertion: " + completed.stderr.strip())
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise ContractInvalidError("action did not return one JSON value") from exc
+
+
+def _criterion_findings(
+    criterion: CompiledCriterion,
+    *,
+    workspace: Path,
+    template: Template,
+) -> tuple[Finding, ...]:
+    if criterion.form == "satisfied_by_template":
+        return ()
+    if criterion.form == "human_test":
+        assert criterion.human_test is not None
+        completed = subprocess.run(
+            criterion.human_test.command,
+            cwd=workspace,
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+        if completed.returncode == 0:
+            return ()
+        output = completed.stdout + completed.stderr
+        if "AssertionError" not in output and "assert " not in output:
+            raise ContractInvalidError("human test failed before an assertion")
+        return (
+            Finding(
+                "ASSERTION_FAILED",
+                criterion.criterion_id,
+                "human-authored acceptance assertion failed",
+                (criterion.human_test.path,),
+            ),
+        )
+    if criterion.form == "measure":
+        raise ContractInvalidError("measure has no registered deterministic observation source")
+    assert criterion.when is not None
+    if any(not _assertion_passes(item, template.context) for item in criterion.given):
+        raise ContractInvalidError(f"{criterion.criterion_id}: Given precondition is false")
+    target = template.actions[criterion.when.action]
+    result = _run_action(workspace, target, criterion.when.arguments)
+    wrapped = {"result": result}
+    if all(_assertion_passes(item, wrapped) for item in criterion.then):
+        return ()
+    module = target.split(":", maxsplit=1)[0].replace(".", "/") + ".py"
+    return (
+        Finding(
+            "ASSERTION_FAILED",
+            criterion.criterion_id,
+            "compiled acceptance assertion failed",
+            (module,),
+        ),
+    )
+
+
+def _verify(plan: AcceptanceBuildPlan, workspace: Path, template: Template) -> tuple[Finding, ...]:
+    findings: list[Finding] = []
+    for criterion in plan.criteria:
+        findings.extend(_criterion_findings(criterion, workspace=workspace, template=template))
+    return tuple(findings)
+
+
+def _security_findings(workspace: Path) -> tuple[Finding, ...]:
+    findings: list[Finding] = []
+    for path in sorted(workspace.rglob("*.py")):
+        content = path.read_text()
+        relative = str(path.relative_to(workspace))
+        if _CREDENTIAL.search(content):
+            findings.append(
+                Finding("CRITICAL_CREDENTIAL", relative, "credential material", (relative,))
+            )
+        if _HIGH_RISK_CODE.search(content):
+            findings.append(
+                Finding("HIGH_DYNAMIC_EXECUTION", relative, "dynamic execution", (relative,))
+            )
+        if "TODO" in content:
+            findings.append(Finding("LOW_TODO", relative, "TODO remains", (relative,)))
+    return tuple(findings)
+
+
+def _model_request(
+    *,
+    contract: Mapping[str, Any],
+    plan: AcceptanceBuildPlan,
+    workspace: Path,
+    findings: Sequence[Finding],
+) -> dict[str, Any]:
+    body = {
+        "contract": contract,
+        "plan": plan.as_dict(),
+        "files": {
+            str(path.relative_to(workspace)): path.read_text()
+            for path in sorted(workspace.rglob("*"))
+            if path.is_file()
+            and "__pycache__" not in path.parts
+            and path.suffix in {".json", ".md", ".py", ".toml", ".txt", ".yaml", ".yml"}
+        },
+        "findings": [asdict(item) for item in findings],
+    }
+    return {**body, "request_digest": canonical_digest(body)}
+
+
+def _invoke_bound(
+    provider: ModelProvider,
+    *,
+    purpose: str,
+    request: Mapping[str, Any],
+    budget: BudgetCaps,
+    counters: dict[str, int],
+) -> Mapping[str, Any]:
+    if counters["calls"] >= budget.max_model_calls:
+        raise RuntimeError("MODEL_CALL_BUDGET_EXHAUSTED")
+    response = provider.invoke(purpose=purpose, request=request)
+    counters["calls"] += 1
+    size = len(json.dumps(response, sort_keys=True, separators=(",", ":")).encode())
+    counters["bytes"] += size
+    if counters["bytes"] > budget.max_model_output_bytes:
+        raise RuntimeError("MODEL_OUTPUT_BUDGET_EXHAUSTED")
+    if response.get("request_digest") != request.get("request_digest"):
+        raise RuntimeError("MODEL_RESPONSE_UNBOUND")
+    return response
+
+
+def run_to_release_ready(
+    *,
+    contract: Mapping[str, Any],
+    repository_root: Path,
+    workspace: Path,
+    run_id: str,
+    provider: ModelProvider,
+    template: Template | None = None,
+    budget: BudgetCaps | None = None,
+    stop_requested: Callable[[], bool] = lambda: False,
+) -> RunResult:
+    """Run the frozen core. It never deploys and stops at RELEASE_READY."""
+
+    started = time.monotonic()
+    active_template = template or default_template()
+    active_budget = budget or BudgetCaps()
+    ledger = EvidenceLedger(repository_root, run_id)
+    counters = {"calls": 0, "bytes": 0}
+    subject_digest = canonical_digest(contract)
+
+    def finish(
+        state: RunState, cause: str, attempts: int, annotation: Mapping[str, Any] | None = None
+    ) -> RunResult:
+        return RunResult(
+            run_id,
+            state,
+            cause,
+            attempts,
+            counters["calls"],
+            int((time.monotonic() - started) * 1000),
+            ledger.events_path,
+            dict(annotation or {}),
+        )
+
+    plan = compile_acceptance_plan(
+        contract,
+        repository_root=repository_root,
+        registered_actions=frozenset(active_template.actions),
+        template_version=active_template.version,
+        template_test_ids=active_template.test_ids,
+    )
+    plan_blob = ledger.put_blob(
+        json.dumps(plan.as_dict(), sort_keys=True, separators=(",", ":")).encode()
+    )
+    ledger.append(
+        event_type="contract_validated",
+        state=RunState.VALIDATED,
+        subject_digest=subject_digest,
+        blob_digests=(plan_blob,),
+        payload={"plan_digest": plan.plan_digest},
+    )
+    if stop_requested():
+        ledger.append(event_type="stopped", state=RunState.STOPPED, subject_digest=subject_digest)
+        return finish(RunState.STOPPED, "STOP_REQUESTED", 0)
+
+    workspace.mkdir(parents=True, exist_ok=True)
+    if any(workspace.iterdir()):
+        raise ValueError("candidate workspace must be empty")
+    _write_files(workspace, active_template.files)
+    protected_tests: set[str] = set()
+    for criterion in plan.criteria:
+        if criterion.human_test is None:
+            continue
+        relative = criterion.human_test.path
+        source = repository_root / relative
+        _write_files(workspace, {relative: source.read_text()})
+        protected_tests.add(relative)
+    baseline = _verify(plan, workspace, active_template)
+    non_template = tuple(item for item in plan.criteria if item.form != "satisfied_by_template")
+    failed_ids = {item.subject_id for item in baseline}
+    if not non_template or failed_ids != {item.criterion_id for item in non_template}:
+        raise ContractInvalidError("baseline must fail every non-template criterion by assertion")
+    baseline_blob = ledger.put_blob(
+        json.dumps(
+            [asdict(item) for item in baseline], sort_keys=True, separators=(",", ":")
+        ).encode()
+    )
+    ledger.append(
+        event_type="meaningful_red_confirmed",
+        state=RunState.BUILDING,
+        subject_digest=subject_digest,
+        blob_digests=(baseline_blob,),
+        payload={"findings": [asdict(item) for item in baseline]},
+    )
+
+    findings: tuple[Finding, ...] = baseline
+    previous_finding_digest = ""
+    for attempt in range(1, active_budget.max_attempts + 1):
+        if stop_requested():
+            ledger.append(
+                event_type="stopped", state=RunState.STOPPED, subject_digest=subject_digest
+            )
+            return finish(RunState.STOPPED, "STOP_REQUESTED", attempt - 1)
+        request = _model_request(
+            contract=contract,
+            plan=plan,
+            workspace=workspace,
+            findings=findings,
+        )
+        try:
+            response = _invoke_bound(
+                provider,
+                purpose="code",
+                request=request,
+                budget=active_budget,
+                counters=counters,
+            )
+        except RuntimeError as exc:
+            ledger.append(
+                event_type="halted",
+                state=RunState.HALTED,
+                subject_digest=subject_digest,
+                payload={"cause": str(exc)},
+            )
+            return finish(RunState.HALTED, str(exc), attempt - 1)
+        files = response.get("files")
+        if not isinstance(files, Mapping):
+            ledger.append(
+                event_type="halted",
+                state=RunState.HALTED,
+                subject_digest=subject_digest,
+                payload={"cause": "CODER_RESPONSE_INVALID"},
+            )
+            return finish(RunState.HALTED, "CODER_RESPONSE_INVALID", attempt)
+        if protected_tests.intersection(files):
+            ledger.append(
+                event_type="halted",
+                state=RunState.HALTED,
+                subject_digest=subject_digest,
+                payload={"cause": "CODER_MODIFIED_EVIDENCE"},
+            )
+            return finish(RunState.HALTED, "CODER_MODIFIED_EVIDENCE", attempt)
+        try:
+            changed = _write_files(workspace, files)
+        except ValueError:
+            ledger.append(
+                event_type="halted",
+                state=RunState.HALTED,
+                subject_digest=subject_digest,
+                payload={"cause": "CODER_RESPONSE_INVALID"},
+            )
+            return finish(RunState.HALTED, "CODER_RESPONSE_INVALID", attempt)
+        coder_blob = ledger.put_blob(
+            json.dumps(response, sort_keys=True, separators=(",", ":")).encode()
+        )
+        ledger.append(
+            event_type="coder_completed",
+            state=RunState.BUILDING,
+            subject_digest=subject_digest,
+            blob_digests=(coder_blob,),
+            payload={"attempt": attempt, "changed": list(changed)},
+        )
+        finding_digest = canonical_digest([asdict(item) for item in findings])
+        implicated = {path for item in findings for path in item.files}
+        if previous_finding_digest == finding_digest and not implicated.intersection(changed):
+            subjects = ",".join(sorted({item.subject_id for item in findings}))
+            cause = f"REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:{subjects}"
+            ledger.append(
+                event_type="halted",
+                state=RunState.HALTED,
+                subject_digest=subject_digest,
+                payload={"cause": cause, "findings": [asdict(item) for item in findings]},
+            )
+            return finish(RunState.HALTED, cause, attempt)
+
+        security = _security_findings(workspace)
+        blocking_security = tuple(
+            item for item in security if item.code.startswith(("CRITICAL_", "HIGH_"))
+        )
+        if blocking_security:
+            findings = blocking_security
+            finding_blob = ledger.put_blob(
+                json.dumps(
+                    [asdict(item) for item in findings],
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode()
+            )
+            ledger.append(
+                event_type="security_failed",
+                state=RunState.BUILDING,
+                subject_digest=subject_digest,
+                blob_digests=(finding_blob,),
+                payload={"attempt": attempt, "findings": [asdict(item) for item in findings]},
+            )
+        else:
+            ledger.append(
+                event_type="verification_started",
+                state=RunState.VERIFYING,
+                subject_digest=subject_digest,
+                payload={"attempt": attempt, "changed": list(changed)},
+            )
+            findings = _verify(plan, workspace, active_template)
+            if not findings:
+                evidence = {
+                    "assertions": "passed",
+                    "coverage": "complete",
+                    "security": [asdict(item) for item in security],
+                    "attempt": attempt,
+                }
+                blob = ledger.put_blob(json.dumps(evidence, sort_keys=True).encode())
+                candidate = {
+                    str(path.relative_to(workspace)): path.read_text()
+                    for path in sorted(workspace.rglob("*"))
+                    if path.is_file()
+                    and "__pycache__" not in path.parts
+                    and path.suffix in {".json", ".md", ".py", ".toml", ".txt", ".yaml", ".yml"}
+                }
+                candidate_blob = ledger.put_blob(
+                    json.dumps(candidate, sort_keys=True, separators=(",", ":")).encode()
+                )
+                review_body = {
+                    "contract_digest": subject_digest,
+                    "plan_digest": plan.plan_digest,
+                    "evidence_digest": blob,
+                    "instruction": "Return one non-blocking advisory annotation.",
+                }
+                review_request = {
+                    **review_body,
+                    "request_digest": canonical_digest(review_body),
+                }
+                try:
+                    annotation = _invoke_bound(
+                        provider,
+                        purpose="advisory_review",
+                        request=review_request,
+                        budget=active_budget,
+                        counters=counters,
+                    )
+                except RuntimeError as exc:
+                    annotation = {"status": "unavailable", "cause": str(exc)}
+                ledger.append(
+                    event_type="release_ready",
+                    state=RunState.RELEASE_READY,
+                    subject_digest=subject_digest,
+                    blob_digests=(blob, candidate_blob),
+                    payload={
+                        "annotation": dict(annotation),
+                        "candidate_digest": candidate_blob,
+                        "telemetry": dict(counters),
+                    },
+                )
+                return finish(RunState.RELEASE_READY, "PASS", attempt, annotation)
+            finding_blob = ledger.put_blob(
+                json.dumps(
+                    [asdict(item) for item in findings],
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode()
+            )
+            ledger.append(
+                event_type="verification_failed",
+                state=RunState.BUILDING,
+                subject_digest=subject_digest,
+                blob_digests=(finding_blob,),
+                payload={"attempt": attempt, "findings": [asdict(item) for item in findings]},
+            )
+        previous_finding_digest = finding_digest
+
+    ledger.append(
+        event_type="halted",
+        state=RunState.HALTED,
+        subject_digest=subject_digest,
+        payload={
+            "cause": "ATTEMPT_BUDGET_EXHAUSTED",
+            "findings": [asdict(item) for item in findings],
+        },
+    )
+    return finish(RunState.HALTED, "ATTEMPT_BUDGET_EXHAUSTED", active_budget.max_attempts)

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -1001,10 +1001,14 @@ def run_to_release_ready(
         human_test_repair = bool(changed) and any(
             item.subject_id in human_test_ids for item in findings
         )
+        dependency_repair = any(
+            item.code == "CANDIDATE_EXECUTION_FAILED" for item in findings
+        ) and any(path.endswith(".py") for path in changed)
         if (
             previous_finding_digest == finding_digest
             and not implicated.intersection(changed)
             and not human_test_repair
+            and not dependency_repair
         ):
             subjects = ",".join(sorted({item.subject_id for item in findings}))
             cause = f"REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:{subjects}"

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -216,7 +216,7 @@ class BubblewrapCandidateSandbox:
             limiter,
             f"--as={1024 * 1024 * 1024}",
             f"--cpu={int(timeout_seconds) + 1}",
-            f"--fsize={_CANDIDATE_OUTPUT_LIMIT_BYTES + 1}",
+            f"--fsize={64 * 1024 * 1024}",
             "--nofile=256",
             "--nproc=128",
             "--",
@@ -822,6 +822,10 @@ def run_to_release_ready(
         registered_measures=frozenset(active_template.measures),
         trusted_test_digests=trusted_test_digests,
     )
+    workspace_root = workspace.resolve()
+    evidence_root = (repository_root / ".pmpe").resolve()
+    if workspace_root.is_relative_to(evidence_root) or evidence_root.is_relative_to(workspace_root):
+        raise ContractInvalidError("candidate workspace must not overlap evidence storage")
     if workspace.exists() and (not workspace.is_dir() or any(workspace.iterdir())):
         raise ContractInvalidError("candidate workspace must be empty")
     workspace.mkdir(parents=True, exist_ok=True)

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -17,7 +17,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 from pmpe.contracts.acceptance import (
     AcceptanceBuildPlan,
@@ -94,6 +94,10 @@ _CREDENTIAL = re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|AKI
 _HIGH_RISK_CODE = re.compile(r"\b(?:eval|exec)\s*\(")
 _ACTION_TIMEOUT_SECONDS = 10.0
 _PYTEST_TIMEOUT_SECONDS = 30.0
+
+
+def _reject_non_json_constant(token: str) -> NoReturn:
+    raise ValueError(f"non-JSON numeric constant: {token}")
 
 
 def default_template() -> Template:
@@ -217,8 +221,13 @@ def _run_action(workspace: Path, target: str, arguments: Mapping[str, Any]) -> A
     if completed.returncode != 0:
         raise ContractInvalidError("action failed before an assertion: " + completed.stderr.strip())
     try:
-        return json.loads(completed.stdout)
-    except json.JSONDecodeError as exc:
+        value = json.loads(
+            completed.stdout,
+            parse_constant=_reject_non_json_constant,
+        )
+        canonical_digest(value)
+        return value
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ContractInvalidError("action did not return one JSON value") from exc
 
 
@@ -597,6 +606,13 @@ def run_to_release_ready(
             raise ContractInvalidError("human test changed after compilation")
         _write_files(workspace, {relative: source.read_text()})
         protected_tests.add(_safe_path(workspace, relative))
+    protected_package_initializers: set[Path] = set()
+    for protected_test in protected_tests:
+        parent = protected_test.parent
+        while parent != workspace:
+            protected_package_initializers.add(parent / "__init__.py")
+            parent = parent.parent
+    protected_tests.update(protected_package_initializers)
     baseline = _verify_snapshot(
         plan,
         _workspace_snapshot(workspace),
@@ -604,7 +620,7 @@ def run_to_release_ready(
     )
     non_template = tuple(item for item in plan.criteria if item.form != "satisfied_by_template")
     failed_ids = {item.subject_id for item in baseline}
-    if not non_template or failed_ids != {item.criterion_id for item in non_template}:
+    if failed_ids != {item.criterion_id for item in non_template}:
         raise ContractInvalidError("baseline must fail every non-template criterion by assertion")
     baseline_blob = ledger.put_blob(
         json.dumps(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import operator as comparison
+import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
+import xml.etree.ElementTree as ET
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
@@ -36,12 +40,20 @@ class RunState(StrEnum):
 
 
 @dataclass(frozen=True)
+class TemplateTest:
+    path: str
+    node_id: str
+    command: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class Template:
     version: str
     files: Mapping[str, str]
     actions: Mapping[str, str]
     context: Mapping[str, Any]
-    test_ids: frozenset[str] = frozenset()
+    proofs: Mapping[str, TemplateTest] = field(default_factory=dict)
+    measures: Mapping[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -99,7 +111,9 @@ def default_template() -> Template:
 
 
 def _safe_path(root: Path, relative: str) -> Path:
-    if not _SAFE_RELATIVE.fullmatch(relative) or ".." in Path(relative).parts:
+    if not _SAFE_RELATIVE.fullmatch(relative) or any(
+        part in {".", ".."} for part in relative.split("/")
+    ):
         raise ValueError(f"unsafe candidate path: {relative}")
     target = (root / relative).resolve()
     if not target.is_relative_to(root.resolve()):
@@ -175,13 +189,13 @@ def _run_action(workspace: Path, target: str, arguments: Mapping[str, Any]) -> A
         "print(json.dumps(v,sort_keys=True,separators=(',',':')))"
     )
     completed = subprocess.run(
-        [sys.executable, "-I", "-c", runner, str(module_path), json.dumps(arguments)],
+        [sys.executable, "-I", "-B", "-c", runner, str(module_path), json.dumps(arguments)],
         cwd=workspace,
         text=True,
         capture_output=True,
         timeout=10,
         check=False,
-        env={"PYTHONPATH": str(workspace)},
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
     )
     if completed.returncode != 0:
         raise ContractInvalidError("action failed before an assertion: " + completed.stderr.strip())
@@ -191,6 +205,47 @@ def _run_action(workspace: Path, target: str, arguments: Mapping[str, Any]) -> A
         raise ContractInvalidError("action did not return one JSON value") from exc
 
 
+def _run_pytest_node(workspace: Path, test: TemplateTest) -> bool:
+    descriptor, report_name = tempfile.mkstemp(suffix=".xml")
+    os.close(descriptor)
+    report = Path(report_name)
+    try:
+        completed = subprocess.run(
+            [
+                *test.command,
+                f"--junitxml={report}",
+                "-o",
+                "junit_family=xunit2",
+                "-p",
+                "no:cacheprovider",
+            ],
+            cwd=workspace,
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=False,
+            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        )
+        try:
+            root = ET.parse(report).getroot()
+        except (ET.ParseError, OSError) as exc:
+            raise ContractInvalidError("human test produced no structured pytest result") from exc
+        cases = [item for item in root.iter("testcase") if item.get("name") == test.node_id]
+        if len(cases) != 1:
+            raise ContractInvalidError("bound human test node did not execute exactly once")
+        case = cases[0]
+        if case.find("skipped") is not None or case.find("error") is not None:
+            raise ContractInvalidError("bound human test was skipped or errored")
+        failure = case.find("failure")
+        if failure is not None and completed.returncode == 1:
+            return False
+        if failure is None and completed.returncode == 0:
+            return True
+        raise ContractInvalidError("human test failed outside its bound assertion")
+    finally:
+        report.unlink(missing_ok=True)
+
+
 def _criterion_findings(
     criterion: CompiledCriterion,
     *,
@@ -198,22 +253,31 @@ def _criterion_findings(
     template: Template,
 ) -> tuple[Finding, ...]:
     if criterion.form == "satisfied_by_template":
+        assert criterion.template_proof is not None
+        proof = template.proofs[criterion.template_proof.test_id]
+        proof_path = _safe_path(workspace, proof.path)
+        digest = "sha256:" + hashlib.sha256(proof_path.read_bytes()).hexdigest()
+        if digest != criterion.template_proof.file_digest:
+            raise ContractInvalidError("template proof file does not match its compiled digest")
+        if not _run_pytest_node(workspace, proof):
+            return (
+                Finding(
+                    "ASSERTION_FAILED",
+                    criterion.criterion_id,
+                    "template acceptance proof failed",
+                    (proof.path,),
+                ),
+            )
         return ()
     if criterion.form == "human_test":
         assert criterion.human_test is not None
-        completed = subprocess.run(
+        human_test = TemplateTest(
+            criterion.human_test.path,
+            criterion.human_test.node_id,
             criterion.human_test.command,
-            cwd=workspace,
-            text=True,
-            capture_output=True,
-            timeout=30,
-            check=False,
         )
-        if completed.returncode == 0:
+        if _run_pytest_node(workspace, human_test):
             return ()
-        output = completed.stdout + completed.stderr
-        if "AssertionError" not in output and "assert " not in output:
-            raise ContractInvalidError("human test failed before an assertion")
         return (
             Finding(
                 "ASSERTION_FAILED",
@@ -223,7 +287,27 @@ def _criterion_findings(
             ),
         )
     if criterion.form == "measure":
-        raise ContractInvalidError("measure has no registered deterministic observation source")
+        assert criterion.operator is not None
+        assert criterion.minimum_sample is not None
+        target = template.measures[criterion.measure]
+        observation = _run_action(workspace, target, {})
+        if not isinstance(observation, Mapping):
+            raise ContractInvalidError("measure did not return a JSON object")
+        sample_size = observation.get("sample_size")
+        if isinstance(sample_size, bool) or not isinstance(sample_size, int):
+            raise ContractInvalidError("measure did not return an integer sample_size")
+        assertion = PropertyAssertion("value", criterion.operator, criterion.value)
+        if sample_size >= criterion.minimum_sample and _assertion_passes(assertion, observation):
+            return ()
+        module = target.split(":", maxsplit=1)[0].replace(".", "/") + ".py"
+        return (
+            Finding(
+                "ASSERTION_FAILED",
+                criterion.criterion_id,
+                "compiled measure assertion failed",
+                (module,),
+            ),
+        )
     assert criterion.when is not None
     if any(not _assertion_passes(item, template.context) for item in criterion.given):
         raise ContractInvalidError(f"{criterion.criterion_id}: Given precondition is false")
@@ -266,6 +350,21 @@ def _security_findings(workspace: Path) -> tuple[Finding, ...]:
         if "TODO" in content:
             findings.append(Finding("LOW_TODO", relative, "TODO remains", (relative,)))
     return tuple(findings)
+
+
+def _candidate_manifest(workspace: Path, ledger: EvidenceLedger) -> tuple[str, tuple[str, ...]]:
+    manifest: dict[str, str] = {}
+    blobs: list[str] = []
+    for path in sorted(workspace.rglob("*")):
+        if not path.is_file():
+            continue
+        digest = ledger.put_blob(path.read_bytes())
+        manifest[str(path.relative_to(workspace))] = digest
+        blobs.append(digest)
+    manifest_blob = ledger.put_blob(
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    )
+    return manifest_blob, tuple(sorted(set(blobs)))
 
 
 def _model_request(
@@ -331,6 +430,16 @@ def run_to_release_ready(
     counters = {"calls": 0, "bytes": 0}
     subject_digest = canonical_digest(contract)
 
+    template_test_digests: dict[str, str] = {}
+    for test_id, proof in active_template.proofs.items():
+        _safe_path(workspace, proof.path)
+        target = f"{proof.path}::{proof.node_id}"
+        if proof.path not in active_template.files or target not in proof.command:
+            raise ContractInvalidError(f"invalid template proof binding: {test_id}")
+        template_test_digests[test_id] = (
+            "sha256:" + hashlib.sha256(active_template.files[proof.path].encode()).hexdigest()
+        )
+
     def finish(
         state: RunState, cause: str, attempts: int, annotation: Mapping[str, Any] | None = None
     ) -> RunResult:
@@ -350,7 +459,8 @@ def run_to_release_ready(
         repository_root=repository_root,
         registered_actions=frozenset(active_template.actions),
         template_version=active_template.version,
-        template_test_ids=active_template.test_ids,
+        template_test_digests=template_test_digests,
+        registered_measures=frozenset(active_template.measures),
     )
     plan_blob = ledger.put_blob(
         json.dumps(plan.as_dict(), sort_keys=True, separators=(",", ":")).encode()
@@ -373,14 +483,19 @@ def run_to_release_ready(
     if any(workspace.iterdir()):
         raise ValueError("candidate workspace must be empty")
     _write_files(workspace, active_template.files)
-    protected_tests: set[str] = set()
+    protected_tests = {
+        _safe_path(workspace, proof.path) for proof in active_template.proofs.values()
+    }
     for criterion in plan.criteria:
         if criterion.human_test is None:
             continue
         relative = criterion.human_test.path
         source = repository_root / relative
+        digest = "sha256:" + hashlib.sha256(source.read_bytes()).hexdigest()
+        if digest != criterion.human_test.file_digest:
+            raise ContractInvalidError("human test changed after compilation")
         _write_files(workspace, {relative: source.read_text()})
-        protected_tests.add(relative)
+        protected_tests.add(_safe_path(workspace, relative))
     baseline = _verify(plan, workspace, active_template)
     non_template = tuple(item for item in plan.criteria if item.form != "satisfied_by_template")
     failed_ids = {item.subject_id for item in baseline}
@@ -438,7 +553,21 @@ def run_to_release_ready(
                 payload={"cause": "CODER_RESPONSE_INVALID"},
             )
             return finish(RunState.HALTED, "CODER_RESPONSE_INVALID", attempt)
-        if protected_tests.intersection(files):
+        try:
+            response_paths = {
+                _safe_path(workspace, relative) for relative in files if isinstance(relative, str)
+            }
+            if len(response_paths) != len(files):
+                raise ValueError("candidate paths must be strings")
+        except ValueError:
+            ledger.append(
+                event_type="halted",
+                state=RunState.HALTED,
+                subject_digest=subject_digest,
+                payload={"cause": "CODER_RESPONSE_INVALID"},
+            )
+            return finish(RunState.HALTED, "CODER_RESPONSE_INVALID", attempt)
+        if protected_tests.intersection(response_paths):
             ledger.append(
                 event_type="halted",
                 state=RunState.HALTED,
@@ -533,16 +662,7 @@ def run_to_release_ready(
                     "attempt": attempt,
                 }
                 blob = ledger.put_blob(json.dumps(evidence, sort_keys=True).encode())
-                candidate = {
-                    str(path.relative_to(workspace)): path.read_text()
-                    for path in sorted(workspace.rglob("*"))
-                    if path.is_file()
-                    and "__pycache__" not in path.parts
-                    and path.suffix in {".json", ".md", ".py", ".toml", ".txt", ".yaml", ".yml"}
-                }
-                candidate_blob = ledger.put_blob(
-                    json.dumps(candidate, sort_keys=True, separators=(",", ":")).encode()
-                )
+                candidate_blob, candidate_file_blobs = _candidate_manifest(workspace, ledger)
                 review_body = {
                     "contract_digest": subject_digest,
                     "plan_digest": plan.plan_digest,
@@ -567,7 +687,7 @@ def run_to_release_ready(
                     event_type="release_ready",
                     state=RunState.RELEASE_READY,
                     subject_digest=subject_digest,
-                    blob_digests=(blob, candidate_blob),
+                    blob_digests=(blob, candidate_blob, *candidate_file_blobs),
                     payload={
                         "annotation": dict(annotation),
                         "candidate_digest": candidate_blob,
@@ -589,7 +709,7 @@ def run_to_release_ready(
                 blob_digests=(finding_blob,),
                 payload={"attempt": attempt, "findings": [asdict(item) for item in findings]},
             )
-        previous_finding_digest = finding_digest
+        previous_finding_digest = canonical_digest([asdict(item) for item in findings])
 
     ledger.append(
         event_type="halted",

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -605,7 +605,7 @@ def run_to_release_ready(
     trusted_test_digests = {
         relative: "sha256:" + hashlib.sha256(content.encode()).hexdigest()
         for relative, content in active_template.files.items()
-        if relative.startswith("tests/") and relative.endswith(".py")
+        if relative.startswith("tests/")
     }
 
     def finish(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -459,18 +459,21 @@ def _verify_snapshot(
 
 def _security_findings(workspace: Path) -> tuple[Finding, ...]:
     findings: list[Finding] = []
-    for path in sorted(workspace.rglob("*.py")):
-        content = path.read_text()
+    for path in sorted(item for item in workspace.rglob("*") if item.is_file()):
+        try:
+            content = path.read_text()
+        except UnicodeDecodeError:
+            continue
         relative = str(path.relative_to(workspace))
         if _CREDENTIAL.search(content):
             findings.append(
                 Finding("CRITICAL_CREDENTIAL", relative, "credential material", (relative,))
             )
-        if _HIGH_RISK_CODE.search(content):
+        if path.suffix == ".py" and _HIGH_RISK_CODE.search(content):
             findings.append(
                 Finding("HIGH_DYNAMIC_EXECUTION", relative, "dynamic execution", (relative,))
             )
-        if "TODO" in content:
+        if path.suffix == ".py" and "TODO" in content:
             findings.append(Finding("LOW_TODO", relative, "TODO remains", (relative,)))
     return tuple(findings)
 
@@ -741,7 +744,15 @@ def run_to_release_ready(
         )
         finding_digest = canonical_digest([asdict(item) for item in findings])
         implicated = {path for item in findings for path in item.files}
-        if previous_finding_digest == finding_digest and not implicated.intersection(changed):
+        human_test_ids = {item.criterion_id for item in plan.criteria if item.form == "human_test"}
+        human_test_repair = bool(changed) and any(
+            item.subject_id in human_test_ids for item in findings
+        )
+        if (
+            previous_finding_digest == finding_digest
+            and not implicated.intersection(changed)
+            and not human_test_repair
+        ):
             subjects = ",".join(sorted({item.subject_id for item in findings}))
             cause = f"REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:{subjects}"
             ledger.append(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -355,12 +355,15 @@ def run_to_release_ready(
     plan_blob = ledger.put_blob(
         json.dumps(plan.as_dict(), sort_keys=True, separators=(",", ":")).encode()
     )
+    contract_blob = ledger.put_blob(
+        json.dumps(contract, sort_keys=True, separators=(",", ":")).encode()
+    )
     ledger.append(
         event_type="contract_validated",
         state=RunState.VALIDATED,
         subject_digest=subject_digest,
-        blob_digests=(plan_blob,),
-        payload={"plan_digest": plan.plan_digest},
+        blob_digests=(contract_blob, plan_blob),
+        payload={"contract_digest": contract_blob, "plan_digest": plan.plan_digest},
     )
     if stop_requested():
         ledger.append(event_type="stopped", state=RunState.STOPPED, subject_digest=subject_digest)
@@ -503,7 +506,25 @@ def run_to_release_ready(
                 subject_digest=subject_digest,
                 payload={"attempt": attempt, "changed": list(changed)},
             )
-            findings = _verify(plan, workspace, active_template)
+            try:
+                findings = _verify(plan, workspace, active_template)
+            except ContractInvalidError as exc:
+                implicated_files = tuple(
+                    sorted(
+                        {
+                            target.split(":", maxsplit=1)[0].replace(".", "/") + ".py"
+                            for target in active_template.actions.values()
+                        }
+                    )
+                )
+                findings = (
+                    Finding(
+                        "CANDIDATE_EXECUTION_FAILED",
+                        "candidate",
+                        str(exc),
+                        implicated_files,
+                    ),
+                )
             if not findings:
                 evidence = {
                     "assertions": "passed",

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -168,14 +168,17 @@ def _assertion_passes(assertion: PropertyAssertion, value: Any) -> bool:
             return operation(left, right)
         return False
 
-    def contains(left: Any, right: Any) -> bool:
+    def contains(left: Any, right: Any, *, negate: bool = False) -> bool:
         if isinstance(left, list):
-            return any(canonical_digest(item) == canonical_digest(right) for item in left)
-        if isinstance(left, str) and isinstance(right, str):
-            return right in left
-        if isinstance(left, Mapping) and isinstance(right, str):
-            return right in left
-        return False
+            present = any(canonical_digest(item) == canonical_digest(right) for item in left)
+        elif isinstance(right, str) and isinstance(left, (str, Mapping)):
+            present = right in left
+        else:
+            return False
+        return not present if negate else present
+
+    def matches(left: Any, right: Any) -> bool:
+        return isinstance(left, str) and isinstance(right, str) and bool(re.search(right, left))
 
     binary: dict[Operator, Callable[[Any, Any], bool]] = {
         Operator.EQ: lambda left, right: canonical_digest(left) == canonical_digest(right),
@@ -185,8 +188,8 @@ def _assertion_passes(assertion: PropertyAssertion, value: Any) -> bool:
         Operator.GT: lambda left, right: ordered(left, right, comparison.gt),
         Operator.GTE: lambda left, right: ordered(left, right, comparison.ge),
         Operator.CONTAINS: contains,
-        Operator.NOT_CONTAINS: lambda left, right: not contains(left, right),
-        Operator.MATCHES: lambda left, right: bool(re.search(str(right), str(left))),
+        Operator.NOT_CONTAINS: lambda left, right: contains(left, right, negate=True),
+        Operator.MATCHES: matches,
     }
     if assertion.operator in binary:
         try:

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -168,6 +168,15 @@ def _assertion_passes(assertion: PropertyAssertion, value: Any) -> bool:
             return operation(left, right)
         return False
 
+    def contains(left: Any, right: Any) -> bool:
+        if isinstance(left, list):
+            return any(canonical_digest(item) == canonical_digest(right) for item in left)
+        if isinstance(left, str) and isinstance(right, str):
+            return right in left
+        if isinstance(left, Mapping) and isinstance(right, str):
+            return right in left
+        return False
+
     binary: dict[Operator, Callable[[Any, Any], bool]] = {
         Operator.EQ: lambda left, right: canonical_digest(left) == canonical_digest(right),
         Operator.NE: lambda left, right: canonical_digest(left) != canonical_digest(right),
@@ -175,8 +184,8 @@ def _assertion_passes(assertion: PropertyAssertion, value: Any) -> bool:
         Operator.LTE: lambda left, right: ordered(left, right, comparison.le),
         Operator.GT: lambda left, right: ordered(left, right, comparison.gt),
         Operator.GTE: lambda left, right: ordered(left, right, comparison.ge),
-        Operator.CONTAINS: lambda left, right: right in left,
-        Operator.NOT_CONTAINS: lambda left, right: right not in left,
+        Operator.CONTAINS: contains,
+        Operator.NOT_CONTAINS: lambda left, right: not contains(left, right),
         Operator.MATCHES: lambda left, right: bool(re.search(str(right), str(left))),
     }
     if assertion.operator in binary:
@@ -292,7 +301,19 @@ def _run_pytest_node(workspace: Path, test: TemplateTest) -> bool:
             root = ET.parse(report).getroot()
         except (ET.ParseError, OSError) as exc:
             raise ContractInvalidError("human test produced no structured pytest result") from exc
-        cases = [item for item in root.iter("testcase") if item.get("name") == test.node_id]
+        node_parts = test.node_id.split("::")
+        expected_name = node_parts[-1]
+        expected_classes = node_parts[:-1]
+        cases = [
+            item
+            for item in root.iter("testcase")
+            if item.get("name") == expected_name
+            and (
+                not expected_classes
+                or (item.get("classname") or "").split(".")[-len(expected_classes) :]
+                == expected_classes
+            )
+        ]
         if len(cases) != 1:
             raise ContractInvalidError("bound human test node did not execute exactly once")
         case = cases[0]
@@ -620,7 +641,9 @@ def run_to_release_ready(
     )
     non_template = tuple(item for item in plan.criteria if item.form != "satisfied_by_template")
     failed_ids = {item.subject_id for item in baseline}
-    if failed_ids != {item.criterion_id for item in non_template}:
+    if any(item.code != "ASSERTION_FAILED" for item in baseline) or failed_ids != {
+        item.criterion_id for item in non_template
+    }:
         raise ContractInvalidError("baseline must fail every non-template criterion by assertion")
     baseline_blob = ledger.put_blob(
         json.dumps(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -445,7 +445,21 @@ def _verify_snapshot(
         with tempfile.TemporaryDirectory(prefix="pmpe-verification-") as temporary:
             isolated = Path(temporary)
             _materialize_snapshot(isolated, snapshot)
-            findings.extend(_criterion_findings(criterion, workspace=isolated, template=template))
+            try:
+                findings.extend(
+                    _criterion_findings(criterion, workspace=isolated, template=template)
+                )
+            except ContractInvalidError as exc:
+                if criterion.human_test is None:
+                    raise
+                findings.append(
+                    Finding(
+                        "CANDIDATE_EXECUTION_FAILED",
+                        criterion.criterion_id,
+                        str(exc),
+                        (criterion.human_test.path,),
+                    )
+                )
             observed = _workspace_snapshot(isolated)
             if observed != snapshot:
                 changed = tuple(
@@ -588,6 +602,11 @@ def run_to_release_ready(
         template_test_digests[test_id] = (
             "sha256:" + hashlib.sha256(active_template.files[proof.path].encode()).hexdigest()
         )
+    trusted_test_digests = {
+        relative: "sha256:" + hashlib.sha256(content.encode()).hexdigest()
+        for relative, content in active_template.files.items()
+        if relative.startswith("tests/") and relative.endswith(".py")
+    }
 
     def finish(
         state: RunState, cause: str, attempts: int, annotation: Mapping[str, Any] | None = None
@@ -610,6 +629,7 @@ def run_to_release_ready(
         template_version=active_template.version,
         template_test_digests=template_test_digests,
         registered_measures=frozenset(active_template.measures),
+        trusted_test_digests=trusted_test_digests,
     )
     plan_blob = ledger.put_blob(
         json.dumps(plan.as_dict(), sort_keys=True, separators=(",", ":")).encode()
@@ -635,6 +655,12 @@ def run_to_release_ready(
     protected_tests = {
         _safe_path(workspace, proof.path) for proof in active_template.proofs.values()
     }
+    for relative, digest in plan.trusted_test_digests:
+        trusted_path = _safe_path(workspace, relative)
+        observed = "sha256:" + hashlib.sha256(trusted_path.read_bytes()).hexdigest()
+        if observed != digest:
+            raise ContractInvalidError("trusted test support does not match its compiled digest")
+        protected_tests.add(trusted_path)
     for criterion in plan.criteria:
         if criterion.human_test is None:
             continue

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -7,6 +7,7 @@ import json
 import operator as comparison
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -219,10 +220,30 @@ def _run_pytest_node(workspace: Path, test: TemplateTest) -> bool:
         config.write("[pytest]\n")
     config_path = Path(config_name)
     try:
+        if len(test.command) >= 3 and test.command[1:3] == ("-m", "pytest"):
+            trusted_runner = (
+                "import sys,pytest;"
+                "sys.path.insert(0,sys.argv[1]);"
+                "raise SystemExit(pytest.main(sys.argv[2:]))"
+            )
+            pytest_command = (
+                test.command[0],
+                "-I",
+                "-B",
+                "-c",
+                trusted_runner,
+                str(workspace),
+                *test.command[3:],
+            )
+        else:
+            executable = shutil.which(test.command[0])
+            if executable is None:
+                raise ContractInvalidError("bound pytest executable is unavailable")
+            pytest_command = (executable, *test.command[1:])
         try:
             completed = subprocess.run(
                 [
-                    *test.command,
+                    *pytest_command,
                     "--noconftest",
                     "-c",
                     str(config_path),

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -91,6 +91,8 @@ _SAFE_RELATIVE = re.compile(r"[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\Z")
 _MODULE_TARGET = re.compile(r"([A-Za-z_][A-Za-z0-9_.]*):([A-Za-z_][A-Za-z0-9_]*)\Z")
 _CREDENTIAL = re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|AKIA[0-9A-Z]{16}")
 _HIGH_RISK_CODE = re.compile(r"\b(?:eval|exec)\s*\(")
+_ACTION_TIMEOUT_SECONDS = 10.0
+_PYTEST_TIMEOUT_SECONDS = 30.0
 
 
 def default_template() -> Template:
@@ -151,8 +153,8 @@ def _assertion_passes(assertion: PropertyAssertion, value: Any) -> bool:
     except KeyError:
         actual = None
     binary: dict[Operator, Callable[[Any, Any], bool]] = {
-        Operator.EQ: comparison.eq,
-        Operator.NE: comparison.ne,
+        Operator.EQ: lambda left, right: canonical_digest(left) == canonical_digest(right),
+        Operator.NE: lambda left, right: canonical_digest(left) != canonical_digest(right),
         Operator.LT: comparison.lt,
         Operator.LTE: comparison.le,
         Operator.GT: comparison.gt,
@@ -188,15 +190,18 @@ def _run_action(workspace: Path, target: str, arguments: Mapping[str, Any]) -> A
         f"v=getattr(m,{function!r})(**json.loads(sys.argv[2]));"
         "print(json.dumps(v,sort_keys=True,separators=(',',':')))"
     )
-    completed = subprocess.run(
-        [sys.executable, "-I", "-B", "-c", runner, str(module_path), json.dumps(arguments)],
-        cwd=workspace,
-        text=True,
-        capture_output=True,
-        timeout=10,
-        check=False,
-        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
-    )
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-I", "-B", "-c", runner, str(module_path), json.dumps(arguments)],
+            cwd=workspace,
+            text=True,
+            capture_output=True,
+            timeout=_ACTION_TIMEOUT_SECONDS,
+            check=False,
+            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ContractInvalidError("action timed out before an assertion") from exc
     if completed.returncode != 0:
         raise ContractInvalidError("action failed before an assertion: " + completed.stderr.strip())
     try:
@@ -209,23 +214,39 @@ def _run_pytest_node(workspace: Path, test: TemplateTest) -> bool:
     descriptor, report_name = tempfile.mkstemp(suffix=".xml")
     os.close(descriptor)
     report = Path(report_name)
+    config_descriptor, config_name = tempfile.mkstemp(suffix=".ini")
+    with os.fdopen(config_descriptor, "w") as config:
+        config.write("[pytest]\n")
+    config_path = Path(config_name)
     try:
-        completed = subprocess.run(
-            [
-                *test.command,
-                f"--junitxml={report}",
-                "-o",
-                "junit_family=xunit2",
-                "-p",
-                "no:cacheprovider",
-            ],
-            cwd=workspace,
-            text=True,
-            capture_output=True,
-            timeout=30,
-            check=False,
-            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
-        )
+        try:
+            completed = subprocess.run(
+                [
+                    *test.command,
+                    "--noconftest",
+                    "-c",
+                    str(config_path),
+                    f"--junitxml={report}",
+                    "-o",
+                    "junit_family=xunit2",
+                    "-p",
+                    "no:cacheprovider",
+                ],
+                cwd=workspace,
+                text=True,
+                capture_output=True,
+                timeout=_PYTEST_TIMEOUT_SECONDS,
+                check=False,
+                env={
+                    **os.environ,
+                    "PYTHONDONTWRITEBYTECODE": "1",
+                    "PYTEST_ADDOPTS": "",
+                    "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+                    "PYTEST_PLUGINS": "",
+                },
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ContractInvalidError("bound human test timed out") from exc
         try:
             root = ET.parse(report).getroot()
         except (ET.ParseError, OSError) as exc:
@@ -244,6 +265,7 @@ def _run_pytest_node(workspace: Path, test: TemplateTest) -> bool:
         raise ContractInvalidError("human test failed outside its bound assertion")
     finally:
         report.unlink(missing_ok=True)
+        config_path.unlink(missing_ok=True)
 
 
 def _criterion_findings(
@@ -352,14 +374,22 @@ def _security_findings(workspace: Path) -> tuple[Finding, ...]:
     return tuple(findings)
 
 
-def _candidate_manifest(workspace: Path, ledger: EvidenceLedger) -> tuple[str, tuple[str, ...]]:
+def _workspace_snapshot(workspace: Path) -> dict[str, bytes]:
+    return {
+        str(path.relative_to(workspace)): path.read_bytes()
+        for path in sorted(workspace.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _candidate_manifest(
+    snapshot: Mapping[str, bytes], ledger: EvidenceLedger
+) -> tuple[str, tuple[str, ...]]:
     manifest: dict[str, str] = {}
     blobs: list[str] = []
-    for path in sorted(workspace.rglob("*")):
-        if not path.is_file():
-            continue
-        digest = ledger.put_blob(path.read_bytes())
-        manifest[str(path.relative_to(workspace))] = digest
+    for relative, payload in sorted(snapshot.items()):
+        digest = ledger.put_blob(payload)
+        manifest[relative] = digest
         blobs.append(digest)
     manifest_blob = ledger.put_blob(
         json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
@@ -608,6 +638,7 @@ def run_to_release_ready(
             )
             return finish(RunState.HALTED, cause, attempt)
 
+        verification_snapshot = _workspace_snapshot(workspace)
         security = _security_findings(workspace)
         blocking_security = tuple(
             item for item in security if item.code.startswith(("CRITICAL_", "HIGH_"))
@@ -642,7 +673,10 @@ def run_to_release_ready(
                     sorted(
                         {
                             target.split(":", maxsplit=1)[0].replace(".", "/") + ".py"
-                            for target in active_template.actions.values()
+                            for target in (
+                                *active_template.actions.values(),
+                                *active_template.measures.values(),
+                            )
                         }
                     )
                 )
@@ -654,6 +688,29 @@ def run_to_release_ready(
                         implicated_files,
                     ),
                 )
+            observed_snapshot = _workspace_snapshot(workspace)
+            if observed_snapshot != verification_snapshot:
+                changed_during_verification = tuple(
+                    sorted(
+                        {
+                            *verification_snapshot.keys(),
+                            *observed_snapshot.keys(),
+                        }
+                        - {
+                            path
+                            for path in set(verification_snapshot).intersection(observed_snapshot)
+                            if verification_snapshot[path] == observed_snapshot[path]
+                        }
+                    )
+                )
+                findings = (
+                    Finding(
+                        "CANDIDATE_MUTATED_DURING_VERIFICATION",
+                        "candidate",
+                        "candidate changed while its exact snapshot was being verified",
+                        changed_during_verification,
+                    ),
+                )
             if not findings:
                 evidence = {
                     "assertions": "passed",
@@ -662,7 +719,9 @@ def run_to_release_ready(
                     "attempt": attempt,
                 }
                 blob = ledger.put_blob(json.dumps(evidence, sort_keys=True).encode())
-                candidate_blob, candidate_file_blobs = _candidate_manifest(workspace, ledger)
+                candidate_blob, candidate_file_blobs = _candidate_manifest(
+                    verification_snapshot, ledger
+                )
                 review_body = {
                     "contract_digest": subject_digest,
                     "plan_digest": plan.plan_digest,

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -5,18 +5,17 @@ from __future__ import annotations
 import hashlib
 import json
 import operator as comparison
-import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
 import time
-import xml.etree.ElementTree as ET
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import Any, NoReturn, Protocol
 
 from pmpe.contracts.acceptance import (
     AcceptanceBuildPlan,
@@ -93,6 +92,150 @@ _CREDENTIAL = re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|AKI
 _HIGH_RISK_CODE = re.compile(r"\b(?:eval|exec)\s*\(")
 _ACTION_TIMEOUT_SECONDS = 10.0
 _PYTEST_TIMEOUT_SECONDS = 30.0
+_SANDBOX_PATH = "/usr/local/bin:/usr/bin:/bin"
+_PYTEST_RESULT_PREFIX = "__PMPE_PYTEST_RESULT__:"
+
+
+class CandidateSandbox(Protocol):
+    """Trusted OS boundary used for every execution of generated code."""
+
+    def run(
+        self,
+        workspace: Path,
+        argv: Sequence[str],
+        *,
+        timeout_seconds: float,
+        environment: Mapping[str, str],
+    ) -> subprocess.CompletedProcess[str]: ...
+
+
+class BubblewrapCandidateSandbox:
+    """Run generated code with no network, host environment, or host filesystem view."""
+
+    def __init__(self, executable: str = "bwrap", limiter: str = "prlimit") -> None:
+        self.executable = executable
+        self.limiter = limiter
+
+    @staticmethod
+    def _runtime_roots() -> tuple[Path, ...]:
+        executable_root = Path(sys.executable).resolve().parent.parent
+        candidates = {
+            Path("/usr"),
+            Path("/bin"),
+            Path("/sbin"),
+            Path("/lib"),
+            Path("/lib64"),
+            Path(sys.base_prefix).resolve(),
+            Path(sys.prefix).resolve(),
+            executable_root,
+        }
+        return tuple(sorted((item for item in candidates if item.exists()), key=str))
+
+    @staticmethod
+    def _parent_directories(path: Path) -> tuple[str, ...]:
+        parents: list[str] = []
+        current = path.parent
+        while current != Path("/"):
+            parents.append(str(current))
+            current = current.parent
+        return tuple(reversed(parents))
+
+    def run(
+        self,
+        workspace: Path,
+        argv: Sequence[str],
+        *,
+        timeout_seconds: float,
+        environment: Mapping[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        sandbox = shutil.which(self.executable, path=_SANDBOX_PATH)
+        limiter = shutil.which(self.limiter, path=_SANDBOX_PATH)
+        if sandbox is None or limiter is None:
+            raise ContractInvalidError("candidate OS sandbox is unavailable")
+        sandbox_argv = [
+            sandbox,
+            "--die-with-parent",
+            "--new-session",
+            "--unshare-all",
+            "--clearenv",
+            "--tmpfs",
+            "/",
+            "--dir",
+            "/workspace",
+            "--dir",
+            "/etc",
+        ]
+        created_directories: set[str] = {"/etc", "/workspace"}
+        bound_roots: list[Path] = []
+        for runtime_root in self._runtime_roots():
+            if any(runtime_root.is_relative_to(bound) for bound in bound_roots):
+                continue
+            for parent in self._parent_directories(runtime_root):
+                if any(Path(parent).is_relative_to(bound) for bound in bound_roots):
+                    continue
+                if parent not in created_directories:
+                    sandbox_argv.extend(("--dir", parent))
+                    created_directories.add(parent)
+            sandbox_argv.extend(("--ro-bind", str(runtime_root), str(runtime_root)))
+            bound_roots.append(runtime_root)
+        for host_path in (
+            "/etc/alternatives",
+            "/etc/group",
+            "/etc/ld.so.cache",
+            "/etc/ld.so.conf",
+            "/etc/ld.so.conf.d",
+            "/etc/localtime",
+            "/etc/nsswitch.conf",
+            "/etc/passwd",
+        ):
+            sandbox_argv.extend(("--ro-bind-try", host_path, host_path))
+        sandbox_argv.extend(
+            (
+                "--ro-bind",
+                str(workspace.resolve()),
+                "/workspace",
+                "--dev",
+                "/dev",
+                "--remount-ro",
+                "/dev",
+                "--proc",
+                "/proc",
+                "--size",
+                str(64 * 1024 * 1024),
+                "--tmpfs",
+                "/tmp",
+                "--dir",
+                "/tmp/home",
+            )
+        )
+        for name, value in sorted(environment.items()):
+            sandbox_argv.extend(("--setenv", name, value))
+        sandbox_argv.extend(("--chdir", "/workspace", "--", *argv))
+        command = [
+            limiter,
+            f"--as={1024 * 1024 * 1024}",
+            f"--cpu={int(timeout_seconds) + 1}",
+            f"--fsize={64 * 1024 * 1024}",
+            "--nofile=256",
+            "--nproc=128",
+            "--",
+            *sandbox_argv,
+        ]
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=workspace,
+                text=True,
+                capture_output=True,
+                timeout=timeout_seconds,
+                check=False,
+                env={"LC_ALL": "C", "PATH": _SANDBOX_PATH},
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ContractInvalidError("candidate execution timed out") from exc
+        if completed.returncode != 0 and completed.stderr.lstrip().startswith("bwrap:"):
+            raise ContractInvalidError("candidate OS sandbox could not establish isolation")
+        return completed
 
 
 def _reject_non_json_constant(token: str) -> NoReturn:
@@ -204,7 +347,12 @@ def _assertion_passes(assertion: PropertyAssertion, value: Any) -> bool:
     return unary[assertion.operator]
 
 
-def _run_action(workspace: Path, target: str, arguments: Mapping[str, Any]) -> Any:
+def _run_action(
+    workspace: Path,
+    target: str,
+    arguments: Mapping[str, Any],
+    sandbox: CandidateSandbox,
+) -> Any:
     match = _MODULE_TARGET.fullmatch(target)
     if match is None:
         raise ContractInvalidError(f"invalid template action target: {target}")
@@ -214,33 +362,34 @@ def _run_action(workspace: Path, target: str, arguments: Mapping[str, Any]) -> A
         raise ContractInvalidError(f"template action module is missing: {module}")
     runner = (
         "import importlib,json,sys;"
-        "sys.path.insert(0,sys.argv[1]);"
+        "sys.path.insert(0,'/workspace');"
         "m=importlib.import_module(sys.argv[2]);"
         "v=getattr(m,sys.argv[3])(**json.loads(sys.argv[4]));"
         "print(json.dumps(v,sort_keys=True,separators=(',',':')))"
     )
-    try:
-        completed = subprocess.run(
-            [
-                sys.executable,
-                "-I",
-                "-B",
-                "-c",
-                runner,
-                str(workspace),
-                module,
-                function,
-                json.dumps(arguments),
-            ],
-            cwd=workspace,
-            text=True,
-            capture_output=True,
-            timeout=_ACTION_TIMEOUT_SECONDS,
-            check=False,
-            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise ContractInvalidError("action timed out before an assertion") from exc
+    completed = sandbox.run(
+        workspace,
+        [
+            sys.executable,
+            "-I",
+            "-B",
+            "-c",
+            runner,
+            "unused-workspace-argument",
+            module,
+            function,
+            json.dumps(arguments),
+        ],
+        timeout_seconds=_ACTION_TIMEOUT_SECONDS,
+        environment={
+            "HOME": "/tmp/home",
+            "LC_ALL": "C",
+            "PATH": _SANDBOX_PATH,
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONNOUSERSITE": "1",
+            "TMPDIR": "/tmp",
+        },
+    )
     if completed.returncode != 0:
         raise ContractInvalidError("action failed before an assertion: " + completed.stderr.strip())
     try:
@@ -254,124 +403,120 @@ def _run_action(workspace: Path, target: str, arguments: Mapping[str, Any]) -> A
         raise ContractInvalidError("action did not return one JSON value") from exc
 
 
-def _run_pytest_node(workspace: Path, test: TemplateTest, protected_paths: frozenset[str]) -> bool:
-    descriptor, report_name = tempfile.mkstemp(suffix=".xml")
-    os.close(descriptor)
-    report = Path(report_name)
-    config_descriptor, config_name = tempfile.mkstemp(suffix=".ini")
-    with os.fdopen(config_descriptor, "w") as config:
-        config.write("[pytest]\n")
-    config_path = Path(config_name)
+def _run_pytest_node(
+    workspace: Path,
+    test: TemplateTest,
+    protected_paths: frozenset[str],
+    sandbox: CandidateSandbox,
+) -> bool:
+    pytest_arguments = (
+        test.command[3:]
+        if len(test.command) >= 3 and test.command[1:3] == ("-m", "pytest")
+        else test.command[1:]
+    )
+    trusted_runner = (
+        "import json, os, sys, pytest\n"
+        "root = '/workspace'\n"
+        "protected = {os.path.realpath(os.path.join(root, p)) "
+        "for p in json.loads(sys.argv[1])}\n"
+        "writes = []\n"
+        "write_flags = os.O_WRONLY | os.O_RDWR | os.O_CREAT | os.O_TRUNC | os.O_APPEND\n"
+        "def resolve(path):\n"
+        " try:\n"
+        "  value = os.fspath(path)\n"
+        "  return os.path.realpath(value) if isinstance(value, str) else ''\n"
+        " except (OSError, TypeError, ValueError):\n"
+        "  return ''\n"
+        "def audit(event,args):\n"
+        " path = resolve(args[0]) if args else ''\n"
+        " targets = {path}\n"
+        " if event in {'os.rename', 'os.replace'} and len(args) > 1:\n"
+        "  targets.add(resolve(args[1]))\n"
+        " def touches(target):\n"
+        "  return any(item == target or item.startswith(target + os.sep) for item in protected)\n"
+        " if event == 'open':\n"
+        "  if path not in protected:\n"
+        "   return\n"
+        "  mode = args[1] or ''\n"
+        "  flags = args[2] or 0\n"
+        "  if any(character in mode for character in 'wax+') or flags & write_flags:\n"
+        "   writes.append((event, path, str(mode), flags))\n"
+        "  return\n"
+        " if not any(touches(target) for target in targets if target):\n"
+        "  return\n"
+        " if event.startswith('os.') and event not in "
+        "{'os.chdir', 'os.listdir', 'os.scandir', 'os.stat'}:\n"
+        "  writes.append((event, path))\n"
+        "sys.addaudithook(audit)\n"
+        "class Recorder:\n"
+        " def __init__(self): self.reports = {}\n"
+        " def pytest_runtest_logreport(self, report):\n"
+        "  if report.when == 'call' or report.outcome != 'passed':\n"
+        "   self.reports[report.nodeid] = {'outcome': report.outcome, 'when': report.when}\n"
+        "recorder = Recorder()\n"
+        "sys.path.insert(0, root)\n"
+        "code = pytest.main(sys.argv[2:], plugins=[recorder])\n"
+        f"print({_PYTEST_RESULT_PREFIX!r} + json.dumps("
+        "{'code': int(code), 'reports': recorder.reports, 'writes': writes}, sort_keys=True))\n"
+        "raise SystemExit(5 if writes else code)\n"
+    )
+    pytest_command = (
+        sys.executable,
+        "-I",
+        "-B",
+        "-c",
+        trusted_runner,
+        json.dumps(sorted(protected_paths)),
+        *pytest_arguments,
+        "--noconftest",
+        "--rootdir=/workspace",
+        "-c",
+        "/dev/null",
+        "-p",
+        "no:cacheprovider",
+    )
+    completed = sandbox.run(
+        workspace,
+        pytest_command,
+        timeout_seconds=_PYTEST_TIMEOUT_SECONDS,
+        environment={
+            "HOME": "/tmp/home",
+            "LC_ALL": "C",
+            "PATH": _SANDBOX_PATH,
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONNOUSERSITE": "1",
+            "PYTEST_ADDOPTS": "",
+            "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+            "PYTEST_PLUGINS": "",
+            "TMPDIR": "/tmp",
+        },
+    )
+    result_lines = [
+        line.removeprefix(_PYTEST_RESULT_PREFIX)
+        for line in completed.stdout.splitlines()
+        if line.startswith(_PYTEST_RESULT_PREFIX)
+    ]
+    if len(result_lines) != 1:
+        detail = completed.stderr.strip()
+        raise ContractInvalidError(
+            "human test produced no structured pytest result" + (f": {detail}" if detail else "")
+        )
     try:
-        pytest_arguments = (
-            test.command[3:]
-            if len(test.command) >= 3 and test.command[1:3] == ("-m", "pytest")
-            else test.command[1:]
-        )
-        trusted_runner = (
-            "import json, os, sys, pytest\n"
-            "root = os.path.realpath(sys.argv[1])\n"
-            "protected = {os.path.realpath(os.path.join(root, p)) "
-            "for p in json.loads(sys.argv[2])}\n"
-            "writes = []\n"
-            "write_flags = os.O_WRONLY | os.O_RDWR | os.O_CREAT | os.O_TRUNC | os.O_APPEND\n"
-            "def resolve(path):\n"
-            " try:\n"
-            "  return os.path.realpath(os.fspath(path))\n"
-            " except (OSError, TypeError, ValueError):\n"
-            "  return ''\n"
-            "def audit(event,args):\n"
-            " path = resolve(args[0]) if args else ''\n"
-            " targets = {path}\n"
-            " if event in {'os.rename', 'os.replace'} and len(args) > 1:\n"
-            "  targets.add(resolve(args[1]))\n"
-            " if not protected.intersection(targets):\n"
-            "  return\n"
-            " if event == 'open':\n"
-            "  mode = args[1] or ''\n"
-            "  flags = args[2] or 0\n"
-            "  if any(character in mode for character in 'wax+') or flags & write_flags:\n"
-            "   writes.append((event, path))\n"
-            " elif event.startswith('os.') and event not in {'os.stat', 'os.listdir'}:\n"
-            "  writes.append((event, path))\n"
-            "sys.addaudithook(audit)\n"
-            "sys.path.insert(0, root)\n"
-            "code = pytest.main(sys.argv[3:])\n"
-            "raise SystemExit(5 if writes else code)\n"
-        )
-        pytest_command = (
-            sys.executable,
-            "-I",
-            "-B",
-            "-c",
-            trusted_runner,
-            str(workspace),
-            json.dumps(sorted(protected_paths)),
-            *pytest_arguments,
-        )
-        try:
-            completed = subprocess.run(
-                [
-                    *pytest_command,
-                    "--noconftest",
-                    "-c",
-                    str(config_path),
-                    f"--junitxml={report}",
-                    "-o",
-                    "junit_family=xunit2",
-                    "-p",
-                    "no:cacheprovider",
-                ],
-                cwd=workspace,
-                text=True,
-                capture_output=True,
-                timeout=_PYTEST_TIMEOUT_SECONDS,
-                check=False,
-                env={
-                    **os.environ,
-                    "PYTHONDONTWRITEBYTECODE": "1",
-                    "PYTEST_ADDOPTS": "",
-                    "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
-                    "PYTEST_PLUGINS": "",
-                },
-            )
-        except subprocess.TimeoutExpired as exc:
-            raise ContractInvalidError("bound human test timed out") from exc
-        try:
-            root = ET.parse(report).getroot()
-        except (ET.ParseError, OSError) as exc:
-            detail = completed.stderr.strip()
-            raise ContractInvalidError(
-                "human test produced no structured pytest result"
-                + (f": {detail}" if detail else "")
-            ) from exc
-        node_parts = test.node_id.split("::")
-        expected_name = node_parts[-1]
-        expected_classes = node_parts[:-1]
-        cases = [
-            item
-            for item in root.iter("testcase")
-            if item.get("name") == expected_name
-            and (
-                not expected_classes
-                or (item.get("classname") or "").split(".")[-len(expected_classes) :]
-                == expected_classes
-            )
-        ]
-        if len(cases) != 1:
-            raise ContractInvalidError("bound human test node did not execute exactly once")
-        case = cases[0]
-        if case.find("skipped") is not None or case.find("error") is not None:
-            raise ContractInvalidError("bound human test was skipped or errored")
-        failure = case.find("failure")
-        if failure is not None and completed.returncode == 1:
-            return False
-        if failure is None and completed.returncode == 0:
-            return True
-        raise ContractInvalidError("human test failed outside its bound assertion")
-    finally:
-        report.unlink(missing_ok=True)
-        config_path.unlink(missing_ok=True)
+        structured = json.loads(result_lines[0], parse_constant=_reject_non_json_constant)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ContractInvalidError("human test produced malformed structured evidence") from exc
+    expected_node = f"{test.path}::{test.node_id}"
+    report = structured.get("reports", {}).get(expected_node)
+    if not isinstance(report, Mapping):
+        raise ContractInvalidError("bound human test node did not execute exactly once")
+    if report.get("outcome") == "failed" and completed.returncode == 1:
+        return False
+    if report.get("outcome") == "passed" and completed.returncode == 0:
+        return True
+    raise ContractInvalidError(
+        "bound human test was skipped, errored, or mutated evidence: "
+        + json.dumps(structured.get("writes", []), sort_keys=True)
+    )
 
 
 def _criterion_findings(
@@ -379,6 +524,7 @@ def _criterion_findings(
     *,
     workspace: Path,
     template: Template,
+    sandbox: CandidateSandbox,
 ) -> tuple[Finding, ...]:
     protected_paths = frozenset(
         {
@@ -393,7 +539,7 @@ def _criterion_findings(
         digest = "sha256:" + hashlib.sha256(proof_path.read_bytes()).hexdigest()
         if digest != criterion.template_proof.file_digest:
             raise ContractInvalidError("template proof file does not match its compiled digest")
-        if not _run_pytest_node(workspace, proof, protected_paths):
+        if not _run_pytest_node(workspace, proof, protected_paths, sandbox):
             return (
                 Finding(
                     "ASSERTION_FAILED",
@@ -410,7 +556,7 @@ def _criterion_findings(
             criterion.human_test.node_id,
             criterion.human_test.command,
         )
-        if _run_pytest_node(workspace, human_test, protected_paths):
+        if _run_pytest_node(workspace, human_test, protected_paths, sandbox):
             return ()
         return (
             Finding(
@@ -424,7 +570,7 @@ def _criterion_findings(
         assert criterion.operator is not None
         assert criterion.minimum_sample is not None
         target = template.measures[criterion.measure]
-        observation = _run_action(workspace, target, {})
+        observation = _run_action(workspace, target, {}, sandbox)
         if not isinstance(observation, Mapping):
             raise ContractInvalidError("measure did not return a JSON object")
         sample_size = observation.get("sample_size")
@@ -446,7 +592,7 @@ def _criterion_findings(
     if any(not _assertion_passes(item, template.context) for item in criterion.given):
         raise ContractInvalidError(f"{criterion.criterion_id}: Given precondition is false")
     target = template.actions[criterion.when.action]
-    result = _run_action(workspace, target, criterion.when.arguments)
+    result = _run_action(workspace, target, criterion.when.arguments, sandbox)
     wrapped = {"result": result}
     if all(_assertion_passes(item, wrapped) for item in criterion.then):
         return ()
@@ -472,6 +618,7 @@ def _verify_snapshot(
     plan: AcceptanceBuildPlan,
     snapshot: Mapping[str, bytes],
     template: Template,
+    sandbox: CandidateSandbox,
 ) -> tuple[Finding, ...]:
     """Verify each criterion against a fresh disposable copy of the exact snapshot."""
 
@@ -482,7 +629,12 @@ def _verify_snapshot(
             _materialize_snapshot(isolated, snapshot)
             try:
                 findings.extend(
-                    _criterion_findings(criterion, workspace=isolated, template=template)
+                    _criterion_findings(
+                        criterion,
+                        workspace=isolated,
+                        template=template,
+                        sandbox=sandbox,
+                    )
                 )
             except ContractInvalidError as exc:
                 if criterion.human_test is None:
@@ -618,13 +770,14 @@ def run_to_release_ready(
     template: Template | None = None,
     budget: BudgetCaps | None = None,
     stop_requested: Callable[[], bool] = lambda: False,
+    candidate_sandbox: CandidateSandbox | None = None,
 ) -> RunResult:
     """Run the frozen core. It never deploys and stops at RELEASE_READY."""
 
     started = time.monotonic()
     active_template = template or default_template()
     active_budget = budget or BudgetCaps()
-    ledger = EvidenceLedger(repository_root, run_id)
+    active_sandbox = candidate_sandbox or BubblewrapCandidateSandbox()
     counters = {"calls": 0, "bytes": 0}
     subject_digest = canonical_digest(contract)
 
@@ -643,6 +796,17 @@ def run_to_release_ready(
         if relative.startswith("tests/")
     }
 
+    plan = compile_acceptance_plan(
+        contract,
+        repository_root=repository_root,
+        registered_actions=frozenset(active_template.actions),
+        template_version=active_template.version,
+        template_test_digests=template_test_digests,
+        registered_measures=frozenset(active_template.measures),
+        trusted_test_digests=trusted_test_digests,
+    )
+    ledger = EvidenceLedger(repository_root, run_id)
+
     def finish(
         state: RunState, cause: str, attempts: int, annotation: Mapping[str, Any] | None = None
     ) -> RunResult:
@@ -657,15 +821,6 @@ def run_to_release_ready(
             dict(annotation or {}),
         )
 
-    plan = compile_acceptance_plan(
-        contract,
-        repository_root=repository_root,
-        registered_actions=frozenset(active_template.actions),
-        template_version=active_template.version,
-        template_test_digests=template_test_digests,
-        registered_measures=frozenset(active_template.measures),
-        trusted_test_digests=trusted_test_digests,
-    )
     plan_blob = ledger.put_blob(
         json.dumps(plan.as_dict(), sort_keys=True, separators=(",", ":")).encode()
     )
@@ -717,6 +872,7 @@ def run_to_release_ready(
         plan,
         _workspace_snapshot(workspace),
         active_template,
+        active_sandbox,
     )
     non_template = tuple(item for item in plan.criteria if item.form != "satisfied_by_template")
     failed_ids = {item.subject_id for item in baseline}
@@ -868,7 +1024,12 @@ def run_to_release_ready(
                 payload={"attempt": attempt, "changed": list(changed)},
             )
             try:
-                findings = _verify_snapshot(plan, verification_snapshot, active_template)
+                findings = _verify_snapshot(
+                    plan,
+                    verification_snapshot,
+                    active_template,
+                    active_sandbox,
+                )
             except ContractInvalidError as exc:
                 implicated_files = tuple(
                     sorted(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -92,6 +92,7 @@ _CREDENTIAL = re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|AKI
 _HIGH_RISK_CODE = re.compile(r"\b(?:eval|exec)\s*\(")
 _ACTION_TIMEOUT_SECONDS = 10.0
 _PYTEST_TIMEOUT_SECONDS = 30.0
+_CANDIDATE_OUTPUT_LIMIT_BYTES = 1_000_000
 _SANDBOX_PATH = "/usr/local/bin:/usr/bin:/bin"
 _PYTEST_RESULT_PREFIX = "__PMPE_PYTEST_RESULT__:"
 
@@ -215,27 +216,43 @@ class BubblewrapCandidateSandbox:
             limiter,
             f"--as={1024 * 1024 * 1024}",
             f"--cpu={int(timeout_seconds) + 1}",
-            f"--fsize={64 * 1024 * 1024}",
+            f"--fsize={_CANDIDATE_OUTPUT_LIMIT_BYTES + 1}",
             "--nofile=256",
             "--nproc=128",
             "--",
             *sandbox_argv,
         ]
-        try:
-            completed = subprocess.run(
-                command,
-                cwd=workspace,
-                text=True,
-                capture_output=True,
-                timeout=timeout_seconds,
-                check=False,
-                env={"LC_ALL": "C", "PATH": _SANDBOX_PATH},
-            )
-        except subprocess.TimeoutExpired as exc:
-            raise ContractInvalidError("candidate execution timed out") from exc
-        if completed.returncode != 0 and completed.stderr.lstrip().startswith("bwrap:"):
+        with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+            try:
+                completed = subprocess.run(
+                    command,
+                    cwd=workspace,
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                    timeout=timeout_seconds,
+                    check=False,
+                    env={"LC_ALL": "C", "PATH": _SANDBOX_PATH},
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise ContractInvalidError("candidate execution timed out") from exc
+            stdout_file.seek(0)
+            stderr_file.seek(0)
+            stdout = stdout_file.read(_CANDIDATE_OUTPUT_LIMIT_BYTES + 1)
+            stderr = stderr_file.read(_CANDIDATE_OUTPUT_LIMIT_BYTES + 1)
+        if (
+            len(stdout) > _CANDIDATE_OUTPUT_LIMIT_BYTES
+            or len(stderr) > _CANDIDATE_OUTPUT_LIMIT_BYTES
+        ):
+            raise ContractInvalidError("candidate output exceeded limit")
+        decoded = subprocess.CompletedProcess[str](
+            completed.args,
+            completed.returncode,
+            stdout.decode("utf-8", errors="replace"),
+            stderr.decode("utf-8", errors="replace"),
+        )
+        if decoded.returncode != 0 and decoded.stderr.lstrip().startswith("bwrap:"):
             raise ContractInvalidError("candidate OS sandbox could not establish isolation")
-        return completed
+        return decoded
 
 
 def _reject_non_json_constant(token: str) -> NoReturn:
@@ -805,6 +822,9 @@ def run_to_release_ready(
         registered_measures=frozenset(active_template.measures),
         trusted_test_digests=trusted_test_digests,
     )
+    if workspace.exists() and (not workspace.is_dir() or any(workspace.iterdir())):
+        raise ContractInvalidError("candidate workspace must be empty")
+    workspace.mkdir(parents=True, exist_ok=True)
     ledger = EvidenceLedger(repository_root, run_id)
 
     def finish(
@@ -838,9 +858,6 @@ def run_to_release_ready(
         ledger.append(event_type="stopped", state=RunState.STOPPED, subject_digest=subject_digest)
         return finish(RunState.STOPPED, "STOP_REQUESTED", 0)
 
-    workspace.mkdir(parents=True, exist_ok=True)
-    if any(workspace.iterdir()):
-        raise ValueError("candidate workspace must be empty")
     _write_files(workspace, active_template.files)
     protected_tests = {
         _safe_path(workspace, proof.path) for proof in active_template.proofs.values()

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -211,16 +211,28 @@ def _run_action(workspace: Path, target: str, arguments: Mapping[str, Any]) -> A
         raise ContractInvalidError(f"invalid template action target: {target}")
     module, function = match.groups()
     module_path = workspace / (module.replace(".", "/") + ".py")
+    if not module_path.is_file():
+        raise ContractInvalidError(f"template action module is missing: {module}")
     runner = (
-        "import importlib.util,json,sys;"
-        "s=importlib.util.spec_from_file_location('candidate',sys.argv[1]);"
-        "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"
-        f"v=getattr(m,{function!r})(**json.loads(sys.argv[2]));"
+        "import importlib,json,sys;"
+        "sys.path.insert(0,sys.argv[1]);"
+        "m=importlib.import_module(sys.argv[2]);"
+        "v=getattr(m,sys.argv[3])(**json.loads(sys.argv[4]));"
         "print(json.dumps(v,sort_keys=True,separators=(',',':')))"
     )
     try:
         completed = subprocess.run(
-            [sys.executable, "-I", "-B", "-c", runner, str(module_path), json.dumps(arguments)],
+            [
+                sys.executable,
+                "-I",
+                "-B",
+                "-c",
+                runner,
+                str(workspace),
+                module,
+                function,
+                json.dumps(arguments),
+            ],
             cwd=workspace,
             text=True,
             capture_output=True,

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -7,7 +7,6 @@ import json
 import operator as comparison
 import os
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -255,7 +254,7 @@ def _run_action(workspace: Path, target: str, arguments: Mapping[str, Any]) -> A
         raise ContractInvalidError("action did not return one JSON value") from exc
 
 
-def _run_pytest_node(workspace: Path, test: TemplateTest) -> bool:
+def _run_pytest_node(workspace: Path, test: TemplateTest, protected_paths: frozenset[str]) -> bool:
     descriptor, report_name = tempfile.mkstemp(suffix=".xml")
     os.close(descriptor)
     report = Path(report_name)
@@ -264,26 +263,52 @@ def _run_pytest_node(workspace: Path, test: TemplateTest) -> bool:
         config.write("[pytest]\n")
     config_path = Path(config_name)
     try:
-        if len(test.command) >= 3 and test.command[1:3] == ("-m", "pytest"):
-            trusted_runner = (
-                "import sys,pytest;"
-                "sys.path.insert(0,sys.argv[1]);"
-                "raise SystemExit(pytest.main(sys.argv[2:]))"
-            )
-            pytest_command = (
-                test.command[0],
-                "-I",
-                "-B",
-                "-c",
-                trusted_runner,
-                str(workspace),
-                *test.command[3:],
-            )
-        else:
-            executable = shutil.which(test.command[0])
-            if executable is None:
-                raise ContractInvalidError("bound pytest executable is unavailable")
-            pytest_command = (executable, *test.command[1:])
+        pytest_arguments = (
+            test.command[3:]
+            if len(test.command) >= 3 and test.command[1:3] == ("-m", "pytest")
+            else test.command[1:]
+        )
+        trusted_runner = (
+            "import json, os, sys, pytest\n"
+            "root = os.path.realpath(sys.argv[1])\n"
+            "protected = {os.path.realpath(os.path.join(root, p)) "
+            "for p in json.loads(sys.argv[2])}\n"
+            "writes = []\n"
+            "write_flags = os.O_WRONLY | os.O_RDWR | os.O_CREAT | os.O_TRUNC | os.O_APPEND\n"
+            "def resolve(path):\n"
+            " try:\n"
+            "  return os.path.realpath(os.fspath(path))\n"
+            " except (OSError, TypeError, ValueError):\n"
+            "  return ''\n"
+            "def audit(event,args):\n"
+            " path = resolve(args[0]) if args else ''\n"
+            " targets = {path}\n"
+            " if event in {'os.rename', 'os.replace'} and len(args) > 1:\n"
+            "  targets.add(resolve(args[1]))\n"
+            " if not protected.intersection(targets):\n"
+            "  return\n"
+            " if event == 'open':\n"
+            "  mode = args[1] or ''\n"
+            "  flags = args[2] or 0\n"
+            "  if any(character in mode for character in 'wax+') or flags & write_flags:\n"
+            "   writes.append((event, path))\n"
+            " elif event.startswith('os.') and event not in {'os.stat', 'os.listdir'}:\n"
+            "  writes.append((event, path))\n"
+            "sys.addaudithook(audit)\n"
+            "sys.path.insert(0, root)\n"
+            "code = pytest.main(sys.argv[3:])\n"
+            "raise SystemExit(5 if writes else code)\n"
+        )
+        pytest_command = (
+            sys.executable,
+            "-I",
+            "-B",
+            "-c",
+            trusted_runner,
+            str(workspace),
+            json.dumps(sorted(protected_paths)),
+            *pytest_arguments,
+        )
         try:
             completed = subprocess.run(
                 [
@@ -315,7 +340,11 @@ def _run_pytest_node(workspace: Path, test: TemplateTest) -> bool:
         try:
             root = ET.parse(report).getroot()
         except (ET.ParseError, OSError) as exc:
-            raise ContractInvalidError("human test produced no structured pytest result") from exc
+            detail = completed.stderr.strip()
+            raise ContractInvalidError(
+                "human test produced no structured pytest result"
+                + (f": {detail}" if detail else "")
+            ) from exc
         node_parts = test.node_id.split("::")
         expected_name = node_parts[-1]
         expected_classes = node_parts[:-1]
@@ -351,6 +380,12 @@ def _criterion_findings(
     workspace: Path,
     template: Template,
 ) -> tuple[Finding, ...]:
+    protected_paths = frozenset(
+        {
+            *(relative for relative in template.files if relative.startswith("tests/")),
+            *((criterion.human_test.path,) if criterion.human_test is not None else ()),
+        }
+    )
     if criterion.form == "satisfied_by_template":
         assert criterion.template_proof is not None
         proof = template.proofs[criterion.template_proof.test_id]
@@ -358,7 +393,7 @@ def _criterion_findings(
         digest = "sha256:" + hashlib.sha256(proof_path.read_bytes()).hexdigest()
         if digest != criterion.template_proof.file_digest:
             raise ContractInvalidError("template proof file does not match its compiled digest")
-        if not _run_pytest_node(workspace, proof):
+        if not _run_pytest_node(workspace, proof, protected_paths):
             return (
                 Finding(
                     "ASSERTION_FAILED",
@@ -375,7 +410,7 @@ def _criterion_findings(
             criterion.human_test.node_id,
             criterion.human_test.command,
         )
-        if _run_pytest_node(workspace, human_test):
+        if _run_pytest_node(workspace, human_test, protected_paths):
             return ()
         return (
             Finding(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -152,14 +152,25 @@ def _assertion_passes(assertion: PropertyAssertion, value: Any) -> bool:
     try:
         actual = _path(value, assertion.path)
     except KeyError:
-        actual = None
+        return False
+
+    def ordered(left: Any, right: Any, operation: Callable[[Any, Any], bool]) -> bool:
+        if isinstance(left, bool) or isinstance(right, bool):
+            return False
+        numeric = (int, float)
+        if isinstance(left, numeric) and isinstance(right, numeric):
+            return operation(left, right)
+        if isinstance(left, str) and isinstance(right, str):
+            return operation(left, right)
+        return False
+
     binary: dict[Operator, Callable[[Any, Any], bool]] = {
         Operator.EQ: lambda left, right: canonical_digest(left) == canonical_digest(right),
         Operator.NE: lambda left, right: canonical_digest(left) != canonical_digest(right),
-        Operator.LT: comparison.lt,
-        Operator.LTE: comparison.le,
-        Operator.GT: comparison.gt,
-        Operator.GTE: comparison.ge,
+        Operator.LT: lambda left, right: ordered(left, right, comparison.lt),
+        Operator.LTE: lambda left, right: ordered(left, right, comparison.le),
+        Operator.GT: lambda left, right: ordered(left, right, comparison.gt),
+        Operator.GTE: lambda left, right: ordered(left, right, comparison.ge),
         Operator.CONTAINS: lambda left, right: right in left,
         Operator.NOT_CONTAINS: lambda left, right: right not in left,
         Operator.MATCHES: lambda left, right: bool(re.search(str(right), str(left))),
@@ -370,10 +381,49 @@ def _criterion_findings(
     )
 
 
-def _verify(plan: AcceptanceBuildPlan, workspace: Path, template: Template) -> tuple[Finding, ...]:
+def _materialize_snapshot(workspace: Path, snapshot: Mapping[str, bytes]) -> None:
+    for relative, payload in sorted(snapshot.items()):
+        target = _safe_path(workspace, relative)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+
+
+def _verify_snapshot(
+    plan: AcceptanceBuildPlan,
+    snapshot: Mapping[str, bytes],
+    template: Template,
+) -> tuple[Finding, ...]:
+    """Verify each criterion against a fresh disposable copy of the exact snapshot."""
+
     findings: list[Finding] = []
     for criterion in plan.criteria:
-        findings.extend(_criterion_findings(criterion, workspace=workspace, template=template))
+        with tempfile.TemporaryDirectory(prefix="pmpe-verification-") as temporary:
+            isolated = Path(temporary)
+            _materialize_snapshot(isolated, snapshot)
+            findings.extend(_criterion_findings(criterion, workspace=isolated, template=template))
+            observed = _workspace_snapshot(isolated)
+            if observed != snapshot:
+                changed = tuple(
+                    sorted(
+                        {
+                            *snapshot.keys(),
+                            *observed.keys(),
+                        }
+                        - {
+                            path
+                            for path in set(snapshot).intersection(observed)
+                            if snapshot[path] == observed[path]
+                        }
+                    )
+                )
+                findings.append(
+                    Finding(
+                        "CANDIDATE_MUTATED_DURING_VERIFICATION",
+                        criterion.criterion_id,
+                        "candidate changed its isolated verification snapshot",
+                        changed,
+                    )
+                )
     return tuple(findings)
 
 
@@ -547,7 +597,11 @@ def run_to_release_ready(
             raise ContractInvalidError("human test changed after compilation")
         _write_files(workspace, {relative: source.read_text()})
         protected_tests.add(_safe_path(workspace, relative))
-    baseline = _verify(plan, workspace, active_template)
+    baseline = _verify_snapshot(
+        plan,
+        _workspace_snapshot(workspace),
+        active_template,
+    )
     non_template = tuple(item for item in plan.criteria if item.form != "satisfied_by_template")
     failed_ids = {item.subject_id for item in baseline}
     if not non_template or failed_ids != {item.criterion_id for item in non_template}:
@@ -688,7 +742,7 @@ def run_to_release_ready(
                 payload={"attempt": attempt, "changed": list(changed)},
             )
             try:
-                findings = _verify(plan, workspace, active_template)
+                findings = _verify_snapshot(plan, verification_snapshot, active_template)
             except ContractInvalidError as exc:
                 implicated_files = tuple(
                     sorted(
@@ -707,29 +761,6 @@ def run_to_release_ready(
                         "candidate",
                         str(exc),
                         implicated_files,
-                    ),
-                )
-            observed_snapshot = _workspace_snapshot(workspace)
-            if observed_snapshot != verification_snapshot:
-                changed_during_verification = tuple(
-                    sorted(
-                        {
-                            *verification_snapshot.keys(),
-                            *observed_snapshot.keys(),
-                        }
-                        - {
-                            path
-                            for path in set(verification_snapshot).intersection(observed_snapshot)
-                            if verification_snapshot[path] == observed_snapshot[path]
-                        }
-                    )
-                )
-                findings = (
-                    Finding(
-                        "CANDIDATE_MUTATED_DURING_VERIFICATION",
-                        "candidate",
-                        "candidate changed while its exact snapshot was being verified",
-                        changed_during_verification,
                     ),
                 )
             if not findings:

--- a/src/pmpe/cli/__init__.py
+++ b/src/pmpe/cli/__init__.py
@@ -11,6 +11,7 @@ import argparse
 import sys
 
 from pmpe.cli import (
+    barebones_cmd,
     contracts_cmd,
     core,
     demo_cmd,
@@ -33,6 +34,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sub = parser.add_subparsers(dest="command", required=True)
     core.register(sub)
+    barebones_cmd.register(sub)
     contracts_cmd.register(sub)
     demo_cmd.register(sub)
     eng_cmd.register(sub)

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import selectors
 import shlex
+import signal
 import subprocess
+import tempfile
+import time
 from collections.abc import Mapping
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +20,72 @@ from pmpe.barebones import ContractInvalidError, run_to_release_ready
 from pmpe.contracts.acceptance import AcceptanceCompileError
 from pmpe.contracts.canonical import CanonicalInputError, strict_loads
 from pmpe.evidence.ledger import EvidenceIntegrityError
+
+_PROVIDER_OUTPUT_LIMIT_BYTES = 1_000_000
+
+
+def _terminate_provider(process: subprocess.Popen[bytes]) -> None:
+    with suppress(ProcessLookupError):
+        os.killpg(process.pid, signal.SIGKILL)
+    process.wait()
+
+
+def _run_provider_command(
+    argv: tuple[str, ...],
+    payload: bytes,
+    timeout_seconds: int,
+    output_limit_bytes: int = _PROVIDER_OUTPUT_LIMIT_BYTES,
+) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryFile() as stdin_file:
+        stdin_file.write(payload)
+        stdin_file.seek(0)
+        process = subprocess.Popen(
+            argv,
+            stdin=stdin_file,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        if process.stdout is None or process.stderr is None:
+            _terminate_provider(process)
+            raise RuntimeError("MODEL_PROVIDER_IO_UNAVAILABLE")
+        streams = {"stdout": bytearray(), "stderr": bytearray()}
+        selector = selectors.DefaultSelector()
+        selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+        selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+        deadline = time.monotonic() + timeout_seconds
+        try:
+            while selector.get_map():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise RuntimeError("MODEL_PROVIDER_TIMEOUT")
+                for key, _ in selector.select(min(remaining, 0.1)):
+                    chunk = os.read(key.fd, 64 * 1024)
+                    if not chunk:
+                        selector.unregister(key.fileobj)
+                        continue
+                    output = streams[key.data]
+                    output.extend(chunk)
+                    if len(output) > output_limit_bytes:
+                        raise RuntimeError("MODEL_PROVIDER_OUTPUT_LIMIT")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError("MODEL_PROVIDER_TIMEOUT")
+            returncode = process.wait(timeout=remaining)
+        except subprocess.TimeoutExpired as exc:
+            _terminate_provider(process)
+            raise RuntimeError("MODEL_PROVIDER_TIMEOUT") from exc
+        except RuntimeError:
+            _terminate_provider(process)
+            raise
+        finally:
+            selector.close()
+        return subprocess.CompletedProcess(
+            argv,
+            returncode,
+            streams["stdout"].decode("utf-8", errors="replace"),
+            streams["stderr"].decode("utf-8", errors="replace"),
+        )
 
 
 class CommandModelProvider:
@@ -26,17 +98,11 @@ class CommandModelProvider:
         self.timeout_seconds = timeout_seconds
 
     def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
-        try:
-            completed = subprocess.run(
-                self.argv,
-                input=json.dumps({"purpose": purpose, "request": request}),
-                text=True,
-                capture_output=True,
-                timeout=self.timeout_seconds,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
-            raise RuntimeError("MODEL_PROVIDER_TIMEOUT") from exc
+        completed = _run_provider_command(
+            self.argv,
+            json.dumps({"purpose": purpose, "request": request}).encode(),
+            self.timeout_seconds,
+        )
         if completed.returncode != 0:
             raise RuntimeError("model provider failed: " + completed.stderr.strip())
         try:

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -13,6 +13,7 @@ from typing import Any
 from pmpe.barebones import ContractInvalidError, run_to_release_ready
 from pmpe.contracts.acceptance import AcceptanceCompileError
 from pmpe.contracts.canonical import CanonicalInputError, strict_loads
+from pmpe.evidence.ledger import EvidenceIntegrityError
 
 
 class CommandModelProvider:
@@ -87,6 +88,9 @@ def _run(args: argparse.Namespace) -> int:
         return 3
     except ContractInvalidError as exc:
         print(json.dumps({"state": "HALTED", "cause": "CONTRACT_INVALID", "detail": str(exc)}))
+        return 3
+    except EvidenceIntegrityError as exc:
+        print(json.dumps({"state": "HALTED", "cause": "EVIDENCE_INVALID", "detail": str(exc)}))
         return 3
     print(
         json.dumps(

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pmpe.barebones import ContractInvalidError, run_to_release_ready
 from pmpe.contracts.acceptance import AcceptanceCompileError
-from pmpe.contracts.canonical import strict_loads
+from pmpe.contracts.canonical import CanonicalInputError, strict_loads
 
 
 class CommandModelProvider:
@@ -49,13 +49,13 @@ class CommandModelProvider:
 
 def _run(args: argparse.Namespace) -> int:
     contract_path = Path(args.contract)
-    content_type = (
-        "application/yaml"
-        if contract_path.suffix.lower() in {".yaml", ".yml"}
-        else "application/json"
-    )
-    contract = strict_loads(contract_path.read_bytes(), content_type)
     try:
+        content_type = (
+            "application/yaml"
+            if contract_path.suffix.lower() in {".yaml", ".yml"}
+            else "application/json"
+        )
+        contract = strict_loads(contract_path.read_bytes(), content_type)
         result = run_to_release_ready(
             contract=contract,
             repository_root=Path(args.repository_root).resolve(),
@@ -63,6 +63,18 @@ def _run(args: argparse.Namespace) -> int:
             run_id=args.run_id,
             provider=CommandModelProvider(args.provider_command, args.provider_timeout),
         )
+    except CanonicalInputError as exc:
+        print(
+            json.dumps(
+                {
+                    "state": "HALTED",
+                    "cause": "CONTRACT_INVALID",
+                    "diagnostics": [{"code": exc.code, "message": str(exc)}],
+                },
+                sort_keys=True,
+            )
+        )
+        return 3
     except AcceptanceCompileError as exc:
         print(
             json.dumps(

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -1,0 +1,111 @@
+"""CLI entry point for the frozen bare-bones core."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from pmpe.barebones import ContractInvalidError, run_to_release_ready
+from pmpe.contracts.acceptance import AcceptanceCompileError
+from pmpe.contracts.canonical import strict_loads
+
+
+class CommandModelProvider:
+    """ModelProvider that exchanges one JSON object with a local command."""
+
+    def __init__(self, command: str, timeout_seconds: int) -> None:
+        self.argv = tuple(shlex.split(command))
+        if not self.argv:
+            raise ValueError("provider command cannot be empty")
+        self.timeout_seconds = timeout_seconds
+
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        completed = subprocess.run(
+            self.argv,
+            input=json.dumps({"purpose": purpose, "request": request}),
+            text=True,
+            capture_output=True,
+            timeout=self.timeout_seconds,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError("model provider failed: " + completed.stderr.strip())
+        try:
+            response = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("model provider returned malformed JSON") from exc
+        if not isinstance(response, dict):
+            raise RuntimeError("model provider response must be an object")
+        return response
+
+
+def _run(args: argparse.Namespace) -> int:
+    contract_path = Path(args.contract)
+    content_type = (
+        "application/yaml"
+        if contract_path.suffix.lower() in {".yaml", ".yml"}
+        else "application/json"
+    )
+    contract = strict_loads(contract_path.read_bytes(), content_type)
+    try:
+        result = run_to_release_ready(
+            contract=contract,
+            repository_root=Path(args.repository_root).resolve(),
+            workspace=Path(args.workspace).resolve(),
+            run_id=args.run_id,
+            provider=CommandModelProvider(args.provider_command, args.provider_timeout),
+        )
+    except AcceptanceCompileError as exc:
+        print(
+            json.dumps(
+                {
+                    "state": "HALTED",
+                    "cause": "CONTRACT_INVALID",
+                    "diagnostics": [item.__dict__ for item in exc.diagnostics],
+                },
+                sort_keys=True,
+            )
+        )
+        return 3
+    except ContractInvalidError as exc:
+        print(json.dumps({"state": "HALTED", "cause": "CONTRACT_INVALID", "detail": str(exc)}))
+        return 3
+    print(
+        json.dumps(
+            {
+                "run_id": result.run_id,
+                "state": result.state,
+                "cause": result.cause,
+                "attempts": result.attempts,
+                "model_calls": result.model_calls,
+                "elapsed_ms": result.elapsed_ms,
+                "evidence": str(result.evidence_path),
+                "annotation": result.annotation,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0 if result.state == "RELEASE_READY" else 3
+
+
+def register(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    parser = sub.add_parser(
+        "barebones",
+        help="compile a PMOS contract and stop at RELEASE_READY",
+    )
+    parser.add_argument("contract")
+    parser.add_argument("--workspace", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--repository-root", default=".")
+    parser.add_argument(
+        "--provider-command",
+        required=True,
+        help="local ModelProvider command; receives and returns JSON over stdio",
+    )
+    parser.add_argument("--provider-timeout", type=int, default=120)
+    parser.set_defaults(fn=_run)

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -39,11 +39,9 @@ class CommandModelProvider:
         if completed.returncode != 0:
             raise RuntimeError("model provider failed: " + completed.stderr.strip())
         try:
-            response = json.loads(completed.stdout)
-        except json.JSONDecodeError as exc:
+            response = strict_loads(completed.stdout.encode(), "application/json")
+        except CanonicalInputError as exc:
             raise RuntimeError("model provider returned malformed JSON") from exc
-        if not isinstance(response, dict):
-            raise RuntimeError("model provider response must be an object")
         return response
 
 

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -35,7 +35,7 @@ def _run_provider_command(
     payload: bytes,
     timeout_seconds: int,
     output_limit_bytes: int = _PROVIDER_OUTPUT_LIMIT_BYTES,
-) -> subprocess.CompletedProcess[str]:
+) -> subprocess.CompletedProcess[bytes]:
     with tempfile.TemporaryFile() as stdin_file:
         stdin_file.write(payload)
         stdin_file.seek(0)
@@ -83,8 +83,8 @@ def _run_provider_command(
         return subprocess.CompletedProcess(
             argv,
             returncode,
-            streams["stdout"].decode("utf-8", errors="replace"),
-            streams["stderr"].decode("utf-8", errors="replace"),
+            bytes(streams["stdout"]),
+            bytes(streams["stderr"]),
         )
 
 
@@ -104,9 +104,10 @@ class CommandModelProvider:
             self.timeout_seconds,
         )
         if completed.returncode != 0:
-            raise RuntimeError("model provider failed: " + completed.stderr.strip())
+            detail = completed.stderr.decode("utf-8", errors="replace").strip()
+            raise RuntimeError("model provider failed: " + detail)
         try:
-            response = strict_loads(completed.stdout.encode(), "application/json")
+            response = strict_loads(completed.stdout, "application/json")
         except CanonicalInputError as exc:
             raise RuntimeError("model provider returned malformed JSON") from exc
         return response

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -25,14 +25,17 @@ class CommandModelProvider:
         self.timeout_seconds = timeout_seconds
 
     def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
-        completed = subprocess.run(
-            self.argv,
-            input=json.dumps({"purpose": purpose, "request": request}),
-            text=True,
-            capture_output=True,
-            timeout=self.timeout_seconds,
-            check=False,
-        )
+        try:
+            completed = subprocess.run(
+                self.argv,
+                input=json.dumps({"purpose": purpose, "request": request}),
+                text=True,
+                capture_output=True,
+                timeout=self.timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError("MODEL_PROVIDER_TIMEOUT") from exc
         if completed.returncode != 0:
             raise RuntimeError("model provider failed: " + completed.stderr.strip())
         try:

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -100,6 +100,7 @@ class AcceptanceBuildPlan:
     requirements: tuple[str, ...]
     tasks: tuple[BuildTask, ...]
     criteria: tuple[CompiledCriterion, ...]
+    trusted_test_digests: tuple[tuple[str, str], ...]
     plan_digest: str
 
     def as_dict(self) -> dict[str, Any]:
@@ -342,6 +343,7 @@ def compile_acceptance_plan(
     template_version: str,
     template_test_digests: Mapping[str, str],
     registered_measures: frozenset[str] = frozenset(),
+    trusted_test_digests: Mapping[str, str] | None = None,
 ) -> AcceptanceBuildPlan:
     """Compile typed criteria and prove task/test coverage before any build."""
 
@@ -469,6 +471,33 @@ def compile_acceptance_plan(
                     )
                 )
                 continue
+            assertion_value = item.get("value")
+            if operator is Operator.MATCHES:
+                try:
+                    if not isinstance(assertion_value, str):
+                        raise re.error("pattern must be a string")
+                    re.compile(assertion_value)
+                except re.error:
+                    diagnostics.append(
+                        AcceptanceDiagnostic(
+                            "INVALID_REGEX_ASSERTION",
+                            cid,
+                            "measure requires a valid string regex",
+                        )
+                    )
+                    continue
+            if operator in {Operator.LT, Operator.LTE, Operator.GT, Operator.GTE} and (
+                isinstance(assertion_value, bool)
+                or not isinstance(assertion_value, (int, float, str))
+            ):
+                diagnostics.append(
+                    AcceptanceDiagnostic(
+                        "INVALID_ORDERED_ASSERTION_VALUE",
+                        cid,
+                        "measure requires a number or string value",
+                    )
+                )
+                continue
             compiled.append(
                 CompiledCriterion(
                     cid,
@@ -476,7 +505,7 @@ def compile_acceptance_plan(
                     form,
                     measure=measure,
                     operator=operator,
-                    value=item.get("value"),
+                    value=assertion_value,
                     minimum_sample=minimum,
                 )
             )
@@ -531,16 +560,19 @@ def compile_acceptance_plan(
     tasks = tuple(
         BuildTask(f"TASK-{index:03d}", item) for index, item in enumerate(requirements, 1)
     )
+    trusted_digests = trusted_test_digests or {}
     shell = {
         "contract_digest": canonical_digest(contract),
         "requirements": requirements,
         "tasks": [asdict(item) for item in tasks],
         "criteria": [asdict(item) for item in compiled],
+        "trusted_test_digests": sorted(trusted_digests.items()),
     }
     return AcceptanceBuildPlan(
         contract_digest=str(shell["contract_digest"]),
         requirements=requirements,
         tasks=tasks,
         criteria=tuple(compiled),
+        trusted_test_digests=tuple(sorted(trusted_digests.items())),
         plan_digest=canonical_digest(shell),
     )

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -199,9 +199,8 @@ def _assertions(
             )
             return tuple(compiled)
     for ancestor in compiled:
-        if "mapping" in _assertion_domains(ancestor):
-            continue
-        if any(item.path.startswith(ancestor.path + ".") for item in compiled):
+        descendants = tuple(item for item in compiled if item.path.startswith(ancestor.path + "."))
+        if any(_ancestor_contradicts_descendant(ancestor, item) for item in descendants):
             diagnostics.append(
                 AcceptanceDiagnostic(
                     "CONTRADICTORY_ASSERTIONS",
@@ -330,6 +329,29 @@ def _assertion_domains(assertion: PropertyAssertion) -> frozenset[str]:
         Operator.IS_NULL: frozenset({"null"}),
         Operator.NOT_NULL: _JSON_DOMAINS - {"null"},
     }[assertion.operator]
+
+
+def _ancestor_contradicts_descendant(
+    ancestor: PropertyAssertion, descendant: PropertyAssertion
+) -> bool:
+    if "mapping" not in _assertion_domains(ancestor):
+        return True
+    suffix = descendant.path.removeprefix(ancestor.path + ".")
+    first = suffix.split(".", maxsplit=1)[0]
+    if (
+        ancestor.operator is Operator.NOT_CONTAINS
+        and isinstance(ancestor.value, str)
+        and ancestor.value == first
+    ):
+        return True
+    if ancestor.operator is not Operator.EQ or not isinstance(ancestor.value, Mapping):
+        return False
+    current: Any = ancestor.value
+    for part in suffix.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return True
+        current = current[part]
+    return not _literal_satisfies(descendant, current)
 
 
 def _contradictory(left: PropertyAssertion, right: PropertyAssertion) -> bool:

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -198,6 +198,18 @@ def _assertions(
                 )
             )
             return tuple(compiled)
+    for ancestor in compiled:
+        if "mapping" in _assertion_domains(ancestor):
+            continue
+        if any(item.path.startswith(ancestor.path + ".") for item in compiled):
+            diagnostics.append(
+                AcceptanceDiagnostic(
+                    "CONTRADICTORY_ASSERTIONS",
+                    criterion_id,
+                    f"{field} constrains {ancestor.path} to a non-object with descendants",
+                )
+            )
+            return tuple(compiled)
     return tuple(compiled)
 
 
@@ -280,16 +292,48 @@ def _assertion_set_contradictory(assertions: tuple[PropertyAssertion, ...]) -> b
     )
 
 
+_JSON_DOMAINS = frozenset({"null", "boolean", "number", "string", "list", "mapping"})
+
+
+def _value_domain(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "list"
+    return "mapping" if isinstance(value, Mapping) else "other"
+
+
+def _assertion_domains(assertion: PropertyAssertion) -> frozenset[str]:
+    if assertion.operator is Operator.EQ:
+        return frozenset({_value_domain(assertion.value)})
+    if assertion.operator is Operator.NE:
+        return _JSON_DOMAINS
+    if assertion.operator in {Operator.LT, Operator.LTE, Operator.GT, Operator.GTE}:
+        return frozenset({_value_domain(assertion.value)})
+    if assertion.operator is Operator.MATCHES:
+        return frozenset({"string"})
+    if assertion.operator in {Operator.CONTAINS, Operator.NOT_CONTAINS}:
+        return (
+            frozenset({"string", "list", "mapping"})
+            if isinstance(assertion.value, str)
+            else frozenset({"list"})
+        )
+    return {
+        Operator.IS_TRUE: frozenset({"boolean"}),
+        Operator.IS_FALSE: frozenset({"boolean"}),
+        Operator.IS_NULL: frozenset({"null"}),
+        Operator.NOT_NULL: _JSON_DOMAINS - {"null"},
+    }[assertion.operator]
+
+
 def _contradictory(left: PropertyAssertion, right: PropertyAssertion) -> bool:
-    containment = {Operator.CONTAINS, Operator.NOT_CONTAINS}
-    if (
-        left.operator is Operator.MATCHES
-        and right.operator in containment
-        and not isinstance(right.value, str)
-        or right.operator is Operator.MATCHES
-        and left.operator in containment
-        and not isinstance(left.value, str)
-    ):
+    if not _assertion_domains(left).intersection(_assertion_domains(right)):
         return True
     if left.operator is Operator.EQ and right.operator is Operator.EQ:
         return canonical_digest(left.value) != canonical_digest(right.value)

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -281,6 +281,16 @@ def _assertion_set_contradictory(assertions: tuple[PropertyAssertion, ...]) -> b
 
 
 def _contradictory(left: PropertyAssertion, right: PropertyAssertion) -> bool:
+    containment = {Operator.CONTAINS, Operator.NOT_CONTAINS}
+    if (
+        left.operator is Operator.MATCHES
+        and right.operator in containment
+        and not isinstance(right.value, str)
+        or right.operator is Operator.MATCHES
+        and left.operator in containment
+        and not isinstance(left.value, str)
+    ):
+        return True
     if left.operator is Operator.EQ and right.operator is Operator.EQ:
         return canonical_digest(left.value) != canonical_digest(right.value)
     if {left.operator, right.operator} == {Operator.EQ, Operator.NE}:

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -166,6 +166,17 @@ def _assertions(
 
 
 def _ordered_comparison(left: Any, operator: Operator, right: Any) -> bool | None:
+    if isinstance(left, bool) or isinstance(right, bool):
+        return None
+    numeric = (int, float)
+    compatible = (
+        isinstance(left, numeric)
+        and isinstance(right, numeric)
+        or isinstance(left, str)
+        and isinstance(right, str)
+    )
+    if not compatible:
+        return None
     operations = {
         Operator.LT: lambda: left < right,
         Operator.LTE: lambda: left <= right,
@@ -208,10 +219,10 @@ def _contradictory(left: PropertyAssertion, right: PropertyAssertion) -> bool:
     ordered = {Operator.LT, Operator.LTE, Operator.GT, Operator.GTE}
     if left.operator is Operator.EQ and right.operator in ordered:
         result = _ordered_comparison(left.value, right.operator, right.value)
-        return result is False
+        return result is not True
     if right.operator is Operator.EQ and left.operator in ordered:
         result = _ordered_comparison(right.value, left.operator, left.value)
-        return result is False
+        return result is not True
     lower = left if left.operator in {Operator.GT, Operator.GTE} else right
     upper = right if right.operator in {Operator.LT, Operator.LTE} else left
     if lower.operator not in {Operator.GT, Operator.GTE} or upper.operator not in {
@@ -219,14 +230,12 @@ def _contradictory(left: PropertyAssertion, right: PropertyAssertion) -> bool:
         Operator.LTE,
     }:
         return False
-    try:
-        if lower.value > upper.value:
-            return True
-        return lower.value == upper.value and (
-            lower.operator is Operator.GT or upper.operator is Operator.LT
-        )
-    except TypeError:
-        return False
+    greater = _ordered_comparison(lower.value, Operator.GT, upper.value)
+    if greater is None or greater:
+        return True
+    return lower.value == upper.value and (
+        lower.operator is Operator.GT or upper.operator is Operator.LT
+    )
 
 
 def _human_test(

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -319,6 +319,12 @@ def _contradictory(left: PropertyAssertion, right: PropertyAssertion) -> bool:
             return not unary_matches
         return unary_assertion.operator is not Operator.NOT_NULL and unary_matches
     ordered = {Operator.LT, Operator.LTE, Operator.GT, Operator.GTE}
+    if (
+        left.operator in ordered
+        and right.operator in ordered
+        and _ordered_comparison(left.value, Operator.GT, right.value) is None
+    ):
+        return True
     if left.operator is Operator.EQ and right.operator in ordered:
         result = _ordered_comparison(left.value, right.operator, right.value)
         return result is not True

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -188,19 +188,16 @@ def _assertions(
             )
             continue
         compiled.append(PropertyAssertion(str(item["path"]), operator, assertion_value))
-    for index, left in enumerate(compiled):
-        for right in compiled[index + 1 :]:
-            if left.path != right.path:
-                continue
-            if _contradictory(left, right):
-                diagnostics.append(
-                    AcceptanceDiagnostic(
-                        "CONTRADICTORY_ASSERTIONS",
-                        criterion_id,
-                        f"{field} contains incompatible assertions for {left.path}",
-                    )
+    for path in sorted({item.path for item in compiled}):
+        if _assertion_set_contradictory(tuple(item for item in compiled if item.path == path)):
+            diagnostics.append(
+                AcceptanceDiagnostic(
+                    "CONTRADICTORY_ASSERTIONS",
+                    criterion_id,
+                    f"{field} contains incompatible assertions for {path}",
                 )
-                return tuple(compiled)
+            )
+            return tuple(compiled)
     return tuple(compiled)
 
 
@@ -228,6 +225,61 @@ def _ordered_comparison(left: Any, operator: Operator, right: Any) -> bool | Non
         return None
 
 
+def _literal_satisfies(assertion: PropertyAssertion, value: Any) -> bool:
+    if assertion.operator is Operator.EQ:
+        return canonical_digest(value) == canonical_digest(assertion.value)
+    if assertion.operator is Operator.NE:
+        return canonical_digest(value) != canonical_digest(assertion.value)
+    if assertion.operator in {Operator.LT, Operator.LTE, Operator.GT, Operator.GTE}:
+        return _ordered_comparison(value, assertion.operator, assertion.value) is True
+    if assertion.operator is Operator.MATCHES:
+        return isinstance(value, str) and bool(re.search(assertion.value, value))
+    if assertion.operator in {Operator.CONTAINS, Operator.NOT_CONTAINS}:
+        if isinstance(value, list):
+            present = any(
+                canonical_digest(item) == canonical_digest(assertion.value) for item in value
+            )
+        elif isinstance(assertion.value, str) and isinstance(value, (str, Mapping)):
+            present = assertion.value in value
+        else:
+            return False
+        return present if assertion.operator is Operator.CONTAINS else not present
+    unary = {
+        Operator.IS_TRUE: value is True,
+        Operator.IS_FALSE: value is False,
+        Operator.IS_NULL: value is None,
+        Operator.NOT_NULL: value is not None,
+    }
+    return unary[assertion.operator]
+
+
+def _assertion_set_contradictory(assertions: tuple[PropertyAssertion, ...]) -> bool:
+    for index, left in enumerate(assertions):
+        if any(_contradictory(left, right) for right in assertions[index + 1 :]):
+            return True
+
+    exact_values = [item.value for item in assertions if item.operator is Operator.EQ]
+    exact_values.extend(
+        {
+            Operator.IS_TRUE: True,
+            Operator.IS_FALSE: False,
+            Operator.IS_NULL: None,
+        }[item.operator]
+        for item in assertions
+        if item.operator in {Operator.IS_TRUE, Operator.IS_FALSE, Operator.IS_NULL}
+    )
+    lower = [item for item in assertions if item.operator is Operator.GTE]
+    upper = [item for item in assertions if item.operator is Operator.LTE]
+    for floor in lower:
+        for ceiling in upper:
+            if canonical_digest(floor.value) == canonical_digest(ceiling.value):
+                exact_values.append(floor.value)
+    return any(
+        any(not _literal_satisfies(assertion, value) for assertion in assertions)
+        for value in exact_values
+    )
+
+
 def _contradictory(left: PropertyAssertion, right: PropertyAssertion) -> bool:
     if left.operator is Operator.EQ and right.operator is Operator.EQ:
         return canonical_digest(left.value) != canonical_digest(right.value)
@@ -243,6 +295,15 @@ def _contradictory(left: PropertyAssertion, right: PropertyAssertion) -> bool:
     }
     if (left.operator, right.operator) in opposite_unary:
         return True
+    exact_unary = {
+        Operator.IS_TRUE: True,
+        Operator.IS_FALSE: False,
+        Operator.IS_NULL: None,
+    }
+    if left.operator in exact_unary:
+        return not _literal_satisfies(right, exact_unary[left.operator])
+    if right.operator in exact_unary:
+        return not _literal_satisfies(left, exact_unary[right.operator])
     equality = {Operator.EQ, Operator.NE}
     unary = {Operator.IS_TRUE, Operator.IS_FALSE, Operator.IS_NULL, Operator.NOT_NULL}
     equality_assertion = left if left.operator in equality else right

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
 from enum import StrEnum
@@ -148,7 +149,44 @@ def _assertions(
                 )
             )
             continue
-        compiled.append(PropertyAssertion(str(item["path"]), operator, item.get("value")))
+        unary = {Operator.IS_TRUE, Operator.IS_FALSE, Operator.IS_NULL, Operator.NOT_NULL}
+        if operator not in unary and "value" not in item:
+            diagnostics.append(
+                AcceptanceDiagnostic(
+                    "MISSING_ASSERTION_VALUE",
+                    criterion_id,
+                    f"{field}[{index}] requires an explicit value",
+                )
+            )
+            continue
+        assertion_value = item.get("value")
+        if operator is Operator.MATCHES:
+            try:
+                if not isinstance(assertion_value, str):
+                    raise re.error("pattern must be a string")
+                re.compile(assertion_value)
+            except re.error:
+                diagnostics.append(
+                    AcceptanceDiagnostic(
+                        "INVALID_REGEX_ASSERTION",
+                        criterion_id,
+                        f"{field}[{index}] requires a valid string regex",
+                    )
+                )
+                continue
+        ordered = {Operator.LT, Operator.LTE, Operator.GT, Operator.GTE}
+        if operator in ordered and (
+            isinstance(assertion_value, bool) or not isinstance(assertion_value, (int, float, str))
+        ):
+            diagnostics.append(
+                AcceptanceDiagnostic(
+                    "INVALID_ORDERED_ASSERTION_VALUE",
+                    criterion_id,
+                    f"{field}[{index}] requires a number or string value",
+                )
+            )
+            continue
+        compiled.append(PropertyAssertion(str(item["path"]), operator, assertion_value))
     for index, left in enumerate(compiled):
         for right in compiled[index + 1 :]:
             if left.path != right.path:

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -1,0 +1,446 @@
+"""Deterministic acceptance-criteria compilation for the bare-bones core."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from pmpe.contracts.canonical import canonical_digest
+
+
+class AcceptanceCompileError(ValueError):
+    """The product contract cannot be compiled without guessing."""
+
+    def __init__(self, diagnostics: Sequence[AcceptanceDiagnostic]) -> None:
+        self.diagnostics = tuple(diagnostics)
+        super().__init__("; ".join(f"{item.code}:{item.subject_id}" for item in diagnostics))
+
+
+class Operator(StrEnum):
+    EQ = "eq"
+    NE = "ne"
+    LT = "lt"
+    LTE = "lte"
+    GT = "gt"
+    GTE = "gte"
+    CONTAINS = "contains"
+    NOT_CONTAINS = "not_contains"
+    MATCHES = "matches"
+    IS_TRUE = "is_true"
+    IS_FALSE = "is_false"
+    IS_NULL = "is_null"
+    NOT_NULL = "not_null"
+
+
+@dataclass(frozen=True)
+class AcceptanceDiagnostic:
+    code: str
+    subject_id: str
+    message: str
+
+
+@dataclass(frozen=True)
+class PropertyAssertion:
+    path: str
+    operator: Operator
+    value: Any = None
+
+
+@dataclass(frozen=True)
+class ActionCall:
+    action: str
+    arguments: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class HumanTest:
+    path: str
+    node_id: str
+    command: tuple[str, ...]
+    file_digest: str
+
+
+@dataclass(frozen=True)
+class TemplateProof:
+    template_version: str
+    test_id: str
+
+
+@dataclass(frozen=True)
+class CompiledCriterion:
+    criterion_id: str
+    requirement_refs: tuple[str, ...]
+    form: str
+    given: tuple[PropertyAssertion, ...] = ()
+    when: ActionCall | None = None
+    then: tuple[PropertyAssertion, ...] = ()
+    measure: str = ""
+    operator: Operator | None = None
+    value: Any = None
+    minimum_sample: int | None = None
+    human_test: HumanTest | None = None
+    template_proof: TemplateProof | None = None
+
+
+@dataclass(frozen=True)
+class BuildTask:
+    task_id: str
+    requirement_id: str
+
+
+@dataclass(frozen=True)
+class AcceptanceBuildPlan:
+    contract_digest: str
+    requirements: tuple[str, ...]
+    tasks: tuple[BuildTask, ...]
+    criteria: tuple[CompiledCriterion, ...]
+    plan_digest: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _mapping(value: Any) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _assertions(
+    value: Any,
+    *,
+    criterion_id: str,
+    field: str,
+    diagnostics: list[AcceptanceDiagnostic],
+) -> tuple[PropertyAssertion, ...]:
+    if not isinstance(value, list) or not value:
+        diagnostics.append(
+            AcceptanceDiagnostic(
+                "INVALID_ASSERTION_LIST",
+                criterion_id,
+                f"{field} must be a non-empty assertion list",
+            )
+        )
+        return ()
+    compiled: list[PropertyAssertion] = []
+    for index, raw in enumerate(value):
+        item = _mapping(raw)
+        if item is None or not isinstance(item.get("path"), str) or not item["path"]:
+            diagnostics.append(
+                AcceptanceDiagnostic(
+                    "INVALID_ASSERTION_PATH",
+                    criterion_id,
+                    f"{field}[{index}] requires a path",
+                )
+            )
+            continue
+        try:
+            operator = Operator(str(item.get("operator", "")))
+        except ValueError:
+            diagnostics.append(
+                AcceptanceDiagnostic(
+                    "UNKNOWN_ASSERTION_OPERATOR",
+                    criterion_id,
+                    f"{field}[{index}] uses an unregistered operator",
+                )
+            )
+            continue
+        compiled.append(PropertyAssertion(str(item["path"]), operator, item.get("value")))
+    for index, left in enumerate(compiled):
+        for right in compiled[index + 1 :]:
+            if left.path != right.path:
+                continue
+            opposite_unary = {
+                (Operator.IS_TRUE, Operator.IS_FALSE),
+                (Operator.IS_FALSE, Operator.IS_TRUE),
+                (Operator.IS_NULL, Operator.NOT_NULL),
+                (Operator.NOT_NULL, Operator.IS_NULL),
+            }
+            contradictory = (
+                (
+                    left.operator is Operator.EQ
+                    and right.operator is Operator.EQ
+                    and canonical_digest(left.value) != canonical_digest(right.value)
+                )
+                or (
+                    {left.operator, right.operator} == {Operator.EQ, Operator.NE}
+                    and canonical_digest(left.value) == canonical_digest(right.value)
+                )
+                or ((left.operator, right.operator) in opposite_unary)
+            )
+            if contradictory:
+                diagnostics.append(
+                    AcceptanceDiagnostic(
+                        "CONTRADICTORY_ASSERTIONS",
+                        criterion_id,
+                        f"{field} contains incompatible assertions for {left.path}",
+                    )
+                )
+                return tuple(compiled)
+    return tuple(compiled)
+
+
+def _human_test(
+    raw: Mapping[str, Any],
+    *,
+    criterion_id: str,
+    repository_root: Path,
+    diagnostics: list[AcceptanceDiagnostic],
+) -> HumanTest | None:
+    path_value = raw.get("path")
+    node_id = raw.get("node_id")
+    command = raw.get("command")
+    if (
+        not isinstance(path_value, str)
+        or not path_value.startswith("tests/")
+        or Path(path_value).is_absolute()
+        or ".." in Path(path_value).parts
+        or not isinstance(node_id, str)
+        or not node_id
+        or not isinstance(command, list)
+        or not command
+        or not all(isinstance(item, str) and item for item in command)
+    ):
+        diagnostics.append(
+            AcceptanceDiagnostic(
+                "INVALID_HUMAN_TEST_REFERENCE",
+                criterion_id,
+                "human test must bind a safe tests/ path, node ID, and argv",
+            )
+        )
+        return None
+    path = repository_root / path_value
+    if not path.is_file():
+        diagnostics.append(
+            AcceptanceDiagnostic(
+                "HUMAN_TEST_MISSING",
+                criterion_id,
+                f"human test does not exist: {path_value}",
+            )
+        )
+        return None
+    target = f"{path_value}::{node_id}"
+    if path_value not in command and target not in command:
+        diagnostics.append(
+            AcceptanceDiagnostic(
+                "HUMAN_TEST_COMMAND_MISMATCH",
+                criterion_id,
+                "human test command does not target its bound file or node",
+            )
+        )
+        return None
+    digest = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    return HumanTest(path_value, node_id, tuple(command), digest)
+
+
+def compile_acceptance_plan(
+    contract: Mapping[str, Any],
+    *,
+    repository_root: Path,
+    registered_actions: frozenset[str],
+    template_version: str,
+    template_test_ids: frozenset[str],
+    registered_measures: frozenset[str] = frozenset(),
+) -> AcceptanceBuildPlan:
+    """Compile typed criteria and prove task/test coverage before any build."""
+
+    diagnostics: list[AcceptanceDiagnostic] = []
+    requirements_raw = _mapping(contract.get("functional_requirements"))
+    criteria_raw = _mapping(contract.get("acceptance_criteria"))
+    if not requirements_raw:
+        diagnostics.append(
+            AcceptanceDiagnostic(
+                "REQUIREMENTS_MISSING", "contract", "functional requirements are required"
+            )
+        )
+        requirements_raw = {}
+    if not criteria_raw:
+        diagnostics.append(
+            AcceptanceDiagnostic("CRITERIA_MISSING", "contract", "acceptance criteria are required")
+        )
+        criteria_raw = {}
+
+    requirements = tuple(sorted(str(item) for item in requirements_raw))
+    requirement_set = frozenset(requirements)
+    covered: set[str] = set()
+    compiled: list[CompiledCriterion] = []
+
+    for criterion_id, raw in sorted(criteria_raw.items(), key=lambda item: str(item[0])):
+        cid = str(criterion_id)
+        item = _mapping(raw)
+        if item is None:
+            diagnostics.append(
+                AcceptanceDiagnostic("INVALID_CRITERION", cid, "criterion must be an object")
+            )
+            continue
+        refs_raw = item.get("requirement_refs")
+        if (
+            not isinstance(refs_raw, list)
+            or not refs_raw
+            or not all(isinstance(ref, str) and ref for ref in refs_raw)
+        ):
+            diagnostics.append(
+                AcceptanceDiagnostic(
+                    "REQUIREMENT_REFS_MISSING", cid, "criterion needs requirement_refs"
+                )
+            )
+            continue
+        refs = tuple(sorted(set(refs_raw)))
+        unknown = sorted(set(refs) - requirement_set)
+        if unknown:
+            diagnostics.append(
+                AcceptanceDiagnostic("UNKNOWN_REQUIREMENT_REF", cid, ", ".join(unknown))
+            )
+            continue
+        covered.update(refs)
+
+        forms = {
+            "given_when_then": all(key in item for key in ("given", "when", "then")),
+            "measure": all(key in item for key in ("measure", "operator", "value")),
+            "human_test": "human_test" in item,
+            "satisfied_by_template": "satisfied_by_template" in item,
+        }
+        selected = [name for name, present in forms.items() if present]
+        if len(selected) != 1:
+            diagnostics.append(
+                AcceptanceDiagnostic(
+                    "CRITERION_FORM_INVALID",
+                    cid,
+                    "criterion must select exactly one executable form",
+                )
+            )
+            continue
+        form = selected[0]
+        if form == "given_when_then":
+            when_raw = _mapping(item.get("when"))
+            action = "" if when_raw is None else str(when_raw.get("action", ""))
+            arguments = {} if when_raw is None else when_raw.get("arguments", {})
+            if action not in registered_actions or not isinstance(arguments, Mapping):
+                diagnostics.append(
+                    AcceptanceDiagnostic(
+                        "ACTION_NOT_REGISTERED", cid, "when.action is not registered"
+                    )
+                )
+                continue
+            given = _assertions(
+                item.get("given"), criterion_id=cid, field="given", diagnostics=diagnostics
+            )
+            then = _assertions(
+                item.get("then"), criterion_id=cid, field="then", diagnostics=diagnostics
+            )
+            if given and then:
+                compiled.append(
+                    CompiledCriterion(
+                        cid,
+                        refs,
+                        form,
+                        given=given,
+                        when=ActionCall(action, dict(arguments)),
+                        then=then,
+                    )
+                )
+        elif form == "measure":
+            try:
+                operator = Operator(str(item.get("operator", "")))
+            except ValueError:
+                diagnostics.append(
+                    AcceptanceDiagnostic(
+                        "UNKNOWN_ASSERTION_OPERATOR", cid, "measure operator is unregistered"
+                    )
+                )
+                continue
+            measure = item.get("measure")
+            sample = _mapping(item.get("sample")) or {}
+            minimum = sample.get("minimum")
+            if (
+                not isinstance(measure, str)
+                or not measure
+                or measure not in registered_measures
+                or isinstance(minimum, bool)
+                or not isinstance(minimum, int)
+                or minimum <= 0
+            ):
+                diagnostics.append(
+                    AcceptanceDiagnostic(
+                        "MEASURE_INVALID",
+                        cid,
+                        "measure needs a registered source and positive sample.minimum",
+                    )
+                )
+                continue
+            compiled.append(
+                CompiledCriterion(
+                    cid,
+                    refs,
+                    form,
+                    measure=measure,
+                    operator=operator,
+                    value=item.get("value"),
+                    minimum_sample=minimum,
+                )
+            )
+        elif form == "human_test":
+            human_raw = _mapping(item.get("human_test"))
+            human = (
+                None
+                if human_raw is None
+                else _human_test(
+                    human_raw,
+                    criterion_id=cid,
+                    repository_root=repository_root,
+                    diagnostics=diagnostics,
+                )
+            )
+            if human is not None:
+                compiled.append(CompiledCriterion(cid, refs, form, human_test=human))
+        else:
+            proof_raw = _mapping(item.get("satisfied_by_template"))
+            version = "" if proof_raw is None else str(proof_raw.get("template_version", ""))
+            test_id = "" if proof_raw is None else str(proof_raw.get("test_id", ""))
+            if version != template_version or test_id not in template_test_ids:
+                diagnostics.append(
+                    AcceptanceDiagnostic(
+                        "TEMPLATE_PROOF_INVALID",
+                        cid,
+                        "template proof does not match the pinned template",
+                    )
+                )
+                continue
+            compiled.append(
+                CompiledCriterion(
+                    cid,
+                    refs,
+                    form,
+                    template_proof=TemplateProof(version, test_id),
+                )
+            )
+
+    for requirement_id in sorted(requirement_set - covered):
+        diagnostics.append(
+            AcceptanceDiagnostic(
+                "REQUIREMENT_UNCOVERED",
+                requirement_id,
+                "requirement has no executable criterion",
+            )
+        )
+    if diagnostics:
+        raise AcceptanceCompileError(diagnostics)
+
+    tasks = tuple(
+        BuildTask(f"TASK-{index:03d}", item) for index, item in enumerate(requirements, 1)
+    )
+    shell = {
+        "contract_digest": canonical_digest(contract),
+        "requirements": requirements,
+        "tasks": [asdict(item) for item in tasks],
+        "criteria": [asdict(item) for item in compiled],
+    }
+    return AcceptanceBuildPlan(
+        contract_digest=str(shell["contract_digest"]),
+        requirements=requirements,
+        tasks=tasks,
+        criteria=tuple(compiled),
+        plan_digest=canonical_digest(shell),
+    )

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -68,6 +68,7 @@ class HumanTest:
 class TemplateProof:
     template_version: str
     test_id: str
+    file_digest: str
 
 
 @dataclass(frozen=True)
@@ -152,25 +153,7 @@ def _assertions(
         for right in compiled[index + 1 :]:
             if left.path != right.path:
                 continue
-            opposite_unary = {
-                (Operator.IS_TRUE, Operator.IS_FALSE),
-                (Operator.IS_FALSE, Operator.IS_TRUE),
-                (Operator.IS_NULL, Operator.NOT_NULL),
-                (Operator.NOT_NULL, Operator.IS_NULL),
-            }
-            contradictory = (
-                (
-                    left.operator is Operator.EQ
-                    and right.operator is Operator.EQ
-                    and canonical_digest(left.value) != canonical_digest(right.value)
-                )
-                or (
-                    {left.operator, right.operator} == {Operator.EQ, Operator.NE}
-                    and canonical_digest(left.value) == canonical_digest(right.value)
-                )
-                or ((left.operator, right.operator) in opposite_unary)
-            )
-            if contradictory:
+            if _contradictory(left, right):
                 diagnostics.append(
                     AcceptanceDiagnostic(
                         "CONTRADICTORY_ASSERTIONS",
@@ -180,6 +163,56 @@ def _assertions(
                 )
                 return tuple(compiled)
     return tuple(compiled)
+
+
+def _ordered_comparison(left: Any, operator: Operator, right: Any) -> bool | None:
+    operations = {
+        Operator.LT: lambda: left < right,
+        Operator.LTE: lambda: left <= right,
+        Operator.GT: lambda: left > right,
+        Operator.GTE: lambda: left >= right,
+    }
+    try:
+        return bool(operations[operator]())
+    except (KeyError, TypeError):
+        return None
+
+
+def _contradictory(left: PropertyAssertion, right: PropertyAssertion) -> bool:
+    if left.operator is Operator.EQ and right.operator is Operator.EQ:
+        return canonical_digest(left.value) != canonical_digest(right.value)
+    if {left.operator, right.operator} == {Operator.EQ, Operator.NE}:
+        return canonical_digest(left.value) == canonical_digest(right.value)
+    opposite_unary = {
+        (Operator.IS_TRUE, Operator.IS_FALSE),
+        (Operator.IS_FALSE, Operator.IS_TRUE),
+        (Operator.IS_NULL, Operator.NOT_NULL),
+        (Operator.NOT_NULL, Operator.IS_NULL),
+    }
+    if (left.operator, right.operator) in opposite_unary:
+        return True
+    ordered = {Operator.LT, Operator.LTE, Operator.GT, Operator.GTE}
+    if left.operator is Operator.EQ and right.operator in ordered:
+        result = _ordered_comparison(left.value, right.operator, right.value)
+        return result is False
+    if right.operator is Operator.EQ and left.operator in ordered:
+        result = _ordered_comparison(right.value, left.operator, left.value)
+        return result is False
+    lower = left if left.operator in {Operator.GT, Operator.GTE} else right
+    upper = right if right.operator in {Operator.LT, Operator.LTE} else left
+    if lower.operator not in {Operator.GT, Operator.GTE} or upper.operator not in {
+        Operator.LT,
+        Operator.LTE,
+    }:
+        return False
+    try:
+        if lower.value > upper.value:
+            return True
+        return lower.value == upper.value and (
+            lower.operator is Operator.GT or upper.operator is Operator.LT
+        )
+    except TypeError:
+        return False
 
 
 def _human_test(
@@ -196,7 +229,7 @@ def _human_test(
         not isinstance(path_value, str)
         or not path_value.startswith("tests/")
         or Path(path_value).is_absolute()
-        or ".." in Path(path_value).parts
+        or any(part in {".", ".."} for part in path_value.split("/"))
         or not isinstance(node_id, str)
         or not node_id
         or not isinstance(command, list)
@@ -222,12 +255,15 @@ def _human_test(
         )
         return None
     target = f"{path_value}::{node_id}"
-    if path_value not in command and target not in command:
+    is_pytest = Path(command[0]).name.startswith("pytest") or (
+        len(command) >= 3 and command[1:3] == ["-m", "pytest"]
+    )
+    if not is_pytest or target not in command:
         diagnostics.append(
             AcceptanceDiagnostic(
                 "HUMAN_TEST_COMMAND_MISMATCH",
                 criterion_id,
-                "human test command does not target its bound file or node",
+                "human test command must run pytest against its exact bound node",
             )
         )
         return None
@@ -241,7 +277,7 @@ def compile_acceptance_plan(
     repository_root: Path,
     registered_actions: frozenset[str],
     template_version: str,
-    template_test_ids: frozenset[str],
+    template_test_digests: Mapping[str, str],
     registered_measures: frozenset[str] = frozenset(),
 ) -> AcceptanceBuildPlan:
     """Compile typed criteria and prove task/test coverage before any build."""
@@ -399,7 +435,8 @@ def compile_acceptance_plan(
             proof_raw = _mapping(item.get("satisfied_by_template"))
             version = "" if proof_raw is None else str(proof_raw.get("template_version", ""))
             test_id = "" if proof_raw is None else str(proof_raw.get("test_id", ""))
-            if version != template_version or test_id not in template_test_ids:
+            proof_digest = template_test_digests.get(test_id)
+            if version != template_version or proof_digest is None:
                 diagnostics.append(
                     AcceptanceDiagnostic(
                         "TEMPLATE_PROOF_INVALID",
@@ -413,7 +450,7 @@ def compile_acceptance_plan(
                     cid,
                     refs,
                     form,
-                    template_proof=TemplateProof(version, test_id),
+                    template_proof=TemplateProof(version, test_id, proof_digest),
                 )
             )
 

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -194,6 +194,8 @@ def _contradictory(left: PropertyAssertion, right: PropertyAssertion) -> bool:
         return canonical_digest(left.value) != canonical_digest(right.value)
     if {left.operator, right.operator} == {Operator.EQ, Operator.NE}:
         return canonical_digest(left.value) == canonical_digest(right.value)
+    if {left.operator, right.operator} == {Operator.CONTAINS, Operator.NOT_CONTAINS}:
+        return canonical_digest(left.value) == canonical_digest(right.value)
     opposite_unary = {
         (Operator.IS_TRUE, Operator.IS_FALSE),
         (Operator.IS_FALSE, Operator.IS_TRUE),

--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -191,6 +191,20 @@ def _contradictory(left: PropertyAssertion, right: PropertyAssertion) -> bool:
     }
     if (left.operator, right.operator) in opposite_unary:
         return True
+    equality = {Operator.EQ, Operator.NE}
+    unary = {Operator.IS_TRUE, Operator.IS_FALSE, Operator.IS_NULL, Operator.NOT_NULL}
+    equality_assertion = left if left.operator in equality else right
+    unary_assertion = left if left.operator in unary else right
+    if equality_assertion.operator in equality and unary_assertion.operator in unary:
+        unary_matches = {
+            Operator.IS_TRUE: equality_assertion.value is True,
+            Operator.IS_FALSE: equality_assertion.value is False,
+            Operator.IS_NULL: equality_assertion.value is None,
+            Operator.NOT_NULL: equality_assertion.value is not None,
+        }[unary_assertion.operator]
+        if equality_assertion.operator is Operator.EQ:
+            return not unary_matches
+        return unary_assertion.operator is not Operator.NOT_NULL and unary_matches
     ordered = {Operator.LT, Operator.LTE, Operator.GT, Operator.GTE}
     if left.operator is Operator.EQ and right.operator in ordered:
         result = _ordered_comparison(left.value, right.operator, right.value)

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -1,0 +1,120 @@
+"""Plain-file, content-addressed evidence for the bare-bones core."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from collections.abc import Iterator, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from pmpe.contracts.canonical import canonical_digest, canonical_json_bytes
+
+_RUN_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
+_DIGEST = re.compile(r"sha256:([0-9a-f]{64})\Z")
+GENESIS_DIGEST = "sha256:" + "0" * 64
+
+
+class EvidenceIntegrityError(ValueError):
+    """The evidence ledger is malformed or its hash chain is broken."""
+
+
+class EvidenceLedger:
+    """Append-only JSONL events and SHA-256 blobs under one `.pmpe` directory."""
+
+    def __init__(self, repository_root: Path, run_id: str) -> None:
+        if not _RUN_ID.fullmatch(run_id):
+            raise ValueError("run_id must be a bounded filesystem-safe identifier")
+        self.root = repository_root / ".pmpe"
+        self.run_directory = self.root / "runs" / run_id
+        self.events_path = self.run_directory / "events.jsonl"
+        self.blobs_directory = self.root / "blobs"
+        self.run_directory.mkdir(parents=True, exist_ok=True)
+        self.blobs_directory.mkdir(parents=True, exist_ok=True)
+
+    def put_blob(self, payload: bytes) -> str:
+        digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+        destination = self.blobs_directory / digest.removeprefix("sha256:")
+        if destination.exists():
+            if destination.read_bytes() != payload:
+                raise EvidenceIntegrityError("content-addressed blob does not match its name")
+            return digest
+        descriptor, temporary_name = tempfile.mkstemp(dir=self.blobs_directory)
+        try:
+            with os.fdopen(descriptor, "wb") as temporary:
+                temporary.write(payload)
+                temporary.flush()
+                os.fsync(temporary.fileno())
+            try:
+                os.link(temporary_name, destination)
+            except FileExistsError:
+                if destination.read_bytes() != payload:
+                    raise EvidenceIntegrityError("concurrent blob write changed content") from None
+        finally:
+            Path(temporary_name).unlink(missing_ok=True)
+        return digest
+
+    def append(
+        self,
+        *,
+        event_type: str,
+        state: str,
+        subject_digest: str,
+        blob_digests: Sequence[str] = (),
+        payload: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        if not event_type or not state or _DIGEST.fullmatch(subject_digest) is None:
+            raise ValueError("event type, state, and subject digest are required")
+        if any(_DIGEST.fullmatch(item) is None for item in blob_digests):
+            raise ValueError("blob references must be SHA-256 digests")
+        events = tuple(self.verify())
+        body: dict[str, Any] = {
+            "sequence": len(events) + 1,
+            "previous_digest": events[-1]["event_digest"] if events else GENESIS_DIGEST,
+            "event_type": event_type,
+            "state": state,
+            "subject_digest": subject_digest,
+            "blob_digests": sorted(set(blob_digests)),
+            "payload": dict(payload or {}),
+        }
+        event = {**body, "event_digest": canonical_digest(body)}
+        with self.events_path.open("ab") as stream:
+            stream.write(canonical_json_bytes(event) + b"\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        return event
+
+    def verify(self) -> Iterator[Mapping[str, Any]]:
+        if not self.events_path.exists():
+            return
+        previous = GENESIS_DIGEST
+        for expected_sequence, raw_line in enumerate(
+            self.events_path.read_bytes().splitlines(), start=1
+        ):
+            try:
+                event = json.loads(raw_line)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise EvidenceIntegrityError("event is not canonical JSON") from exc
+            if not isinstance(event, dict):
+                raise EvidenceIntegrityError("event must be an object")
+            event_digest = event.pop("event_digest", None)
+            if (
+                event.get("sequence") != expected_sequence
+                or event.get("previous_digest") != previous
+                or event_digest != canonical_digest(event)
+                or raw_line != canonical_json_bytes({**event, "event_digest": event_digest})
+            ):
+                raise EvidenceIntegrityError(f"broken evidence chain at event {expected_sequence}")
+            for digest in event.get("blob_digests", []):
+                match = _DIGEST.fullmatch(digest) if isinstance(digest, str) else None
+                blob_path = self.blobs_directory / (match.group(1) if match else "invalid")
+                if match is None or not blob_path.is_file():
+                    raise EvidenceIntegrityError("event references a missing blob")
+                if "sha256:" + hashlib.sha256(blob_path.read_bytes()).hexdigest() != digest:
+                    raise EvidenceIntegrityError("blob content does not match its digest")
+            restored = {**event, "event_digest": event_digest}
+            previous = str(event_digest)
+            yield restored

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -25,7 +25,7 @@ class EvidenceIntegrityError(ValueError):
 class EvidenceLedger:
     """Append-only JSONL events and SHA-256 blobs under one `.pmpe` directory."""
 
-    def __init__(self, repository_root: Path, run_id: str) -> None:
+    def __init__(self, repository_root: Path, run_id: str, *, resume: bool = False) -> None:
         if not _RUN_ID.fullmatch(run_id):
             raise ValueError("run_id must be a bounded filesystem-safe identifier")
         self.run_id = run_id
@@ -35,6 +35,26 @@ class EvidenceLedger:
         self.blobs_directory = self.root / "blobs"
         self.run_directory.mkdir(parents=True, exist_ok=True)
         self.blobs_directory.mkdir(parents=True, exist_ok=True)
+        if resume:
+            if not self.events_path.is_file():
+                raise EvidenceIntegrityError("cannot resume a run without an evidence ledger")
+            events = tuple(self.verify())
+            if not events:
+                raise EvidenceIntegrityError("cannot resume an empty evidence ledger")
+            if events[-1].get("state") in {"RELEASE_READY", "HALTED", "STOPPED"}:
+                raise EvidenceIntegrityError("a terminal run cannot be resumed")
+        else:
+            try:
+                descriptor = os.open(
+                    self.events_path,
+                    os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                    0o600,
+                )
+            except FileExistsError as exc:
+                raise EvidenceIntegrityError(
+                    "run_id already has an evidence ledger; use a new run_id"
+                ) from exc
+            os.close(descriptor)
 
     def put_blob(self, payload: bytes) -> str:
         digest = "sha256:" + hashlib.sha256(payload).hexdigest()

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -28,6 +28,7 @@ class EvidenceLedger:
     def __init__(self, repository_root: Path, run_id: str) -> None:
         if not _RUN_ID.fullmatch(run_id):
             raise ValueError("run_id must be a bounded filesystem-safe identifier")
+        self.run_id = run_id
         self.root = repository_root / ".pmpe"
         self.run_directory = self.root / "runs" / run_id
         self.events_path = self.run_directory / "events.jsonl"
@@ -72,6 +73,8 @@ class EvidenceLedger:
             raise ValueError("blob references must be SHA-256 digests")
         events = tuple(self.verify())
         body: dict[str, Any] = {
+            "schema_version": "1.0.0",
+            "run_id": self.run_id,
             "sequence": len(events) + 1,
             "previous_digest": events[-1]["event_digest"] if events else GENESIS_DIGEST,
             "event_type": event_type,

--- a/src/pmpe/model_provider.py
+++ b/src/pmpe/model_provider.py
@@ -1,0 +1,12 @@
+"""The only external adapter used by the bare-bones Engineering OS core."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+
+class ModelProvider(Protocol):
+    """Return structured output for one digest-bound model request."""
+
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 import copy
 import json
+import os
+import subprocess
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -48,6 +51,62 @@ def golden_spec_dict() -> dict[str, Any]:
 @pytest.fixture()
 def fixtures_dir() -> Path:
     return FIXTURES_DIR
+
+
+class _LocalCandidateTestSandbox:
+    """Test-only runner; production defaults are exercised by dedicated boundary tests."""
+
+    def run(
+        self,
+        workspace: Path,
+        argv: list[str] | tuple[str, ...],
+        *,
+        timeout_seconds: float,
+        environment: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        translated: list[str] = []
+        for index, argument in enumerate(argv):
+            if index == 0 and argument == sys.executable:
+                translated.append(argument)
+                continue
+            rewritten = argument.replace("'/workspace'", repr(str(workspace)))
+            if rewritten == "/workspace" or rewritten.startswith("/workspace/"):
+                rewritten = str(workspace) + rewritten.removeprefix("/workspace")
+            elif rewritten.startswith("--rootdir=/workspace"):
+                rewritten = "--rootdir=" + str(workspace)
+            translated.append(rewritten)
+        try:
+            return subprocess.run(
+                translated,
+                cwd=workspace,
+                text=True,
+                capture_output=True,
+                timeout=timeout_seconds,
+                check=False,
+                env={
+                    **environment,
+                    "PATH": os.environ.get("PATH", environment.get("PATH", "")),
+                },
+            )
+        except subprocess.TimeoutExpired as exc:
+            from pmpe.barebones import ContractInvalidError
+
+            raise ContractInvalidError("candidate execution timed out") from exc
+
+
+@pytest.fixture(autouse=True)
+def local_candidate_sandbox_for_barebones_tests(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if request.path.name not in {
+        "test_barebones_cli.py",
+        "test_barebones_e1.py",
+        "test_barebones_evals.py",
+    }:
+        return
+    from pmpe import barebones
+
+    monkeypatch.setattr(barebones, "BubblewrapCandidateSandbox", _LocalCandidateTestSandbox)
 
 
 @pytest.fixture()

--- a/tests/e2e/test_barebones_e1.py
+++ b/tests/e2e/test_barebones_e1.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from pmpe.barebones import RunState, run_to_release_ready
+
+
+class E1Provider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        if purpose == "code":
+            return {
+                "request_digest": request["request_digest"],
+                "files": {
+                    "product.py": (
+                        '"""E1 health product."""\n\n'
+                        "def health() -> dict[str, str]:\n"
+                        '    return {"status": "ok"}\n'
+                    )
+                },
+            }
+        return {
+            "request_digest": request["request_digest"],
+            "summary": "Deterministic evidence passed; human may release.",
+        }
+
+
+def test_e1_real_contract_reaches_release_ready(tmp_path: Path) -> None:
+    contract = {
+        "contract_id": "PMOS-E1",
+        "functional_requirements": {"FR-001": {"statement": "health reports ok"}},
+        "acceptance_criteria": {
+            "AC-001": {
+                "requirement_refs": ["FR-001"],
+                "given": [{"path": "service.running", "operator": "eq", "value": True}],
+                "when": {"action": "health", "arguments": {}},
+                "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+            }
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="e1-real-contract",
+        provider=E1Provider(),
+    )
+
+    assert result.state is RunState.RELEASE_READY
+    assert result.cause == "PASS"
+    assert result.attempts == 1
+    assert result.model_calls == 2
+    assert result.evidence_path.is_file()
+    assert "status" not in result.annotation

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from collections.abc import Mapping
 from pathlib import Path
@@ -7,7 +8,13 @@ from typing import Any
 
 import pytest
 
-from pmpe.barebones import RunState, run_to_release_ready
+from pmpe.barebones import (
+    ContractInvalidError,
+    RunState,
+    Template,
+    TemplateTest,
+    run_to_release_ready,
+)
 from pmpe.contracts.acceptance import AcceptanceCompileError
 
 
@@ -75,6 +82,37 @@ class SyntaxRepairProvider:
         }
 
 
+class RepeatAfterChangedFindingProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        self.calls += 1
+        files = {"product.py": "def health(:\n"} if self.calls == 1 else {"notes.txt": "no fix\n"}
+        return {"request_digest": request["request_digest"], "files": files}
+
+
+class MeasureProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        if purpose == "code":
+            return {
+                "request_digest": request["request_digest"],
+                "files": {
+                    "product.py": "def latency():\n    return {'value': 100, 'sample_size': 20}\n"
+                },
+            }
+        return {"request_digest": request["request_digest"], "summary": "advisory"}
+
+
+class ManifestProvider(PassingProvider):
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        response = dict(super().invoke(purpose=purpose, request=request))
+        if purpose == "code":
+            response["files"] = {**response["files"], "fixtures/data.csv": "id,value\n1,ok\n"}
+        return response
+
+
 def test_e2_unsatisfiable_run_halts_with_exact_requirement(tmp_path: Path) -> None:
     result = run_to_release_ready(
         contract=_contract(),
@@ -111,6 +149,20 @@ def test_coder_can_repair_a_candidate_syntax_failure(tmp_path: Path) -> None:
     )
 
     assert result.state is RunState.RELEASE_READY
+    assert result.attempts == 2
+
+
+def test_repeat_guard_uses_the_latest_verification_finding(tmp_path: Path) -> None:
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="repeat-after-finding-change",
+        provider=RepeatAfterChangedFindingProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:candidate"
     assert result.attempts == 2
 
 
@@ -182,6 +234,45 @@ def test_human_authored_escape_hatch_is_executable_and_protected(tmp_path: Path)
     assert result.state is RunState.RELEASE_READY
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import pytest\n@pytest.mark.skip\ndef test_health():\n    assert False\n",
+        "def test_health(:\n    assert False\n",
+    ],
+)
+def test_human_test_must_execute_once_and_report_a_structured_assertion(
+    tmp_path: Path, source: str
+) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(source)
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
+    }
+
+    with pytest.raises(ContractInvalidError):
+        run_to_release_ready(
+            contract=contract,
+            repository_root=tmp_path,
+            workspace=tmp_path / "candidate",
+            run_id="human-test-structured",
+            provider=PassingProvider(),
+        )
+
+
 class TamperingProvider:
     def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
         return {
@@ -220,3 +311,144 @@ def test_coder_cannot_rewrite_human_authored_evidence(tmp_path: Path) -> None:
 
     assert result.state is RunState.HALTED
     assert result.cause == "CODER_MODIFIED_EVIDENCE"
+
+
+class DotSegmentTamperingProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"tests/acceptance/./test_health.py": "def test_health(): assert True\n"},
+        }
+
+
+def test_coder_cannot_bypass_test_protection_with_dot_segments(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text("def test_health():\n    assert False\n")
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="human-test-dot-tamper",
+        provider=DotSegmentTamperingProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "CODER_RESPONSE_INVALID"
+
+
+def test_template_proof_is_digest_bound_and_executed(tmp_path: Path) -> None:
+    template = Template(
+        version="barebones-1",
+        files={
+            "product.py": "def health():\n    return {'status': 'not_implemented'}\n",
+            "tests/template/test_shape.py": (
+                "from product import health\n\n"
+                "def test_health_shape():\n"
+                "    assert callable(health)\n"
+            ),
+        },
+        actions={"health": "product:health"},
+        context={"service": {"running": True}},
+        proofs={
+            "template::health-shape": TemplateTest(
+                "tests/template/test_shape.py",
+                "test_health_shape",
+                (
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "-q",
+                    "tests/template/test_shape.py::test_health_shape",
+                ),
+            )
+        },
+    )
+    contract = _contract()
+    contract["functional_requirements"]["FR-002"] = {"statement": "template exposes health"}
+    contract["acceptance_criteria"]["AC-002"] = {
+        "requirement_refs": ["FR-002"],
+        "satisfied_by_template": {
+            "template_version": "barebones-1",
+            "test_id": "template::health-shape",
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="template-proof",
+        provider=PassingProvider(),
+        template=template,
+    )
+
+    assert result.state is RunState.RELEASE_READY
+
+
+def test_registered_measure_runs_deterministically(tmp_path: Path) -> None:
+    template = Template(
+        version="barebones-1",
+        files={"product.py": "def latency():\n    return {'value': 500, 'sample_size': 20}\n"},
+        actions={},
+        context={},
+        measures={"latency.p95_ms": "product:latency"},
+    )
+    contract = {
+        "functional_requirements": {"FR-001": {"statement": "latency is bounded"}},
+        "acceptance_criteria": {
+            "AC-001": {
+                "requirement_refs": ["FR-001"],
+                "measure": "latency.p95_ms",
+                "operator": "lte",
+                "value": 200,
+                "sample": {"minimum": 20},
+            }
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="measure",
+        provider=MeasureProvider(),
+        template=template,
+    )
+
+    assert result.state is RunState.RELEASE_READY
+
+
+def test_release_manifest_digests_every_candidate_file(tmp_path: Path) -> None:
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="complete-manifest",
+        provider=ManifestProvider(),
+    )
+
+    event = json.loads(result.evidence_path.read_text().splitlines()[-1])
+    manifest_digest = event["payload"]["candidate_digest"]
+    manifest_path = tmp_path / ".pmpe/blobs" / manifest_digest.removeprefix("sha256:")
+    manifest = json.loads(manifest_path.read_text())
+    assert "fixtures/data.csv" in manifest
+    file_blob = tmp_path / ".pmpe/blobs" / manifest["fixtures/data.csv"].removeprefix("sha256:")
+    assert file_blob.read_bytes() == b"id,value\n1,ok\n"
+    assert set(manifest.values()).issubset(set(event["blob_digests"]))

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from pmpe import barebones as barebones_module
 from pmpe.barebones import (
     ContractInvalidError,
     RunState,
@@ -113,6 +114,68 @@ class ManifestProvider(PassingProvider):
         return response
 
 
+class MutatingActionProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        if purpose == "advisory_review":
+            return {"request_digest": request["request_digest"], "summary": "advisory"}
+        self.calls += 1
+        content = (
+            "from pathlib import Path\n\n"
+            "def health():\n"
+            "    Path(__file__).write_text(\n"
+            "        \"def health():\\n    return {'status': 'broken'}\\n\"\n"
+            "    )\n"
+            "    return {'status': 'ok'}\n"
+            if self.calls == 1
+            else "def health():\n    return {'status': 'ok'}\n"
+        )
+        return {"request_digest": request["request_digest"], "files": {"product.py": content}}
+
+
+class BooleanProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"product.py": "def health():\n    return {'status': True}\n"},
+        }
+
+
+class MeasureSyntaxRepairProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        if purpose == "advisory_review":
+            return {"request_digest": request["request_digest"], "summary": "advisory"}
+        self.calls += 1
+        content = (
+            "def latency(:\n"
+            if self.calls == 1
+            else "def latency():\n    return {'value': 100, 'sample_size': 20}\n"
+        )
+        return {"request_digest": request["request_digest"], "files": {"product.py": content}}
+
+
+class TimeoutRepairProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        if purpose == "advisory_review":
+            return {"request_digest": request["request_digest"], "summary": "advisory"}
+        self.calls += 1
+        content = (
+            "import time\n\ndef health():\n    time.sleep(1)\n    return {'status': 'ok'}\n"
+            if self.calls == 1
+            else "def health():\n    return {'status': 'ok'}\n"
+        )
+        return {"request_digest": request["request_digest"], "files": {"product.py": content}}
+
+
 def test_e2_unsatisfiable_run_halts_with_exact_requirement(tmp_path: Path) -> None:
     result = run_to_release_ready(
         contract=_contract(),
@@ -146,6 +209,22 @@ def test_coder_can_repair_a_candidate_syntax_failure(tmp_path: Path) -> None:
         workspace=tmp_path / "candidate",
         run_id="syntax-repair",
         provider=SyntaxRepairProvider(),
+    )
+
+    assert result.state is RunState.RELEASE_READY
+    assert result.attempts == 2
+
+
+def test_candidate_action_timeout_becomes_a_repairable_finding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(barebones_module, "_ACTION_TIMEOUT_SECONDS", 0.2)
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="timeout-repair",
+        provider=TimeoutRepairProvider(),
     )
 
     assert result.state is RunState.RELEASE_READY
@@ -353,6 +432,54 @@ def test_coder_cannot_bypass_test_protection_with_dot_segments(tmp_path: Path) -
     assert result.cause == "CODER_RESPONSE_INVALID"
 
 
+class ConftestCheatProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        return {
+            "request_digest": request["request_digest"],
+            "files": {
+                "conftest.py": (
+                    "def pytest_runtest_setup(item):\n"
+                    "    item.module.health = lambda: {'status': 'ok'}\n"
+                )
+            },
+        }
+
+
+def test_coder_controlled_conftest_cannot_change_bound_test_outcome(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "from product import health\n\ndef test_health():\n    assert health()['status'] == 'ok'\n"
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="conftest-isolation",
+        provider=ConftestCheatProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001"
+
+
 def test_template_proof_is_digest_bound_and_executed(tmp_path: Path) -> None:
     template = Template(
         version="barebones-1",
@@ -435,6 +562,55 @@ def test_registered_measure_runs_deterministically(tmp_path: Path) -> None:
     assert result.state is RunState.RELEASE_READY
 
 
+def test_measure_execution_failure_can_be_repaired(tmp_path: Path) -> None:
+    template = Template(
+        version="barebones-1",
+        files={"product.py": "def latency():\n    return {'value': 500, 'sample_size': 20}\n"},
+        actions={},
+        context={},
+        measures={"latency.p95_ms": "product:latency"},
+    )
+    contract = {
+        "functional_requirements": {"FR-001": {"statement": "latency is bounded"}},
+        "acceptance_criteria": {
+            "AC-001": {
+                "requirement_refs": ["FR-001"],
+                "measure": "latency.p95_ms",
+                "operator": "lte",
+                "value": 200,
+                "sample": {"minimum": 20},
+            }
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="measure-repair",
+        provider=MeasureSyntaxRepairProvider(),
+        template=template,
+    )
+
+    assert result.state is RunState.RELEASE_READY
+    assert result.attempts == 2
+
+
+def test_json_equality_does_not_treat_boolean_as_number(tmp_path: Path) -> None:
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"]["then"][0]["value"] = 1
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="json-type-equality",
+        provider=BooleanProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001"
+
+
 def test_release_manifest_digests_every_candidate_file(tmp_path: Path) -> None:
     result = run_to_release_ready(
         contract=_contract(),
@@ -452,3 +628,23 @@ def test_release_manifest_digests_every_candidate_file(tmp_path: Path) -> None:
     file_blob = tmp_path / ".pmpe/blobs" / manifest["fixtures/data.csv"].removeprefix("sha256:")
     assert file_blob.read_bytes() == b"id,value\n1,ok\n"
     assert set(manifest.values()).issubset(set(event["blob_digests"]))
+
+
+def test_release_manifest_is_the_exact_snapshot_that_was_verified(tmp_path: Path) -> None:
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="mutation-detection",
+        provider=MutatingActionProvider(),
+    )
+
+    assert result.state is RunState.RELEASE_READY
+    assert result.attempts == 2
+    event = json.loads(result.evidence_path.read_text().splitlines()[-1])
+    manifest_path = (
+        tmp_path / ".pmpe/blobs" / event["payload"]["candidate_digest"].removeprefix("sha256:")
+    )
+    manifest = json.loads(manifest_path.read_text())
+    product_blob = tmp_path / ".pmpe/blobs" / manifest["product.py"].removeprefix("sha256:")
+    assert product_blob.read_text() == "def health():\n    return {'status': 'ok'}\n"

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -194,6 +194,33 @@ class NonFiniteProvider:
         }
 
 
+class CredentialFileProvider(PassingProvider):
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        response = dict(super().invoke(purpose=purpose, request=request))
+        if purpose == "code":
+            response["files"] = {
+                **response["files"],
+                ".env": "AWS_ACCESS_KEY_ID=AKIAABCDEFGHIJKLMNOP\n",
+            }
+        return response
+
+
+class HumanTestRepairProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        if purpose == "advisory_review":
+            return {"request_digest": request["request_digest"], "summary": "advisory"}
+        self.calls += 1
+        files = (
+            {"notes.txt": "first attempt\n"}
+            if self.calls == 1
+            else {"product.py": "def health():\n    return {'status': 'ok'}\n"}
+        )
+        return {"request_digest": request["request_digest"], "files": files}
+
+
 class MeasureSyntaxRepairProvider:
     def __init__(self) -> None:
         self.calls = 0
@@ -666,6 +693,40 @@ def test_coder_cannot_add_initializers_above_a_protected_test(tmp_path: Path) ->
     assert result.cause == "CODER_MODIFIED_EVIDENCE"
 
 
+def test_human_test_failure_allows_a_changed_product_repair(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "from product import health\n\ndef test_health():\n    assert health()['status'] == 'ok'\n"
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="human-test-repair",
+        provider=HumanTestRepairProvider(),
+    )
+
+    assert result.state is RunState.RELEASE_READY
+    assert result.attempts == 2
+
+
 def test_template_proof_is_digest_bound_and_executed(tmp_path: Path) -> None:
     template = Template(
         version="barebones-1",
@@ -932,6 +993,19 @@ def test_non_finite_action_output_becomes_a_repair_finding(tmp_path: Path) -> No
 
     assert result.state is RunState.HALTED
     assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:candidate"
+
+
+def test_credential_material_is_blocked_in_non_python_files(tmp_path: Path) -> None:
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="credential-in-env",
+        provider=CredentialFileProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:.env"
 
 
 @pytest.mark.parametrize("operator,value", [("lte", 2), ("gt", 0)])

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pmpe.barebones import RunState, run_to_release_ready
+from pmpe.contracts.acceptance import AcceptanceCompileError
+
+
+def _contract() -> dict[str, Any]:
+    return {
+        "contract_id": "PMOS-EVAL",
+        "functional_requirements": {"FR-001": {"statement": "health reports ok"}},
+        "acceptance_criteria": {
+            "AC-001": {
+                "requirement_refs": ["FR-001"],
+                "given": [{"path": "service.running", "operator": "eq", "value": True}],
+                "when": {"action": "health", "arguments": {}},
+                "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+            }
+        },
+    }
+
+
+class PassingProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        if purpose == "code":
+            return {
+                "request_digest": request["request_digest"],
+                "files": {
+                    "product.py": ('def health() -> dict[str, str]:\n    return {"status": "ok"}\n')
+                },
+            }
+        return {"request_digest": request["request_digest"], "summary": "advisory only"}
+
+
+class UnsuccessfulProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        return {
+            "request_digest": request["request_digest"],
+            "files": {
+                "product.py": (
+                    'def health() -> dict[str, str]:\n    return {"status": "not_implemented"}\n'
+                )
+            },
+        }
+
+
+class StaleResponseProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {"request_digest": "sha256:" + "0" * 64, "files": {}}
+
+
+def test_e2_unsatisfiable_run_halts_with_exact_requirement(tmp_path: Path) -> None:
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="e2-unsatisfiable",
+        provider=UnsuccessfulProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001"
+
+
+def test_e3_stale_model_response_is_detected_as_drift(tmp_path: Path) -> None:
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="e3-prompt-drift",
+        provider=StaleResponseProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "MODEL_RESPONSE_UNBOUND"
+
+
+def test_e4_contradiction_stops_before_build(tmp_path: Path) -> None:
+    contract = _contract()
+    criterion = contract["acceptance_criteria"]["AC-001"]
+    criterion["given"].append({"path": "service.running", "operator": "eq", "value": False})
+    workspace = tmp_path / "candidate"
+
+    with pytest.raises(AcceptanceCompileError):
+        run_to_release_ready(
+            contract=contract,
+            repository_root=tmp_path,
+            workspace=workspace,
+            run_id="e4-contradiction",
+            provider=PassingProvider(),
+        )
+
+    assert not workspace.exists()
+
+
+def test_e5_repeated_runs_produce_identical_evidence(tmp_path: Path) -> None:
+    roots = (tmp_path / "first", tmp_path / "second")
+    event_logs: list[bytes] = []
+    for root in roots:
+        result = run_to_release_ready(
+            contract=_contract(),
+            repository_root=root,
+            workspace=root / "candidate",
+            run_id="e5-repeat",
+            provider=PassingProvider(),
+        )
+        assert result.state is RunState.RELEASE_READY
+        event_logs.append(result.evidence_path.read_bytes())
+
+    assert event_logs[0] == event_logs[1]
+
+
+def test_human_authored_escape_hatch_is_executable_and_protected(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "from product import health\n\ndef test_health():\n    assert health()['status'] == 'ok'\n"
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="human-test",
+        provider=PassingProvider(),
+    )
+
+    assert result.state is RunState.RELEASE_READY
+
+
+class TamperingProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"tests/acceptance/test_health.py": "def test_health(): assert True\n"},
+        }
+
+
+def test_coder_cannot_rewrite_human_authored_evidence(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text("def test_health():\n    assert False\n")
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="human-test-tamper",
+        provider=TamperingProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "CODER_MODIFIED_EVIDENCE"

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from collections.abc import Mapping
 from pathlib import Path
@@ -82,6 +83,47 @@ class SyntaxRepairProvider:
             "request_digest": request["request_digest"],
             "files": {"product.py": content},
         }
+
+
+class DependencyRepairProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        if purpose == "advisory_review":
+            return {"request_digest": request["request_digest"], "summary": "advisory"}
+        self.calls += 1
+        files = (
+            {
+                "product.py": (
+                    "from helper import STATUS\n\ndef health():\n    return {'status': STATUS}\n"
+                ),
+                "helper.py": "raise RuntimeError('broken dependency')\n",
+            }
+            if self.calls == 1
+            else {"helper.py": "STATUS = 'ok'\n"}
+        )
+        return {"request_digest": request["request_digest"], "files": files}
+
+
+class StableDependencySandbox:
+    def run(
+        self,
+        workspace: Path,
+        argv: object,
+        *,
+        timeout_seconds: float,
+        environment: Mapping[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        product = (workspace / "product.py").read_text()
+        helper = workspace / "helper.py"
+        if "not_implemented" in product:
+            stdout, stderr, returncode = '{"status":"not_implemented"}', "", 0
+        elif helper.exists() and "broken dependency" in helper.read_text():
+            stdout, stderr, returncode = "", "stable dependency import failure", 1
+        else:
+            stdout, stderr, returncode = '{"status":"ok"}', "", 0
+        return subprocess.CompletedProcess(argv, returncode, stdout, stderr)  # type: ignore[arg-type]
 
 
 class RepeatAfterChangedFindingProvider:
@@ -417,6 +459,20 @@ def test_candidate_action_timeout_becomes_a_repairable_finding(
         workspace=tmp_path / "candidate",
         run_id="timeout-repair",
         provider=TimeoutRepairProvider(),
+    )
+
+    assert result.state is RunState.RELEASE_READY
+    assert result.attempts == 2
+
+
+def test_execution_failure_allows_a_python_dependency_repair(tmp_path: Path) -> None:
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="dependency-repair",
+        provider=DependencyRepairProvider(),
+        candidate_sandbox=StableDependencySandbox(),
     )
 
     assert result.state is RunState.RELEASE_READY

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -446,6 +446,23 @@ class ConftestCheatProvider:
         }
 
 
+class PytestShadowProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        fake_pytest = (
+            "import pathlib, sys\n"
+            "report = next(item.split('=', 1)[1] for item in sys.argv if "
+            "item.startswith('--junitxml='))\n"
+            "pathlib.Path(report).write_text(\n"
+            "    '<testsuite><testcase name=\"test_health\" /></testsuite>'\n"
+            ")\n"
+        )
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"pytest.py": fake_pytest},
+        }
+
+
 def test_coder_controlled_conftest_cannot_change_bound_test_outcome(tmp_path: Path) -> None:
     test_file = tmp_path / "tests/acceptance/test_health.py"
     test_file.parent.mkdir(parents=True)
@@ -474,6 +491,40 @@ def test_coder_controlled_conftest_cannot_change_bound_test_outcome(tmp_path: Pa
         workspace=tmp_path / "candidate",
         run_id="conftest-isolation",
         provider=ConftestCheatProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001"
+
+
+def test_coder_cannot_shadow_the_bound_pytest_runner(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "from product import health\n\ndef test_health():\n    assert health()['status'] == 'ok'\n"
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="pytest-shadow-isolation",
+        provider=PytestShadowProvider(),
     )
 
     assert result.state is RunState.HALTED

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -144,6 +144,16 @@ class BooleanProvider:
         }
 
 
+class ArrayBooleanProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        if purpose == "advisory_review":
+            return {"request_digest": request["request_digest"], "summary": "advisory"}
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"product.py": "def health():\n    return {'status': [1]}\n"},
+        }
+
+
 class MissingPathProvider:
     def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
         assert purpose == "code"
@@ -390,6 +400,42 @@ def test_human_test_must_execute_once_and_report_a_structured_assertion(
             run_id="human-test-structured",
             provider=PassingProvider(),
         )
+
+
+def test_class_scoped_human_test_node_is_matched_exactly(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "from product import health\n\n"
+        "class TestHealth:\n"
+        "    def test_ok(self):\n"
+        "        assert health()['status'] == 'ok'\n"
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "TestHealth::test_ok",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::TestHealth::test_ok",
+            ],
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="class-scoped-human-test",
+        provider=PassingProvider(),
+    )
+
+    assert result.state is RunState.RELEASE_READY
 
 
 class TamperingProvider:
@@ -801,6 +847,60 @@ def test_json_equality_does_not_treat_boolean_as_number(tmp_path: Path) -> None:
 
     assert result.state is RunState.HALTED
     assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001"
+
+
+@pytest.mark.parametrize("operator", ["contains", "not_contains"])
+def test_array_containment_uses_json_type_aware_equality(tmp_path: Path, operator: str) -> None:
+    baseline = "[0]" if operator == "contains" else "[True]"
+    template = Template(
+        version="barebones-1",
+        files={"product.py": f"def health():\n    return {{'status': {baseline}}}\n"},
+        actions={"health": "product:health"},
+        context={"service": {"running": True}},
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"]["then"][0] = {
+        "path": "result.status",
+        "operator": operator,
+        "value": True,
+    }
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id=f"json-type-{operator}",
+        provider=ArrayBooleanProvider(),
+        template=template,
+    )
+
+    expected = RunState.HALTED if operator == "contains" else RunState.RELEASE_READY
+    assert result.state is expected
+
+
+def test_non_assertion_mutation_cannot_satisfy_meaningful_red(tmp_path: Path) -> None:
+    template = Template(
+        version="barebones-1",
+        files={
+            "product.py": (
+                "from pathlib import Path\n\n"
+                "def health():\n"
+                "    Path(__file__).with_name('marker').write_text('changed')\n"
+                "    return {'status': 'ok'}\n"
+            )
+        },
+        actions={"health": "product:health"},
+        context={"service": {"running": True}},
+    )
+
+    with pytest.raises(ContractInvalidError, match="baseline must fail"):
+        run_to_release_ready(
+            contract=_contract(),
+            repository_root=tmp_path,
+            workspace=tmp_path / "candidate",
+            run_id="mutation-is-not-red",
+            provider=PassingProvider(),
+            template=template,
+        )
 
 
 def test_missing_path_never_satisfies_a_null_assertion(tmp_path: Path) -> None:

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -163,6 +163,32 @@ class ScalarProvider:
         }
 
 
+class ImportedHelperProvider(PassingProvider):
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        response = dict(super().invoke(purpose=purpose, request=request))
+        if purpose == "code":
+            response["files"] = {
+                "helper.py": "STATUS = 'ok'\n",
+                "product.py": (
+                    "from helper import STATUS\n\ndef health():\n    return {'status': STATUS}\n"
+                ),
+            }
+        return response
+
+
+class PackageImportProvider(PassingProvider):
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        response = dict(super().invoke(purpose=purpose, request=request))
+        if purpose == "code":
+            response["files"] = {
+                "pkg/helper.py": "STATUS = 'ok'\n",
+                "pkg/product.py": (
+                    "from .helper import STATUS\n\ndef health():\n    return {'status': STATUS}\n"
+                ),
+            }
+        return response
+
+
 class MissingPathProvider:
     def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
         assert purpose == "code"
@@ -299,6 +325,40 @@ def test_coder_can_repair_a_candidate_syntax_failure(tmp_path: Path) -> None:
 
     assert result.state is RunState.RELEASE_READY
     assert result.attempts == 2
+
+
+def test_action_can_import_another_generated_workspace_module(tmp_path: Path) -> None:
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="workspace-import",
+        provider=ImportedHelperProvider(),
+    )
+
+    assert result.state is RunState.RELEASE_READY
+
+
+def test_dotted_action_target_preserves_package_relative_imports(tmp_path: Path) -> None:
+    template = Template(
+        version="barebones-1",
+        files={
+            "pkg/__init__.py": "",
+            "pkg/product.py": "def health():\n    return {'status': 'not_implemented'}\n",
+        },
+        actions={"health": "pkg.product:health"},
+        context={"service": {"running": True}},
+    )
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="package-relative-import",
+        provider=PackageImportProvider(),
+        template=template,
+    )
+
+    assert result.state is RunState.RELEASE_READY
 
 
 def test_candidate_action_timeout_becomes_a_repairable_finding(

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -10,6 +10,7 @@ import pytest
 
 from pmpe import barebones as barebones_module
 from pmpe.barebones import (
+    BudgetCaps,
     ContractInvalidError,
     RunState,
     Template,
@@ -284,6 +285,21 @@ class TrustedFixtureTamperingProvider:
             "request_digest": request["request_digest"],
             "files": {"tests/acceptance/expected.json": '{"status":"not_implemented"}\n'},
         }
+
+
+class TransientFixtureTamperingProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        attack = (
+            "import atexit\n"
+            "from pathlib import Path\n\n"
+            "fixture = Path('tests/acceptance/expected.json')\n"
+            "original = fixture.read_text()\n"
+            'fixture.write_text(\'{"status":"not_implemented"}\\n\')\n'
+            "atexit.register(fixture.write_text, original)\n\n"
+            "def health():\n    return {'status': 'not_implemented'}\n"
+        )
+        return {"request_digest": request["request_digest"], "files": {"product.py": attack}}
 
 
 class MeasureSyntaxRepairProvider:
@@ -961,6 +977,56 @@ def test_coder_cannot_rewrite_template_test_fixture(tmp_path: Path) -> None:
 
     assert result.state is RunState.HALTED
     assert result.cause == "CODER_MODIFIED_EVIDENCE"
+
+
+def test_transient_protected_fixture_write_is_never_release_ready(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health_fixture.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "import json\n"
+        "from pathlib import Path\n"
+        "from product import health\n\n"
+        "def test_health():\n"
+        "    expected = json.loads(Path('tests/acceptance/expected.json').read_text())\n"
+        "    assert health() == expected\n"
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health_fixture.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health_fixture.py::test_health",
+            ],
+        },
+    }
+    template = Template(
+        version="barebones-1",
+        files={
+            "product.py": "def health():\n    return {'status': 'not_implemented'}\n",
+            "tests/acceptance/expected.json": '{"status":"ok"}\n',
+        },
+        actions={"health": "product:health"},
+        context={"service": {"running": True}},
+    )
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="transient-fixture-tamper",
+        provider=TransientFixtureTamperingProvider(),
+        template=template,
+        budget=BudgetCaps(max_attempts=1),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "ATTEMPT_BUDGET_EXHAUSTED"
 
 
 def test_template_proof_is_digest_bound_and_executed(tmp_path: Path) -> None:

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -175,6 +175,15 @@ class TransientCrossCriterionMutationProvider:
         }
 
 
+class NonFiniteProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"product.py": "def health():\n    return {'status': float('nan')}\n"},
+        }
+
+
 class MeasureSyntaxRepairProvider:
     def __init__(self) -> None:
         self.calls = 0
@@ -494,6 +503,21 @@ class PytestShadowProvider:
         }
 
 
+class TestPackageInitializerProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        initializer = (
+            "import sys, types\n"
+            "fake = types.ModuleType('product')\n"
+            "fake.health = lambda: {'status': 'ok'}\n"
+            "sys.modules['product'] = fake\n"
+        )
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"tests/__init__.py": initializer},
+        }
+
+
 def test_coder_controlled_conftest_cannot_change_bound_test_outcome(tmp_path: Path) -> None:
     test_file = tmp_path / "tests/acceptance/test_health.py"
     test_file.parent.mkdir(parents=True)
@@ -562,6 +586,40 @@ def test_coder_cannot_shadow_the_bound_pytest_runner(tmp_path: Path) -> None:
     assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001"
 
 
+def test_coder_cannot_add_initializers_above_a_protected_test(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "from product import health\n\ndef test_health():\n    assert health()['status'] == 'ok'\n"
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="test-package-initializer",
+        provider=TestPackageInitializerProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "CODER_MODIFIED_EVIDENCE"
+
+
 def test_template_proof_is_digest_bound_and_executed(tmp_path: Path) -> None:
     template = Template(
         version="barebones-1",
@@ -604,6 +662,58 @@ def test_template_proof_is_digest_bound_and_executed(tmp_path: Path) -> None:
         repository_root=tmp_path,
         workspace=tmp_path / "candidate",
         run_id="template-proof",
+        provider=PassingProvider(),
+        template=template,
+    )
+
+    assert result.state is RunState.RELEASE_READY
+
+
+def test_contract_fully_satisfied_by_template_proofs_is_valid(tmp_path: Path) -> None:
+    template = Template(
+        version="barebones-1",
+        files={
+            "product.py": "def health():\n    return {'status': 'ok'}\n",
+            "tests/template/test_health.py": (
+                "from product import health\n\n"
+                "def test_health():\n"
+                "    assert health()['status'] == 'ok'\n"
+            ),
+        },
+        actions={},
+        context={},
+        proofs={
+            "template::health": TemplateTest(
+                "tests/template/test_health.py",
+                "test_health",
+                (
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "-q",
+                    "tests/template/test_health.py::test_health",
+                ),
+            )
+        },
+    )
+    contract = {
+        "functional_requirements": {"FR-001": {"statement": "health is ready"}},
+        "acceptance_criteria": {
+            "AC-001": {
+                "requirement_refs": ["FR-001"],
+                "satisfied_by_template": {
+                    "template_version": "barebones-1",
+                    "test_id": "template::health",
+                },
+            }
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="template-only-contract",
         provider=PassingProvider(),
         template=template,
     )
@@ -709,6 +819,19 @@ def test_missing_path_never_satisfies_a_null_assertion(tmp_path: Path) -> None:
 
     assert result.state is RunState.HALTED
     assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001"
+
+
+def test_non_finite_action_output_becomes_a_repair_finding(tmp_path: Path) -> None:
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="non-finite-action-output",
+        provider=NonFiniteProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:candidate"
 
 
 @pytest.mark.parametrize("operator,value", [("lte", 2), ("gt", 0)])

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -154,6 +154,15 @@ class ArrayBooleanProvider:
         }
 
 
+class ScalarProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"product.py": "def health():\n    return {'status': 1}\n"},
+        }
+
+
 class MissingPathProvider:
     def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
         assert purpose == "code"
@@ -936,6 +945,34 @@ def test_array_containment_uses_json_type_aware_equality(tmp_path: Path, operato
 
     expected = RunState.HALTED if operator == "contains" else RunState.RELEASE_READY
     assert result.state is expected
+
+
+@pytest.mark.parametrize("operator,value", [("not_contains", True), ("matches", "1")])
+def test_container_and_regex_operators_reject_wrong_actual_types(
+    tmp_path: Path, operator: str, value: object
+) -> None:
+    template = Template(
+        version="barebones-1",
+        files={"product.py": "def health():\n    return {'status': [True]}\n"},
+        actions={"health": "product:health"},
+        context={"service": {"running": True}},
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"]["then"][0] = {
+        "path": "result.status",
+        "operator": operator,
+        "value": value,
+    }
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id=f"wrong-actual-type-{operator}",
+        provider=ScalarProvider(),
+        template=template,
+    )
+
+    assert result.state is RunState.HALTED
 
 
 def test_non_assertion_mutation_cannot_satisfy_meaningful_red(tmp_path: Path) -> None:

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -144,6 +144,37 @@ class BooleanProvider:
         }
 
 
+class MissingPathProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"product.py": "def health():\n    return {}\n"},
+        }
+
+
+class TransientCrossCriterionMutationProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        second_original = "def second():\n    return {'status': 'broken'}\n"
+        restoring_second = (
+            "from pathlib import Path\n\n"
+            "def second():\n"
+            f"    Path(__file__).write_text({second_original!r})\n"
+            "    return {'status': 'ok'}\n"
+        )
+        first = (
+            "from pathlib import Path\n\n"
+            "def first():\n"
+            f"    Path(__file__).with_name('second.py').write_text({restoring_second!r})\n"
+            "    return {'status': 'ok'}\n"
+        )
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"first.py": first, "second.py": second_original},
+        }
+
+
 class MeasureSyntaxRepairProvider:
     def __init__(self) -> None:
         self.calls = 0
@@ -660,6 +691,89 @@ def test_json_equality_does_not_treat_boolean_as_number(tmp_path: Path) -> None:
 
     assert result.state is RunState.HALTED
     assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001"
+
+
+def test_missing_path_never_satisfies_a_null_assertion(tmp_path: Path) -> None:
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"]["then"][0] = {
+        "path": "result.status",
+        "operator": "is_null",
+    }
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="missing-path",
+        provider=MissingPathProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001"
+
+
+@pytest.mark.parametrize("operator,value", [("lte", 2), ("gt", 0)])
+def test_ordered_assertions_reject_boolean_results(
+    tmp_path: Path, operator: str, value: int
+) -> None:
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"]["then"][0] = {
+        "path": "result.status",
+        "operator": operator,
+        "value": value,
+    }
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id=f"ordered-boolean-{operator}",
+        provider=BooleanProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001"
+
+
+def test_each_criterion_verifies_a_fresh_exact_snapshot(tmp_path: Path) -> None:
+    template = Template(
+        version="barebones-1",
+        files={
+            "first.py": "def first():\n    return {'status': 'broken'}\n",
+            "second.py": "def second():\n    return {'status': 'broken'}\n",
+        },
+        actions={"first": "first:first", "second": "second:second"},
+        context={"ready": None},
+    )
+    contract = {
+        "functional_requirements": {
+            "FR-001": {"statement": "first works"},
+            "FR-002": {"statement": "second works"},
+        },
+        "acceptance_criteria": {
+            "AC-001": {
+                "requirement_refs": ["FR-001"],
+                "given": [{"path": "ready", "operator": "is_null"}],
+                "when": {"action": "first", "arguments": {}},
+                "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+            },
+            "AC-002": {
+                "requirement_refs": ["FR-002"],
+                "given": [{"path": "ready", "operator": "is_null"}],
+                "when": {"action": "second", "arguments": {}},
+                "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+            },
+        },
+    }
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="transient-cross-criterion-mutation",
+        provider=TransientCrossCriterionMutationProvider(),
+        template=template,
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001,AC-002"
 
 
 def test_release_manifest_digests_every_candidate_file(tmp_path: Path) -> None:

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -56,6 +56,25 @@ class StaleResponseProvider:
         return {"request_digest": "sha256:" + "0" * 64, "files": {}}
 
 
+class SyntaxRepairProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        if purpose == "advisory_review":
+            return {"request_digest": request["request_digest"], "summary": "advisory"}
+        self.calls += 1
+        content = (
+            "def health(:\n"
+            if self.calls == 1
+            else "def health() -> dict[str, str]:\n    return {'status': 'ok'}\n"
+        )
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"product.py": content},
+        }
+
+
 def test_e2_unsatisfiable_run_halts_with_exact_requirement(tmp_path: Path) -> None:
     result = run_to_release_ready(
         contract=_contract(),
@@ -80,6 +99,19 @@ def test_e3_stale_model_response_is_detected_as_drift(tmp_path: Path) -> None:
 
     assert result.state is RunState.HALTED
     assert result.cause == "MODEL_RESPONSE_UNBOUND"
+
+
+def test_coder_can_repair_a_candidate_syntax_failure(tmp_path: Path) -> None:
+    result = run_to_release_ready(
+        contract=_contract(),
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="syntax-repair",
+        provider=SyntaxRepairProvider(),
+    )
+
+    assert result.state is RunState.RELEASE_READY
+    assert result.attempts == 2
 
 
 def test_e4_contradiction_stops_before_build(tmp_path: Path) -> None:

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -256,6 +256,27 @@ class HumanTestRepairProvider:
         return {"request_digest": request["request_digest"], "files": files}
 
 
+class HumanTestSyntaxRepairProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        if purpose == "advisory_review":
+            return {"request_digest": request["request_digest"], "summary": "advisory"}
+        self.calls += 1
+        content = "VALUE =\n" if self.calls == 1 else "VALUE = 'ok'\n"
+        return {"request_digest": request["request_digest"], "files": {"config.py": content}}
+
+
+class TrustedHelperTamperingProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"tests/acceptance/helper.py": "def check():\n    return None\n"},
+        }
+
+
 class MeasureSyntaxRepairProvider:
     def __init__(self) -> None:
         self.calls = 0
@@ -794,6 +815,94 @@ def test_human_test_failure_allows_a_changed_product_repair(tmp_path: Path) -> N
 
     assert result.state is RunState.RELEASE_READY
     assert result.attempts == 2
+
+
+def test_human_test_execution_failure_preserves_repair_identity(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_config.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "from config import VALUE\n\ndef test_config():\n    assert VALUE == 'ok'\n"
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_config.py",
+            "node_id": "test_config",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_config.py::test_config",
+            ],
+        },
+    }
+    template = Template(
+        version="barebones-1",
+        files={"config.py": "VALUE = 'not_implemented'\n"},
+        actions={},
+        context={},
+    )
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="human-test-syntax-repair",
+        provider=HumanTestSyntaxRepairProvider(),
+        template=template,
+    )
+
+    assert result.state is RunState.RELEASE_READY
+    assert result.attempts == 2
+
+
+def test_coder_cannot_rewrite_template_test_support_module(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "from tests.acceptance.helper import check\n\ndef test_health():\n    check()\n"
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
+    }
+    template = Template(
+        version="barebones-1",
+        files={
+            "product.py": "def health():\n    return {'status': 'not_implemented'}\n",
+            "tests/acceptance/helper.py": (
+                "from product import health\n\n"
+                "def check():\n    assert health()['status'] == 'ok'\n"
+            ),
+        },
+        actions={"health": "product:health"},
+        context={"service": {"running": True}},
+    )
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="trusted-helper-tamper",
+        provider=TrustedHelperTamperingProvider(),
+        template=template,
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "CODER_MODIFIED_EVIDENCE"
 
 
 def test_template_proof_is_digest_bound_and_executed(tmp_path: Path) -> None:

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -277,6 +277,15 @@ class TrustedHelperTamperingProvider:
         }
 
 
+class TrustedFixtureTamperingProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"tests/acceptance/expected.json": '{"status":"not_implemented"}\n'},
+        }
+
+
 class MeasureSyntaxRepairProvider:
     def __init__(self) -> None:
         self.calls = 0
@@ -898,6 +907,55 @@ def test_coder_cannot_rewrite_template_test_support_module(tmp_path: Path) -> No
         workspace=tmp_path / "candidate",
         run_id="trusted-helper-tamper",
         provider=TrustedHelperTamperingProvider(),
+        template=template,
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "CODER_MODIFIED_EVIDENCE"
+
+
+def test_coder_cannot_rewrite_template_test_fixture(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health_fixture.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "import json\n"
+        "from pathlib import Path\n"
+        "from product import health\n\n"
+        "def test_health():\n"
+        "    expected = json.loads(Path('tests/acceptance/expected.json').read_text())\n"
+        "    assert health() == expected\n"
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health_fixture.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health_fixture.py::test_health",
+            ],
+        },
+    }
+    template = Template(
+        version="barebones-1",
+        files={
+            "product.py": "def health():\n    return {'status': 'not_implemented'}\n",
+            "tests/acceptance/expected.json": '{"status":"ok"}\n',
+        },
+        actions={"health": "product:health"},
+        context={"service": {"running": True}},
+    )
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="trusted-fixture-tamper",
+        provider=TrustedFixtureTamperingProvider(),
         template=template,
     )
 

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -121,6 +121,35 @@ def test_non_empty_workspace_is_rejected_before_evidence_is_created(
     assert not (tmp_path / ".pmpe" / "runs" / "occupied-workspace").exists()
 
 
+def test_workspace_cannot_overlap_evidence_storage(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository = Path(__file__).parents[2]
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    args = build_parser().parse_args(
+        [
+            "barebones",
+            str(repository / "examples/barebones/e1-contract.json"),
+            "--workspace",
+            str(workspace),
+            "--run-id",
+            "overlapping-roots",
+            "--repository-root",
+            str(workspace),
+            "--provider-command",
+            "provider",
+        ]
+    )
+
+    assert args.fn(args) == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["state"] == "HALTED"
+    assert output["cause"] == "CONTRACT_INVALID"
+    assert output["detail"] == "candidate workspace must not overlap evidence storage"
+    assert not (workspace / ".pmpe").exists()
+
+
 def test_command_provider_rejects_non_json_numeric_constants(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -39,14 +39,10 @@ def test_barebones_cli_runs_a_contract_without_cloud_services(
 def test_provider_timeout_is_a_classified_halt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    original_run = barebones_cmd.subprocess.run
+    def timeout(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("MODEL_PROVIDER_TIMEOUT")
 
-    def timeout(args: object, **kwargs: object) -> object:
-        if args == ("provider",):
-            raise barebones_cmd.subprocess.TimeoutExpired("provider", 1)
-        return original_run(args, **kwargs)  # type: ignore[call-overload]
-
-    monkeypatch.setattr(barebones_cmd.subprocess, "run", timeout)
+    monkeypatch.setattr(barebones_cmd, "_run_provider_command", timeout)
     repository = Path(__file__).parents[2]
     contract = json.loads((repository / "examples/barebones/e1-contract.json").read_text())
     result = run_to_release_ready(
@@ -158,9 +154,19 @@ def test_command_provider_rejects_non_json_numeric_constants(
         stdout = '{"request_digest":"bound","score":NaN}'
         stderr = ""
 
-    monkeypatch.setattr(barebones_cmd.subprocess, "run", lambda *args, **kwargs: Completed())
+    monkeypatch.setattr(barebones_cmd, "_run_provider_command", lambda *args, **kwargs: Completed())
 
     with pytest.raises(RuntimeError, match="malformed JSON"):
         CommandModelProvider("provider", 1).invoke(
             purpose="advisory_review", request={"request_digest": "bound"}
+        )
+
+
+def test_command_provider_output_is_bounded_before_capture() -> None:
+    with pytest.raises(RuntimeError, match="MODEL_PROVIDER_OUTPUT_LIMIT"):
+        barebones_cmd._run_provider_command(
+            (sys.executable, "-c", "import sys; sys.stdout.write('x' * 1000)"),
+            b"{}",
+            2,
+            output_limit_bytes=32,
         )

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -62,3 +62,30 @@ def test_provider_timeout_is_a_classified_halt(
     event = json.loads(result.evidence_path.read_text().splitlines()[-1])
     assert event["event_type"] == "halted"
     assert event["payload"]["cause"] == "MODEL_PROVIDER_TIMEOUT"
+
+
+def test_malformed_contract_is_reported_without_a_traceback(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    contract = tmp_path / "malformed.json"
+    contract.write_text("{not-json")
+    args = build_parser().parse_args(
+        [
+            "barebones",
+            str(contract),
+            "--workspace",
+            str(tmp_path / "candidate"),
+            "--run-id",
+            "malformed-contract",
+            "--repository-root",
+            str(tmp_path),
+            "--provider-command",
+            "provider",
+        ]
+    )
+
+    assert args.fn(args) == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["state"] == "HALTED"
+    assert output["cause"] == "CONTRACT_INVALID"
+    assert output["diagnostics"][0]["code"] == "MALFORMED_SOURCE"

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from pmpe.cli import build_parser
+
+
+def test_barebones_cli_runs_a_contract_without_cloud_services(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository = Path(__file__).parents[2]
+    args = build_parser().parse_args(
+        [
+            "barebones",
+            str(repository / "examples/barebones/e1-contract.json"),
+            "--workspace",
+            str(tmp_path / "candidate"),
+            "--run-id",
+            "cli-e1",
+            "--repository-root",
+            str(tmp_path),
+            "--provider-command",
+            f"{sys.executable} {repository / 'examples/barebones/e1-provider.py'}",
+        ]
+    )
+
+    assert args.fn(args) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["state"] == "RELEASE_READY"
+    assert output["model_calls"] == 2

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -151,14 +151,31 @@ def test_command_provider_rejects_non_json_numeric_constants(
 ) -> None:
     class Completed:
         returncode = 0
-        stdout = '{"request_digest":"bound","score":NaN}'
-        stderr = ""
+        stdout = b'{"request_digest":"bound","score":NaN}'
+        stderr = b""
 
     monkeypatch.setattr(barebones_cmd, "_run_provider_command", lambda *args, **kwargs: Completed())
 
     with pytest.raises(RuntimeError, match="malformed JSON"):
         CommandModelProvider("provider", 1).invoke(
             purpose="advisory_review", request={"request_digest": "bound"}
+        )
+
+
+def test_command_provider_rejects_malformed_utf8(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    completed = barebones_cmd.subprocess.CompletedProcess(
+        ("provider",),
+        0,
+        b'{"request_digest":"bound","file":"\xff"}',
+        b"",
+    )
+    monkeypatch.setattr(barebones_cmd, "_run_provider_command", lambda *args, **kwargs: completed)
+
+    with pytest.raises(RuntimeError, match="malformed JSON"):
+        CommandModelProvider("provider", 1).invoke(
+            purpose="code", request={"request_digest": "bound"}
         )
 
 

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -89,3 +89,19 @@ def test_malformed_contract_is_reported_without_a_traceback(
     assert output["state"] == "HALTED"
     assert output["cause"] == "CONTRACT_INVALID"
     assert output["diagnostics"][0]["code"] == "MALFORMED_SOURCE"
+
+
+def test_command_provider_rejects_non_json_numeric_constants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Completed:
+        returncode = 0
+        stdout = '{"request_digest":"bound","score":NaN}'
+        stderr = ""
+
+    monkeypatch.setattr(barebones_cmd.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    with pytest.raises(RuntimeError, match="malformed JSON"):
+        CommandModelProvider("provider", 1).invoke(
+            purpose="advisory_review", request={"request_digest": "bound"}
+        )

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 import pytest
 
-from pmpe.cli import build_parser
+from pmpe.barebones import RunState, run_to_release_ready
+from pmpe.cli import barebones_cmd, build_parser
+from pmpe.cli.barebones_cmd import CommandModelProvider
 
 
 def test_barebones_cli_runs_a_contract_without_cloud_services(
@@ -32,3 +34,31 @@ def test_barebones_cli_runs_a_contract_without_cloud_services(
     output = json.loads(capsys.readouterr().out)
     assert output["state"] == "RELEASE_READY"
     assert output["model_calls"] == 2
+
+
+def test_provider_timeout_is_a_classified_halt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original_run = barebones_cmd.subprocess.run
+
+    def timeout(args: object, **kwargs: object) -> object:
+        if args == ("provider",):
+            raise barebones_cmd.subprocess.TimeoutExpired("provider", 1)
+        return original_run(args, **kwargs)  # type: ignore[call-overload]
+
+    monkeypatch.setattr(barebones_cmd.subprocess, "run", timeout)
+    repository = Path(__file__).parents[2]
+    contract = json.loads((repository / "examples/barebones/e1-contract.json").read_text())
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="provider-timeout",
+        provider=CommandModelProvider("provider", 1),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "MODEL_PROVIDER_TIMEOUT"
+    event = json.loads(result.evidence_path.read_text().splitlines()[-1])
+    assert event["event_type"] == "halted"
+    assert event["payload"]["cause"] == "MODEL_PROVIDER_TIMEOUT"

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -91,6 +91,36 @@ def test_malformed_contract_is_reported_without_a_traceback(
     assert output["diagnostics"][0]["code"] == "MALFORMED_SOURCE"
 
 
+def test_non_empty_workspace_is_rejected_before_evidence_is_created(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository = Path(__file__).parents[2]
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    (workspace / "previous.txt").write_text("occupied")
+    args = build_parser().parse_args(
+        [
+            "barebones",
+            str(repository / "examples/barebones/e1-contract.json"),
+            "--workspace",
+            str(workspace),
+            "--run-id",
+            "occupied-workspace",
+            "--repository-root",
+            str(tmp_path),
+            "--provider-command",
+            "provider",
+        ]
+    )
+
+    assert args.fn(args) == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["state"] == "HALTED"
+    assert output["cause"] == "CONTRACT_INVALID"
+    assert output["detail"] == "candidate workspace must be empty"
+    assert not (tmp_path / ".pmpe" / "runs" / "occupied-workspace").exists()
+
+
 def test_command_provider_rejects_non_json_numeric_constants(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -31,7 +31,7 @@ def test_compiles_structured_given_when_then_without_model_interpretation(
         repository_root=tmp_path,
         registered_actions=frozenset({"health"}),
         template_version="barebones-1",
-        template_test_ids=frozenset(),
+        template_test_digests={},
     )
 
     assert plan.requirements == ("FR-001",)
@@ -55,7 +55,7 @@ def test_free_text_criterion_fails_before_build(tmp_path: Path) -> None:
             repository_root=tmp_path,
             registered_actions=frozenset({"health"}),
             template_version="barebones-1",
-            template_test_ids=frozenset(),
+            template_test_digests={},
         )
 
     assert failure.value.diagnostics[0].code == "CRITERION_FORM_INVALID"
@@ -85,7 +85,7 @@ def test_human_test_is_path_and_digest_bound(tmp_path: Path) -> None:
         repository_root=tmp_path,
         registered_actions=frozenset(),
         template_version="barebones-1",
-        template_test_ids=frozenset(),
+        template_test_digests={},
     )
 
     assert plan.criteria[0].human_test is not None
@@ -114,10 +114,40 @@ def test_human_test_missing_fails_before_build(tmp_path: Path) -> None:
             repository_root=tmp_path,
             registered_actions=frozenset(),
             template_version="barebones-1",
-            template_test_ids=frozenset(),
+            template_test_digests={},
         )
 
     assert failure.value.diagnostics[0].code == "HUMAN_TEST_MISSING"
+
+
+def test_human_test_rejects_dot_segments_and_requires_exact_node(tmp_path: Path) -> None:
+    test_path = tmp_path / "tests/acceptance/test_security.py"
+    test_path.parent.mkdir(parents=True)
+    test_path.write_text("def test_safe():\n    assert True\n")
+    for human_test in (
+        {
+            "path": "tests/acceptance/./test_security.py",
+            "node_id": "test_safe",
+            "command": ["pytest", "tests/acceptance/./test_security.py::test_safe"],
+        },
+        {
+            "path": "tests/acceptance/test_security.py",
+            "node_id": "test_safe",
+            "command": ["pytest", "tests/acceptance/test_security.py"],
+        },
+    ):
+        with pytest.raises(AcceptanceCompileError) as failure:
+            compile_acceptance_plan(
+                _contract({"requirement_refs": ["FR-001"], "human_test": human_test}),
+                repository_root=tmp_path,
+                registered_actions=frozenset(),
+                template_version="barebones-1",
+                template_test_digests={},
+            )
+        assert failure.value.diagnostics[0].code in {
+            "INVALID_HUMAN_TEST_REFERENCE",
+            "HUMAN_TEST_COMMAND_MISMATCH",
+        }
 
 
 def test_every_requirement_must_have_a_criterion(tmp_path: Path) -> None:
@@ -143,7 +173,7 @@ def test_every_requirement_must_have_a_criterion(tmp_path: Path) -> None:
             repository_root=tmp_path,
             registered_actions=frozenset(),
             template_version="barebones-1",
-            template_test_ids=frozenset({"template::health"}),
+            template_test_digests={"template::health": "sha256:" + "0" * 64},
         )
 
     assert any(
@@ -169,7 +199,7 @@ def test_template_pass_requires_exact_pinned_proof(tmp_path: Path) -> None:
             repository_root=tmp_path,
             registered_actions=frozenset(),
             template_version="barebones-1",
-            template_test_ids=frozenset({"template::health"}),
+            template_test_digests={"template::health": "sha256:" + "0" * 64},
         )
 
     assert failure.value.diagnostics[0].code == "TEMPLATE_PROOF_INVALID"
@@ -194,7 +224,44 @@ def test_contradictory_assertions_fail_at_compile_time(tmp_path: Path) -> None:
             repository_root=tmp_path,
             registered_actions=frozenset({"health"}),
             template_version="barebones-1",
-            template_test_ids=frozenset(),
+            template_test_digests={},
+        )
+
+    assert any(item.code == "CONTRADICTORY_ASSERTIONS" for item in failure.value.diagnostics)
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        (("gt", 5), ("lte", 5)),
+        (("gte", 6), ("lt", 6)),
+        (("eq", 5), ("gt", 5)),
+    ],
+)
+def test_ordered_contradictions_fail_at_compile_time(
+    tmp_path: Path,
+    left: tuple[str, int],
+    right: tuple[str, int],
+) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "given": [
+                {"path": "service.count", "operator": left[0], "value": left[1]},
+                {"path": "service.count", "operator": right[0], "value": right[1]},
+            ],
+            "when": {"action": "health", "arguments": {}},
+            "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset({"health"}),
+            template_version="barebones-1",
+            template_test_digests={},
         )
 
     assert any(item.code == "CONTRADICTORY_ASSERTIONS" for item in failure.value.diagnostics)
@@ -217,7 +284,7 @@ def test_measure_requires_a_registered_observation_source(tmp_path: Path) -> Non
             repository_root=tmp_path,
             registered_actions=frozenset(),
             template_version="barebones-1",
-            template_test_ids=frozenset(),
+            template_test_digests={},
         )
 
     assert failure.value.diagnostics[0].code == "MEASURE_INVALID"

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -407,6 +407,14 @@ def test_equal_contains_and_not_contains_are_contradictory(tmp_path: Path) -> No
             {"path": "service", "operator": "is_null"},
             {"path": "service.value", "operator": "eq", "value": "ok"},
         ],
+        [
+            {"path": "service", "operator": "not_contains", "value": "value"},
+            {"path": "service.value", "operator": "eq", "value": "ok"},
+        ],
+        [
+            {"path": "service", "operator": "eq", "value": {}},
+            {"path": "service.value", "operator": "eq", "value": "ok"},
+        ],
     ],
 )
 def test_multi_assertion_and_unary_type_contradictions_fail_before_build(

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -387,6 +387,10 @@ def test_equal_contains_and_not_contains_are_contradictory(tmp_path: Path) -> No
             {"path": "service.value", "operator": "is_false"},
             {"path": "service.value", "operator": "contains", "value": False},
         ],
+        [
+            {"path": "service.value", "operator": "gte", "value": 1},
+            {"path": "service.value", "operator": "gte", "value": "a"},
+        ],
     ],
 )
 def test_multi_assertion_and_unary_type_contradictions_fail_before_build(

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -395,6 +395,18 @@ def test_equal_contains_and_not_contains_are_contradictory(tmp_path: Path) -> No
             {"path": "service.value", "operator": "contains", "value": 1},
             {"path": "service.value", "operator": "matches", "value": ".*"},
         ],
+        [
+            {"path": "service.value", "operator": "gt", "value": 1},
+            {"path": "service.value", "operator": "matches", "value": ".*"},
+        ],
+        [
+            {"path": "service.value", "operator": "gt", "value": 1},
+            {"path": "service.value", "operator": "contains", "value": "x"},
+        ],
+        [
+            {"path": "service", "operator": "is_null"},
+            {"path": "service.value", "operator": "eq", "value": "ok"},
+        ],
     ],
 )
 def test_multi_assertion_and_unary_type_contradictions_fail_before_build(

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -342,6 +342,31 @@ def test_incompatible_equality_and_ordered_bounds_fail_at_compile_time(
     assert any(item.code == "CONTRADICTORY_ASSERTIONS" for item in failure.value.diagnostics)
 
 
+def test_equal_contains_and_not_contains_are_contradictory(tmp_path: Path) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "given": [
+                {"path": "service.values", "operator": "contains", "value": True},
+                {"path": "service.values", "operator": "not_contains", "value": True},
+            ],
+            "when": {"action": "health", "arguments": {}},
+            "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset({"health"}),
+            template_version="barebones-1",
+            template_test_digests={},
+        )
+
+    assert any(item.code == "CONTRADICTORY_ASSERTIONS" for item in failure.value.diagnostics)
+
+
 def test_measure_requires_a_registered_observation_source(tmp_path: Path) -> None:
     contract = _contract(
         {

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -426,3 +426,38 @@ def test_measure_requires_a_registered_observation_source(tmp_path: Path) -> Non
         )
 
     assert failure.value.diagnostics[0].code == "MEASURE_INVALID"
+
+
+@pytest.mark.parametrize(
+    ("operator", "value", "code"),
+    [
+        ("matches", "[", "INVALID_REGEX_ASSERTION"),
+        ("matches", 42, "INVALID_REGEX_ASSERTION"),
+        ("lte", None, "INVALID_ORDERED_ASSERTION_VALUE"),
+        ("gt", True, "INVALID_ORDERED_ASSERTION_VALUE"),
+    ],
+)
+def test_measure_assertion_operands_are_validated_before_build(
+    tmp_path: Path, operator: str, value: object, code: str
+) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "measure": "latency.p95_ms",
+            "operator": operator,
+            "value": value,
+            "sample": {"minimum": 20},
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset(),
+            template_version="barebones-1",
+            template_test_digests={},
+            registered_measures=frozenset({"latency.p95_ms"}),
+        )
+
+    assert any(item.code == code for item in failure.value.diagnostics)

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -305,6 +305,43 @@ def test_equality_and_unary_contradictions_fail_at_compile_time(
     assert any(item.code == "CONTRADICTORY_ASSERTIONS" for item in failure.value.diagnostics)
 
 
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        (("eq", "x"), ("gt", 1)),
+        (("eq", True), ("gt", 0)),
+        (("gt", "x"), ("lt", 1)),
+    ],
+)
+def test_incompatible_equality_and_ordered_bounds_fail_at_compile_time(
+    tmp_path: Path,
+    left: tuple[str, object],
+    right: tuple[str, object],
+) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "given": [
+                {"path": "service.value", "operator": left[0], "value": left[1]},
+                {"path": "service.value", "operator": right[0], "value": right[1]},
+            ],
+            "when": {"action": "health", "arguments": {}},
+            "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset({"health"}),
+            template_version="barebones-1",
+            template_test_digests={},
+        )
+
+    assert any(item.code == "CONTRADICTORY_ASSERTIONS" for item in failure.value.diagnostics)
+
+
 def test_measure_requires_a_registered_observation_source(tmp_path: Path) -> None:
     contract = _contract(
         {

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -391,6 +391,10 @@ def test_equal_contains_and_not_contains_are_contradictory(tmp_path: Path) -> No
             {"path": "service.value", "operator": "gte", "value": 1},
             {"path": "service.value", "operator": "gte", "value": "a"},
         ],
+        [
+            {"path": "service.value", "operator": "contains", "value": 1},
+            {"path": "service.value", "operator": "matches", "value": ".*"},
+        ],
     ],
 )
 def test_multi_assertion_and_unary_type_contradictions_fail_before_build(

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -267,6 +267,44 @@ def test_ordered_contradictions_fail_at_compile_time(
     assert any(item.code == "CONTRADICTORY_ASSERTIONS" for item in failure.value.diagnostics)
 
 
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        (("eq", True), ("is_false", None)),
+        (("eq", None), ("not_null", None)),
+        (("ne", True), ("is_true", None)),
+        (("is_null", None), ("ne", None)),
+    ],
+)
+def test_equality_and_unary_contradictions_fail_at_compile_time(
+    tmp_path: Path,
+    left: tuple[str, object],
+    right: tuple[str, object],
+) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "given": [
+                {"path": "service.value", "operator": left[0], "value": left[1]},
+                {"path": "service.value", "operator": right[0], "value": right[1]},
+            ],
+            "when": {"action": "health", "arguments": {}},
+            "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset({"health"}),
+            template_version="barebones-1",
+            template_test_digests={},
+        )
+
+    assert any(item.code == "CONTRADICTORY_ASSERTIONS" for item in failure.value.diagnostics)
+
+
 def test_measure_requires_a_registered_observation_source(tmp_path: Path) -> None:
     contract = _contract(
         {

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -367,6 +367,44 @@ def test_equal_contains_and_not_contains_are_contradictory(tmp_path: Path) -> No
     assert any(item.code == "CONTRADICTORY_ASSERTIONS" for item in failure.value.diagnostics)
 
 
+@pytest.mark.parametrize(
+    ("assertion", "code"),
+    [
+        ({"path": "service.value", "operator": "eq"}, "MISSING_ASSERTION_VALUE"),
+        (
+            {"path": "service.value", "operator": "matches", "value": "["},
+            "INVALID_REGEX_ASSERTION",
+        ),
+        (
+            {"path": "service.value", "operator": "matches", "value": 1},
+            "INVALID_REGEX_ASSERTION",
+        ),
+    ],
+)
+def test_binary_assertion_operands_are_validated_before_build(
+    tmp_path: Path, assertion: dict[str, object], code: str
+) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "given": [assertion],
+            "when": {"action": "health", "arguments": {}},
+            "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset({"health"}),
+            template_version="barebones-1",
+            template_test_digests={},
+        )
+
+    assert any(item.code == code for item in failure.value.diagnostics)
+
+
 def test_measure_requires_a_registered_observation_source(tmp_path: Path) -> None:
     contract = _contract(
         {

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pmpe.contracts.acceptance import AcceptanceCompileError, compile_acceptance_plan
+
+
+def _contract(criterion: dict[str, object]) -> dict[str, object]:
+    return {
+        "functional_requirements": {"FR-001": {"statement": "health reports ok"}},
+        "acceptance_criteria": {"AC-001": criterion},
+    }
+
+
+def test_compiles_structured_given_when_then_without_model_interpretation(
+    tmp_path: Path,
+) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "given": [{"path": "service.running", "operator": "eq", "value": True}],
+            "when": {"action": "health", "arguments": {}},
+            "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+        }
+    )
+
+    plan = compile_acceptance_plan(
+        contract,
+        repository_root=tmp_path,
+        registered_actions=frozenset({"health"}),
+        template_version="barebones-1",
+        template_test_ids=frozenset(),
+    )
+
+    assert plan.requirements == ("FR-001",)
+    assert plan.tasks[0].requirement_id == "FR-001"
+    assert plan.criteria[0].when is not None
+    assert plan.criteria[0].when.action == "health"
+    assert plan.plan_digest.startswith("sha256:")
+
+
+def test_free_text_criterion_fails_before_build(tmp_path: Path) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "criterion": "Given a service, when health runs, then status is ok.",
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset({"health"}),
+            template_version="barebones-1",
+            template_test_ids=frozenset(),
+        )
+
+    assert failure.value.diagnostics[0].code == "CRITERION_FORM_INVALID"
+
+
+def test_human_test_is_path_and_digest_bound(tmp_path: Path) -> None:
+    test_path = tmp_path / "tests" / "acceptance" / "test_security.py"
+    test_path.parent.mkdir(parents=True)
+    test_path.write_text("def test_safe():\n    assert True\n")
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "human_test": {
+                "path": "tests/acceptance/test_security.py",
+                "node_id": "test_safe",
+                "command": [
+                    "pytest",
+                    "-q",
+                    "tests/acceptance/test_security.py::test_safe",
+                ],
+            },
+        }
+    )
+
+    plan = compile_acceptance_plan(
+        contract,
+        repository_root=tmp_path,
+        registered_actions=frozenset(),
+        template_version="barebones-1",
+        template_test_ids=frozenset(),
+    )
+
+    assert plan.criteria[0].human_test is not None
+    assert plan.criteria[0].human_test.file_digest.startswith("sha256:")
+
+
+def test_human_test_missing_fails_before_build(tmp_path: Path) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "human_test": {
+                "path": "tests/acceptance/test_missing.py",
+                "node_id": "test_missing",
+                "command": [
+                    "pytest",
+                    "-q",
+                    "tests/acceptance/test_missing.py::test_missing",
+                ],
+            },
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset(),
+            template_version="barebones-1",
+            template_test_ids=frozenset(),
+        )
+
+    assert failure.value.diagnostics[0].code == "HUMAN_TEST_MISSING"
+
+
+def test_every_requirement_must_have_a_criterion(tmp_path: Path) -> None:
+    contract = {
+        "functional_requirements": {
+            "FR-001": {"statement": "health reports ok"},
+            "FR-002": {"statement": "config is safe"},
+        },
+        "acceptance_criteria": {
+            "AC-001": {
+                "requirement_refs": ["FR-001"],
+                "satisfied_by_template": {
+                    "template_version": "barebones-1",
+                    "test_id": "template::health",
+                },
+            }
+        },
+    }
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset(),
+            template_version="barebones-1",
+            template_test_ids=frozenset({"template::health"}),
+        )
+
+    assert any(
+        item.code == "REQUIREMENT_UNCOVERED" and item.subject_id == "FR-002"
+        for item in failure.value.diagnostics
+    )
+
+
+def test_template_pass_requires_exact_pinned_proof(tmp_path: Path) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "satisfied_by_template": {
+                "template_version": "old-template",
+                "test_id": "template::health",
+            },
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset(),
+            template_version="barebones-1",
+            template_test_ids=frozenset({"template::health"}),
+        )
+
+    assert failure.value.diagnostics[0].code == "TEMPLATE_PROOF_INVALID"
+
+
+def test_contradictory_assertions_fail_at_compile_time(tmp_path: Path) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "given": [
+                {"path": "service.running", "operator": "eq", "value": True},
+                {"path": "service.running", "operator": "eq", "value": False},
+            ],
+            "when": {"action": "health", "arguments": {}},
+            "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset({"health"}),
+            template_version="barebones-1",
+            template_test_ids=frozenset(),
+        )
+
+    assert any(item.code == "CONTRADICTORY_ASSERTIONS" for item in failure.value.diagnostics)
+
+
+def test_measure_requires_a_registered_observation_source(tmp_path: Path) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "measure": "latency.p95_ms",
+            "operator": "lte",
+            "value": 200,
+            "sample": {"minimum": 20},
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset(),
+            template_version="barebones-1",
+            template_test_ids=frozenset(),
+        )
+
+    assert failure.value.diagnostics[0].code == "MEASURE_INVALID"

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -368,6 +368,52 @@ def test_equal_contains_and_not_contains_are_contradictory(tmp_path: Path) -> No
 
 
 @pytest.mark.parametrize(
+    "assertions",
+    [
+        [
+            {"path": "service.value", "operator": "gte", "value": 5},
+            {"path": "service.value", "operator": "lte", "value": 5},
+            {"path": "service.value", "operator": "ne", "value": 5},
+        ],
+        [
+            {"path": "service.value", "operator": "is_true"},
+            {"path": "service.value", "operator": "gt", "value": 0},
+        ],
+        [
+            {"path": "service.value", "operator": "is_null"},
+            {"path": "service.value", "operator": "matches", "value": ".*"},
+        ],
+        [
+            {"path": "service.value", "operator": "is_false"},
+            {"path": "service.value", "operator": "contains", "value": False},
+        ],
+    ],
+)
+def test_multi_assertion_and_unary_type_contradictions_fail_before_build(
+    tmp_path: Path, assertions: list[dict[str, object]]
+) -> None:
+    contract = _contract(
+        {
+            "requirement_refs": ["FR-001"],
+            "given": assertions,
+            "when": {"action": "health", "arguments": {}},
+            "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+        }
+    )
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset({"health"}),
+            template_version="barebones-1",
+            template_test_digests={},
+        )
+
+    assert any(item.code == "CONTRADICTORY_ASSERTIONS" for item in failure.value.diagnostics)
+
+
+@pytest.mark.parametrize(
     ("assertion", "code"),
     [
         ({"path": "service.value", "operator": "eq"}, "MISSING_ASSERTION_VALUE"),

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -64,6 +64,30 @@ def test_candidate_execution_fails_closed_without_os_sandbox(
         )
 
 
+def test_candidate_output_is_bounded_outside_the_parent_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        barebones.shutil,
+        "which",
+        lambda name, path=None: f"/usr/bin/{name}",
+    )
+
+    def oversized(argv: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        kwargs["stdout"].write(b"x" * (barebones._CANDIDATE_OUTPUT_LIMIT_BYTES + 1))  # type: ignore[union-attr]
+        return subprocess.CompletedProcess(argv, 0, b"", b"")  # type: ignore[arg-type]
+
+    monkeypatch.setattr(barebones.subprocess, "run", oversized)
+
+    with pytest.raises(ContractInvalidError, match="output exceeded limit"):
+        BubblewrapCandidateSandbox().run(
+            tmp_path,
+            ("/usr/bin/python3", "-V"),
+            timeout_seconds=2,
+            environment={},
+        )
+
+
 @pytest.mark.skipif(
     os.environ.get("PMPE_TEST_REAL_SANDBOX") != "true",
     reason="requires the dedicated CI namespace runtime",

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from pmpe import barebones
+from pmpe.barebones import BubblewrapCandidateSandbox, ContractInvalidError
+
+
+def test_default_candidate_sandbox_removes_host_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    observed: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        barebones.shutil,
+        "which",
+        lambda name, path=None: f"/usr/bin/{name}",
+    )
+
+    def completed(argv: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed["argv"] = argv
+        observed["environment"] = kwargs["env"]  # type: ignore[index]
+        return subprocess.CompletedProcess(argv, 0, "{}", "")  # type: ignore[arg-type]
+
+    monkeypatch.setattr(barebones.subprocess, "run", completed)
+    sandbox = BubblewrapCandidateSandbox()
+    sandbox.run(
+        workspace,
+        ("/usr/bin/python3", "-V"),
+        timeout_seconds=2,
+        environment={"PATH": "/usr/bin:/bin", "HOME": "/tmp/home"},
+    )
+
+    argv = observed["argv"]
+    assert isinstance(argv, list)
+    assert "--unshare-all" in argv
+    assert "--clearenv" in argv
+    assert ["--ro-bind", str(workspace), "/workspace"] == argv[
+        argv.index(str(workspace)) - 1 : argv.index(str(workspace)) + 2
+    ]
+    assert not {"/root", "/home"}.intersection(argv)
+    assert observed["environment"] == {"LC_ALL": "C", "PATH": "/usr/local/bin:/usr/bin:/bin"}
+
+
+def test_candidate_execution_fails_closed_without_os_sandbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(barebones.shutil, "which", lambda *args, **kwargs: None)
+
+    with pytest.raises(ContractInvalidError, match="sandbox is unavailable"):
+        BubblewrapCandidateSandbox().run(
+            tmp_path,
+            ("/usr/bin/python3", "-V"),
+            timeout_seconds=2,
+            environment={},
+        )
+
+
+@pytest.mark.skipif(os.environ.get("CI") != "true", reason="requires the CI namespace runtime")
+def test_real_candidate_sandbox_has_no_host_credentials_network_or_write_access(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    (workspace / "product.py").write_text("VALUE = 1\n")
+    monkeypatch.setenv("PMPE_PLANTED_HOST_SECRET", "must-not-cross")
+    program = (
+        "import json, os, pathlib, socket\n"
+        "result = {'secret': os.environ.get('PMPE_PLANTED_HOST_SECRET')}\n"
+        "try:\n"
+        " pathlib.Path('/workspace/product.py').write_text('changed')\n"
+        " result['write'] = True\n"
+        "except OSError:\n"
+        " result['write'] = False\n"
+        "try:\n"
+        " socket.create_connection(('1.1.1.1', 53), timeout=0.1)\n"
+        " result['network'] = True\n"
+        "except OSError:\n"
+        " result['network'] = False\n"
+        "print(json.dumps(result, sort_keys=True))\n"
+    )
+
+    completed = BubblewrapCandidateSandbox().run(
+        workspace,
+        (sys.executable, "-I", "-B", "-c", program),
+        timeout_seconds=5,
+        environment={"HOME": "/tmp/home", "PATH": "/usr/local/bin:/usr/bin:/bin"},
+    )
+
+    assert completed.returncode == 0
+    assert json.loads(completed.stdout) == {"network": False, "secret": None, "write": False}
+    assert (workspace / "product.py").read_text() == "VALUE = 1\n"

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -43,6 +43,7 @@ def test_default_candidate_sandbox_removes_host_authority(
     assert isinstance(argv, list)
     assert "--unshare-all" in argv
     assert "--clearenv" in argv
+    assert f"--fsize={64 * 1024 * 1024}" in argv
     assert ["--ro-bind", str(workspace), "/workspace"] == argv[
         argv.index(str(workspace)) - 1 : argv.index(str(workspace)) + 2
     ]

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -64,7 +64,10 @@ def test_candidate_execution_fails_closed_without_os_sandbox(
         )
 
 
-@pytest.mark.skipif(os.environ.get("CI") != "true", reason="requires the CI namespace runtime")
+@pytest.mark.skipif(
+    os.environ.get("PMPE_TEST_REAL_SANDBOX") != "true",
+    reason="requires the dedicated CI namespace runtime",
+)
 def test_real_candidate_sandbox_has_no_host_credentials_network_or_write_access(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_evidence_ledger.py
+++ b/tests/unit/test_evidence_ledger.py
@@ -22,6 +22,8 @@ def test_ledger_writes_only_the_frozen_two_path_shapes(tmp_path: Path) -> None:
 
     assert ledger.events_path == tmp_path / ".pmpe/runs/run-001/events.jsonl"
     assert (tmp_path / ".pmpe/blobs" / blob.removeprefix("sha256:")).is_file()
+    assert event["schema_version"] == "1.0.0"
+    assert event["run_id"] == "run-001"
     assert tuple(ledger.verify()) == (event,)
 
 

--- a/tests/unit/test_evidence_ledger.py
+++ b/tests/unit/test_evidence_ledger.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pmpe.contracts.canonical import canonical_digest
+from pmpe.evidence.ledger import EvidenceIntegrityError, EvidenceLedger
+
+
+def test_ledger_writes_only_the_frozen_two_path_shapes(tmp_path: Path) -> None:
+    ledger = EvidenceLedger(tmp_path, "run-001")
+    blob = ledger.put_blob(b"verification output")
+    event = ledger.append(
+        event_type="verification_completed",
+        state="VERIFYING",
+        subject_digest=canonical_digest({"candidate": 1}),
+        blob_digests=(blob,),
+        payload={"passed": True},
+    )
+
+    assert ledger.events_path == tmp_path / ".pmpe/runs/run-001/events.jsonl"
+    assert (tmp_path / ".pmpe/blobs" / blob.removeprefix("sha256:")).is_file()
+    assert tuple(ledger.verify()) == (event,)
+
+
+def test_resume_continues_the_existing_hash_chain(tmp_path: Path) -> None:
+    subject = canonical_digest({"candidate": 1})
+    first = EvidenceLedger(tmp_path, "run-001")
+    first_event = first.append(event_type="validated", state="VALIDATED", subject_digest=subject)
+    resumed = EvidenceLedger(tmp_path, "run-001")
+    second_event = resumed.append(event_type="building", state="BUILDING", subject_digest=subject)
+
+    assert second_event["sequence"] == 2
+    assert second_event["previous_digest"] == first_event["event_digest"]
+
+
+def test_event_tampering_is_detected(tmp_path: Path) -> None:
+    ledger = EvidenceLedger(tmp_path, "run-001")
+    ledger.append(
+        event_type="validated",
+        state="VALIDATED",
+        subject_digest=canonical_digest({"candidate": 1}),
+    )
+    event = json.loads(ledger.events_path.read_text())
+    event["state"] = "RELEASE_READY"
+    ledger.events_path.write_text(json.dumps(event, separators=(",", ":")) + "\n")
+
+    with pytest.raises(EvidenceIntegrityError):
+        tuple(ledger.verify())
+
+
+def test_blob_tampering_is_detected(tmp_path: Path) -> None:
+    ledger = EvidenceLedger(tmp_path, "run-001")
+    blob = ledger.put_blob(b"original")
+    ledger.append(
+        event_type="verified",
+        state="VERIFYING",
+        subject_digest=canonical_digest({"candidate": 1}),
+        blob_digests=(blob,),
+    )
+    (ledger.blobs_directory / blob.removeprefix("sha256:")).write_bytes(b"changed")
+
+    with pytest.raises(EvidenceIntegrityError):
+        tuple(ledger.verify())

--- a/tests/unit/test_evidence_ledger.py
+++ b/tests/unit/test_evidence_ledger.py
@@ -31,11 +31,22 @@ def test_resume_continues_the_existing_hash_chain(tmp_path: Path) -> None:
     subject = canonical_digest({"candidate": 1})
     first = EvidenceLedger(tmp_path, "run-001")
     first_event = first.append(event_type="validated", state="VALIDATED", subject_digest=subject)
-    resumed = EvidenceLedger(tmp_path, "run-001")
+    resumed = EvidenceLedger(tmp_path, "run-001", resume=True)
     second_event = resumed.append(event_type="building", state="BUILDING", subject_digest=subject)
 
     assert second_event["sequence"] == 2
     assert second_event["previous_digest"] == first_event["event_digest"]
+
+
+def test_completed_run_id_cannot_be_reused_or_resumed(tmp_path: Path) -> None:
+    subject = canonical_digest({"candidate": 1})
+    ledger = EvidenceLedger(tmp_path, "run-001")
+    ledger.append(event_type="released", state="RELEASE_READY", subject_digest=subject)
+
+    with pytest.raises(EvidenceIntegrityError, match="already has"):
+        EvidenceLedger(tmp_path, "run-001")
+    with pytest.raises(EvidenceIntegrityError, match="terminal"):
+        EvidenceLedger(tmp_path, "run-001", resume=True)
 
 
 def test_event_tampering_is_detected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Outcome

Implements the frozen, cloud-independent Engineering OS core:

- deterministic acceptance compiler with compile-time coverage, general type-domain and ancestor/descendant contradiction detection, registered actions/measures, a human-test escape hatch, and pinned template/evidence digests
- one bounded Coder path behind the sole `ModelProvider` adapter
- meaningful-RED baseline, bounded repair loop, repeat-finding halt, local security gates, advisory review, and stop at `RELEASE_READY`
- plain hash-chained evidence at `.pmpe/runs/<id>/events.jsonl` plus content-addressed `.pmpe/blobs/<sha256>`
- candidate/evidence root separation and protected test/fixture integrity
- OS-isolated candidate execution with no network, host credentials, writable candidate snapshot, or unbounded parent output capture
- bounded command-provider stream capture with strict raw-byte JSON admission
- CLI command and deterministic E1 fixture; no AWS, deployment, GitHub, or cloud runtime dependency

## Evals

- E1 success → `RELEASE_READY`
- E2 unsatisfiable → `HALTED` with the exact criterion
- E3 stale prompt binding → `MODEL_RESPONSE_UNBOUND`
- E4 contradiction → compile-time `CONTRACT_INVALID`
- E5 repeat → byte-identical evidence

The focused suite also covers human-test execution identity, trusted helpers, Coder tampering, package imports and dependency repair, workspace/evidence separation, candidate and provider output bounds, strict UTF-8/JSON admission, execution timeouts, candidate mutation, exact assertion semantics, and release-manifest completeness.

## Verification

- focused compiler/runtime/CLI/eval suite: 97 passed, 1 local namespace-only skip
- dedicated real candidate-isolation smoke: passed on Python 3.11 and 3.12
- Ruff format and lint across the repository: pass
- strict mypy across 177 source files: pass
- Bandit high-severity scan: pass
- exact-head GitHub CI: all 13 jobs passed on run [#818](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32587823069), including Python 3.11/3.12 unit, integration, E2E, and real isolation jobs
- exact-head Codex review: no major issues on `13642bd248`
- all inline findings fixed, answered, and resolved; zero unresolved review threads

## Scope boundary

The core ends at `RELEASE_READY`; a human owns publication. Physical deletion of classified legacy packages follows the committed deletion inventory only after consumer migration. This PR completes issue #140's scoped core without making legacy paths a runtime dependency.

Refs #140.