### PR TITLE
Add a reference real-model provider

### DIFF
--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -1,0 +1,51 @@
+# Reference real-model provider
+
+Issue: #143
+
+`examples/barebones/openai-responses-provider.py` is the first documented real-model
+adapter for the frozen `ModelProvider` boundary. It uses the OpenAI Responses API,
+strict Structured Outputs, and `store: false`.
+
+Official references:
+
+- [Structured Outputs](https://developers.openai.com/api/docs/guides/structured-outputs)
+- [Responses API migration and storage](https://developers.openai.com/api/docs/guides/migrate-to-responses)
+
+The script uses only the Python standard library. It is an adapter example, not a
+mandatory OpenAI dependency in `pmpe`.
+
+## Environment
+
+```bash
+export OPENAI_API_KEY='<set outside the repository>'
+export PMPE_OPENAI_MODEL='<an available structured-output-capable model>'
+```
+
+`PMPE_OPENAI_BASE_URL` is optional and defaults to `https://api.openai.com/v1`.
+Do not put credentials in a contract, provider command, candidate workspace, shell
+history, evidence directory, or committed file.
+
+## Run
+
+```bash
+pmpe barebones examples/barebones/e1-contract.json \
+  --workspace /tmp/pmpe-real-e1-candidate \
+  --run-id real-e1 \
+  --repository-root /tmp/pmpe-real-e1-evidence \
+  --provider-command "python examples/barebones/openai-responses-provider.py"
+```
+
+The provider records non-secret metadata returned through the protocol: provider,
+resolved model name, prompt version, response id, and usage. The core still owns the
+request digest, output limits, candidate-path validation, deterministic verification,
+and evidence chain.
+
+## Evidence rule
+
+The presence of this script does not prove a real-model run. Promotion requires a
+recorded run whose contract, plan, provider metadata, attempts, token usage, elapsed
+time, terminal state, candidate manifest, and evidence chain are published together.
+
+The current example contract is structurally valid but remains a deliberately tiny
+health-action fixture. A successful run is E1 evidence, not breadth or platform
+evidence.

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -21,7 +21,8 @@ export OPENAI_API_KEY='<set outside the repository>'
 export PMPE_OPENAI_MODEL='<an available structured-output-capable model>'
 ```
 
-`PMPE_OPENAI_BASE_URL` is optional and defaults to `https://api.openai.com/v1`.
+The reference adapter sends credentials only to
+`https://api.openai.com/v1/responses`; the endpoint is intentionally not configurable.
 Do not put credentials in a contract, provider command, candidate workspace, shell
 history, evidence directory, or committed file.
 

--- a/examples/barebones/openai-responses-provider.py
+++ b/examples/barebones/openai-responses-provider.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Reference real-model provider for the bare-bones PMPE protocol.
+
+This adapter uses the OpenAI Responses API with Structured Outputs. It reads one
+PMPE provider request from stdin and writes one PMPE provider response to stdout.
+Credentials are read from the environment and are never copied into the response.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Mapping
+from typing import Any, NoReturn
+
+_DEFAULT_BASE_URL = "https://api.openai.com/v1"
+_PROMPT_VERSION = "pmpe-barebones-openai-v1"
+_OUTPUT_LIMIT_BYTES = 1_000_000
+
+
+def _fail(message: str) -> NoReturn:
+    print(message, file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _required_environment(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        _fail(f"{name} is required")
+    return value
+
+
+def _schema(purpose: str) -> dict[str, Any]:
+    if purpose == "code":
+        return {
+            "type": "object",
+            "properties": {
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "content": {"type": "string"},
+                        },
+                        "required": ["path", "content"],
+                        "additionalProperties": False,
+                    },
+                }
+            },
+            "required": ["files"],
+            "additionalProperties": False,
+        }
+    if purpose == "advisory_review":
+        return {
+            "type": "object",
+            "properties": {"summary": {"type": "string"}},
+            "required": ["summary"],
+            "additionalProperties": False,
+        }
+    _fail(f"unsupported provider purpose: {purpose}")
+
+
+def _instructions(purpose: str) -> str:
+    shared = (
+        "You are the single bounded Coder behind PMPE's deterministic compiler. "
+        "The request contains a contract, compiled plan, current candidate files, "
+        "and exact verifier findings. Deterministic verification—not your opinion—"
+        "decides whether the candidate passes. Never modify tests, fixtures, or "
+        "evidence. Do not propose commands or dependencies. Return only the requested "
+        "structured output."
+    )
+    if purpose == "code":
+        return shared + (
+            " Return the smallest set of complete UTF-8 file replacements that fixes "
+            "the exact findings. Paths must be repository-relative."
+        )
+    return shared + (
+        " Deterministic checks have already passed. Return one concise, non-blocking "
+        "human advisory summary; do not claim deployment or production readiness."
+    )
+
+
+def _request_body(message: Mapping[str, Any], model: str) -> dict[str, Any]:
+    purpose = message.get("purpose")
+    request = message.get("request")
+    if not isinstance(purpose, str) or not isinstance(request, Mapping):
+        _fail("stdin must contain purpose and request objects")
+    return {
+        "model": model,
+        "store": False,
+        "instructions": _instructions(purpose),
+        "input": json.dumps(request, sort_keys=True, separators=(",", ":")),
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "pmpe_provider_response",
+                "strict": True,
+                "schema": _schema(purpose),
+            }
+        },
+    }
+
+
+def _post(body: Mapping[str, Any], *, api_key: str, base_url: str) -> Mapping[str, Any]:
+    payload = json.dumps(body, sort_keys=True, separators=(",", ":")).encode()
+    request = urllib.request.Request(
+        base_url.rstrip("/") + "/responses",
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:  # noqa: S310
+            raw = response.read(_OUTPUT_LIMIT_BYTES + 1)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read(8192).decode("utf-8", errors="replace")
+        _fail(f"OpenAI Responses API returned HTTP {exc.code}: {detail}")
+    except urllib.error.URLError as exc:
+        _fail(f"OpenAI Responses API request failed: {exc.reason}")
+    if len(raw) > _OUTPUT_LIMIT_BYTES:
+        _fail("OpenAI Responses API output exceeded the provider limit")
+    try:
+        parsed = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        _fail("OpenAI Responses API returned malformed JSON")
+    if not isinstance(parsed, Mapping):
+        _fail("OpenAI Responses API returned a non-object response")
+    return parsed
+
+
+def _output_text(response: Mapping[str, Any]) -> str:
+    texts: list[str] = []
+    output = response.get("output")
+    if not isinstance(output, list):
+        _fail("OpenAI response has no output items")
+    for item in output:
+        if not isinstance(item, Mapping) or item.get("type") != "message":
+            continue
+        content = item.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if isinstance(part, Mapping) and part.get("type") == "output_text":
+                text = part.get("text")
+                if isinstance(text, str):
+                    texts.append(text)
+            elif isinstance(part, Mapping) and part.get("type") == "refusal":
+                _fail("model refused the provider request")
+    if len(texts) != 1:
+        _fail("OpenAI response must contain exactly one output_text item")
+    return texts[0]
+
+
+def _provider_response(
+    message: Mapping[str, Any], api_response: Mapping[str, Any], model: str
+) -> dict[str, Any]:
+    request = message.get("request")
+    purpose = message.get("purpose")
+    assert isinstance(request, Mapping)
+    assert isinstance(purpose, str)
+    request_digest = request.get("request_digest")
+    if not isinstance(request_digest, str):
+        _fail("provider request is missing request_digest")
+    try:
+        generated = json.loads(_output_text(api_response))
+    except json.JSONDecodeError:
+        _fail("structured model output was not valid JSON")
+    if not isinstance(generated, Mapping):
+        _fail("structured model output must be an object")
+
+    usage = api_response.get("usage")
+    metadata = {
+        "provider": "openai-responses",
+        "model": str(api_response.get("model") or model),
+        "prompt_version": _PROMPT_VERSION,
+        "response_id": str(api_response.get("id") or ""),
+    }
+    if purpose == "code":
+        entries = generated.get("files")
+        if not isinstance(entries, list):
+            _fail("structured model output is missing files")
+        files: dict[str, str] = {}
+        for entry in entries:
+            if not isinstance(entry, Mapping):
+                _fail("each generated file must be an object")
+            path, content = entry.get("path"), entry.get("content")
+            if not isinstance(path, str) or not isinstance(content, str) or path in files:
+                _fail("generated file paths must be unique strings with string content")
+            files[path] = content
+        result: dict[str, Any] = {"request_digest": request_digest, "files": files}
+    else:
+        summary = generated.get("summary")
+        if not isinstance(summary, str):
+            _fail("structured model output is missing summary")
+        result = {"request_digest": request_digest, "summary": summary}
+    result["provider_metadata"] = metadata
+    if isinstance(usage, Mapping):
+        result["usage"] = dict(usage)
+    return result
+
+
+def main() -> int:
+    try:
+        message = json.load(sys.stdin)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        _fail("stdin must be one UTF-8 JSON object")
+    if not isinstance(message, Mapping):
+        _fail("stdin must be one JSON object")
+    model = _required_environment("PMPE_OPENAI_MODEL")
+    api_key = _required_environment("OPENAI_API_KEY")
+    base_url = os.environ.get("PMPE_OPENAI_BASE_URL", _DEFAULT_BASE_URL)
+    body = _request_body(message, model)
+    api_response = _post(body, api_key=api_key, base_url=base_url)
+    json.dump(_provider_response(message, api_response, model), sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/barebones/openai-responses-provider.py
+++ b/examples/barebones/openai-responses-provider.py
@@ -16,7 +16,7 @@ import urllib.request
 from collections.abc import Mapping
 from typing import Any, NoReturn
 
-_DEFAULT_BASE_URL = "https://api.openai.com/v1"
+_RESPONSES_URL = "https://api.openai.com/v1/responses"
 _PROMPT_VERSION = "pmpe-barebones-openai-v1"
 _OUTPUT_LIMIT_BYTES = 1_000_000
 
@@ -105,10 +105,10 @@ def _request_body(message: Mapping[str, Any], model: str) -> dict[str, Any]:
     }
 
 
-def _post(body: Mapping[str, Any], *, api_key: str, base_url: str) -> Mapping[str, Any]:
+def _post(body: Mapping[str, Any], *, api_key: str) -> Mapping[str, Any]:
     payload = json.dumps(body, sort_keys=True, separators=(",", ":")).encode()
     request = urllib.request.Request(
-        base_url.rstrip("/") + "/responses",
+        _RESPONSES_URL,
         data=payload,
         method="POST",
         headers={
@@ -168,6 +168,9 @@ def _provider_response(
     request_digest = request.get("request_digest")
     if not isinstance(request_digest, str):
         _fail("provider request is missing request_digest")
+    if api_response.get("status") != "completed":
+        detail = api_response.get("incomplete_details")
+        _fail("OpenAI response did not complete" + (f": {detail}" if detail else ""))
     try:
         generated = json.loads(_output_text(api_response))
     except json.JSONDecodeError:
@@ -215,9 +218,8 @@ def main() -> int:
         _fail("stdin must be one JSON object")
     model = _required_environment("PMPE_OPENAI_MODEL")
     api_key = _required_environment("OPENAI_API_KEY")
-    base_url = os.environ.get("PMPE_OPENAI_BASE_URL", _DEFAULT_BASE_URL)
     body = _request_body(message, model)
-    api_response = _post(body, api_key=api_key, base_url=base_url)
+    api_response = _post(body, api_key=api_key)
     json.dump(_provider_response(message, api_response, model), sys.stdout)
     return 0
 

--- a/examples/barebones/openai-responses-provider.py
+++ b/examples/barebones/openai-responses-provider.py
@@ -19,6 +19,22 @@ from typing import Any, NoReturn
 _RESPONSES_URL = "https://api.openai.com/v1/responses"
 _PROMPT_VERSION = "pmpe-barebones-openai-v1"
 _OUTPUT_LIMIT_BYTES = 1_000_000
+_MAX_OUTPUT_TOKENS = 16_384
+
+
+class _RejectRedirects(urllib.request.HTTPRedirectHandler):
+    """Reject every redirect so the bearer token never reaches another URL."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        del req, fp, code, msg, headers, newurl
 
 
 def _fail(message: str) -> NoReturn:
@@ -92,6 +108,7 @@ def _request_body(message: Mapping[str, Any], model: str) -> dict[str, Any]:
     return {
         "model": model,
         "store": False,
+        "max_output_tokens": _MAX_OUTPUT_TOKENS,
         "instructions": _instructions(purpose),
         "input": json.dumps(request, sort_keys=True, separators=(",", ":")),
         "text": {
@@ -117,7 +134,8 @@ def _post(body: Mapping[str, Any], *, api_key: str) -> Mapping[str, Any]:
         },
     )
     try:
-        with urllib.request.urlopen(request, timeout=120) as response:  # noqa: S310
+        opener = urllib.request.build_opener(_RejectRedirects)
+        with opener.open(request, timeout=120) as response:  # noqa: S310
             raw = response.read(_OUTPUT_LIMIT_BYTES + 1)
     except urllib.error.HTTPError as exc:
         detail = exc.read(8192).decode("utf-8", errors="replace")

--- a/tests/unit/test_openai_responses_provider.py
+++ b/tests/unit/test_openai_responses_provider.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+def _provider_module() -> ModuleType:
+    path = Path(__file__).parents[2] / "examples" / "barebones" / "openai-responses-provider.py"
+    spec = importlib.util.spec_from_file_location("pmpe_openai_responses_provider", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _message(purpose: str = "code") -> dict[str, Any]:
+    return {
+        "purpose": purpose,
+        "request": {
+            "request_digest": "sha256:" + "1" * 64,
+            "contract": {"contract_id": "PMOS-E1"},
+            "plan": {"plan_digest": "sha256:" + "2" * 64},
+            "files": {"product.py": "def health(): return {}\n"},
+            "findings": [{"code": "ASSERTION_FAILED", "subject_id": "AC-001"}],
+        },
+    }
+
+
+def _api_response(generated: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": "resp_test",
+        "model": "gpt-test-2026-01-01",
+        "output": [
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": json.dumps(generated)}],
+            }
+        ],
+        "usage": {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+    }
+
+
+def test_request_uses_stateless_strict_structured_output() -> None:
+    provider = _provider_module()
+
+    body = provider._request_body(_message(), "gpt-test")
+
+    assert body["store"] is False
+    assert body["model"] == "gpt-test"
+    assert body["text"]["format"]["type"] == "json_schema"
+    assert body["text"]["format"]["strict"] is True
+    assert body["text"]["format"]["schema"]["additionalProperties"] is False
+    assert "Do not propose commands or dependencies" in body["instructions"]
+
+
+def test_code_output_is_adapted_to_digest_bound_file_mapping() -> None:
+    provider = _provider_module()
+    message = _message()
+
+    result = provider._provider_response(
+        message,
+        _api_response(
+            {
+                "files": [
+                    {
+                        "path": "product.py",
+                        "content": "def health():\n    return {'status': 'ok'}\n",
+                    }
+                ]
+            }
+        ),
+        "gpt-test",
+    )
+
+    assert result["request_digest"] == message["request"]["request_digest"]
+    assert result["files"] == {"product.py": "def health():\n    return {'status': 'ok'}\n"}
+    assert result["provider_metadata"] == {
+        "provider": "openai-responses",
+        "model": "gpt-test-2026-01-01",
+        "prompt_version": "pmpe-barebones-openai-v1",
+        "response_id": "resp_test",
+    }
+    assert result["usage"]["total_tokens"] == 120
+
+
+def test_advisory_output_remains_non_blocking_and_bound() -> None:
+    provider = _provider_module()
+    message = _message("advisory_review")
+
+    result = provider._provider_response(
+        message,
+        _api_response({"summary": "Checks passed; a human may inspect the candidate."}),
+        "gpt-test",
+    )
+
+    assert result["request_digest"] == message["request"]["request_digest"]
+    assert result["summary"] == "Checks passed; a human may inspect the candidate."
+
+
+def test_duplicate_generated_paths_fail_closed() -> None:
+    provider = _provider_module()
+
+    with pytest.raises(SystemExit):
+        provider._provider_response(
+            _message(),
+            _api_response(
+                {
+                    "files": [
+                        {"path": "product.py", "content": "first"},
+                        {"path": "product.py", "content": "second"},
+                    ]
+                }
+            ),
+            "gpt-test",
+        )

--- a/tests/unit/test_openai_responses_provider.py
+++ b/tests/unit/test_openai_responses_provider.py
@@ -35,6 +35,7 @@ def _api_response(generated: dict[str, Any]) -> dict[str, Any]:
     return {
         "id": "resp_test",
         "model": "gpt-test-2026-01-01",
+        "status": "completed",
         "output": [
             {
                 "type": "message",
@@ -118,3 +119,13 @@ def test_duplicate_generated_paths_fail_closed() -> None:
             ),
             "gpt-test",
         )
+
+
+def test_incomplete_api_response_fails_closed() -> None:
+    provider = _provider_module()
+    response = _api_response({"files": []})
+    response["status"] = "incomplete"
+    response["incomplete_details"] = {"reason": "max_output_tokens"}
+
+    with pytest.raises(SystemExit):
+        provider._provider_response(_message(), response, "gpt-test")

--- a/tests/unit/test_openai_responses_provider.py
+++ b/tests/unit/test_openai_responses_provider.py
@@ -52,11 +52,28 @@ def test_request_uses_stateless_strict_structured_output() -> None:
     body = provider._request_body(_message(), "gpt-test")
 
     assert body["store"] is False
+    assert body["max_output_tokens"] == 16_384
     assert body["model"] == "gpt-test"
     assert body["text"]["format"]["type"] == "json_schema"
     assert body["text"]["format"]["strict"] is True
     assert body["text"]["format"]["schema"]["additionalProperties"] is False
     assert "Do not propose commands or dependencies" in body["instructions"]
+
+
+def test_redirects_are_rejected_before_authorization_can_be_forwarded() -> None:
+    provider = _provider_module()
+
+    assert (
+        provider._RejectRedirects().redirect_request(
+            req=object(),
+            fp=None,
+            code=302,
+            msg="Found",
+            headers={},
+            newurl="https://example.invalid/capture",
+        )
+        is None
+    )
 
 
 def test_code_output_is_adapted_to_digest_bound_file_mapping() -> None:


### PR DESCRIPTION
Refs #143

## Outcome

Removes the first-run provider implementation cliff without making OpenAI a mandatory package dependency.

## What changed

- adds a standard-library OpenAI Responses API provider using strict Structured Outputs and `store: false`
- pins credential transmission to the official `https://api.openai.com/v1/responses` endpoint and rejects redirects
- accepts credentials and model selection only from environment variables
- bounds generation with `max_output_tokens` and caps response bytes
- converts structured file arrays into the existing digest-bound `ModelProvider` response
- records non-secret provider, resolved model, prompt version, response id, and token usage
- fails closed on refusal, incomplete output, malformed responses, duplicate paths, or oversized API output
- documents the run command and the distinction between provider availability and real-run evidence

## Verification

- 7 provider tests pass, including redirect rejection and the server-side token limit
- focused bare-bones provider/CLI/E1/eval suite: 57 passed
- Ruff lint: pass
- Ruff format: pass
- strict mypy on new Python files: pass
- no live API call was made because this execution environment has no configured model credential

## Evidence boundary

This PR does **not** close #143 and does not claim real E1 success. The remaining gate is an actual PMOS-authored contract run through this or another real provider, with the complete run evidence, usage, cost, time, and failure/success record published.
