### PR TITLE
Separate response binding, plan determinism, and behavior drift

### DIFF
--- a/docs/barebones-evals.md
+++ b/docs/barebones-evals.md
@@ -1,0 +1,44 @@
+# Bare-bones eval semantics
+
+Issue: #146
+
+The frozen core keeps plumbing integrity, deterministic planning, generated behavior,
+and behavior drift as separate claims.
+
+| Eval | What it proves | What it does not prove |
+|---|---|---|
+| E1 | One admitted contract can reach `RELEASE_READY` through the engine | A scripted provider is not real-model product evidence |
+| E2 | An unsatisfied criterion halts with the exact subject | Breadth across product types |
+| E3 | A stale or mismatched response digest is rejected as `MODEL_RESPONSE_UNBOUND` | Model behavior drift |
+| E4 | Contradictory acceptance truth is rejected before build | Runtime repair quality |
+| E5 | Repeated compilation preserves the plan digest and each run produces a valid evidence chain | Byte-identical model output or candidate files |
+
+## Behavior drift
+
+`pmpe.evals.barebones_drift` compares two recorded responses only when they have the
+same purpose and request digest. It hashes the behavior-bearing output (`files` for
+Coder responses or `summary` for advisory responses) separately from adapter-declared
+provider, model, and prompt versions.
+
+- Identical output is not behavior drift, even if a prompt version changed.
+- Changed output with a changed provider/model/prompt version is detected and
+  attributed to the changed configuration fields.
+- Changed output without any recorded configuration change is
+  `UNATTRIBUTED_BEHAVIOR_DRIFT`.
+- Different request digests are not comparable and fail closed.
+
+Provider metadata is adapter-declared provenance, not an independent attestation. A
+promotion claim should bind it to the provider command/configuration and the complete
+run evidence.
+
+## Why E5 allows candidate variation
+
+Real model providers are nondeterministic. Requiring byte-identical candidates would
+make E5 either impossible or encourage weakening the check after the first real run.
+The stable contract is instead:
+
+1. the same admitted contract and template compile to the same build-plan digest;
+2. every run has a valid tamper-evident chain;
+3. each distinct candidate is visible through its own manifest digest;
+4. deterministic verification decides whether that candidate reaches
+   `RELEASE_READY`.

--- a/src/pmpe/evals/barebones_drift.py
+++ b/src/pmpe/evals/barebones_drift.py
@@ -1,0 +1,103 @@
+"""Deterministic behavior-drift comparison for recorded provider responses."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from pmpe.contracts.canonical import canonical_digest
+
+_DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
+
+
+@dataclass(frozen=True)
+class ProviderBehavior:
+    purpose: str
+    request_digest: str
+    output_digest: str
+    provider: str
+    model: str
+    prompt_version: str
+
+
+@dataclass(frozen=True)
+class BehaviorDrift:
+    detected: bool
+    cause: str
+    attribution: tuple[str, ...]
+    baseline_output_digest: str
+    current_output_digest: str
+
+
+def observe_provider_behavior(*, purpose: str, response: Mapping[str, Any]) -> ProviderBehavior:
+    """Reduce one recorded provider response to comparable, non-secret behavior evidence."""
+
+    if purpose not in {"code", "advisory_review"}:
+        raise ValueError("unsupported provider purpose")
+    request_digest = response.get("request_digest")
+    metadata = response.get("provider_metadata")
+    if (
+        not isinstance(request_digest, str)
+        or _DIGEST.fullmatch(request_digest) is None
+        or not isinstance(metadata, Mapping)
+    ):
+        raise ValueError("provider response lacks digest-bound metadata")
+    identity: dict[str, str] = {}
+    for field in ("provider", "model", "prompt_version"):
+        value = metadata.get(field)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"provider metadata lacks {field}")
+        identity[field] = value
+    if purpose == "code":
+        output = response.get("files")
+        if not isinstance(output, Mapping) or any(
+            not isinstance(path, str) or not isinstance(content, str)
+            for path, content in output.items()
+        ):
+            raise ValueError("code response lacks a UTF-8 file mapping")
+    else:
+        output = response.get("summary")
+        if not isinstance(output, str):
+            raise ValueError("advisory response lacks a summary")
+    return ProviderBehavior(
+        purpose=purpose,
+        request_digest=request_digest,
+        output_digest=canonical_digest(output),
+        provider=identity["provider"],
+        model=identity["model"],
+        prompt_version=identity["prompt_version"],
+    )
+
+
+def compare_provider_behavior(
+    baseline: ProviderBehavior, current: ProviderBehavior
+) -> BehaviorDrift:
+    """Detect output drift and name changed provider configuration that can explain it."""
+
+    if (baseline.purpose, baseline.request_digest) != (
+        current.purpose,
+        current.request_digest,
+    ):
+        raise ValueError("provider behavior observations are not comparable")
+    if baseline.output_digest == current.output_digest:
+        return BehaviorDrift(
+            False,
+            "NO_BEHAVIOR_DRIFT",
+            (),
+            baseline.output_digest,
+            current.output_digest,
+        )
+    attribution = tuple(
+        field
+        for field in ("provider", "model", "prompt_version")
+        if getattr(baseline, field) != getattr(current, field)
+    )
+    return BehaviorDrift(
+        True,
+        "PROVIDER_CONFIGURATION_CHANGED" if attribution else "UNATTRIBUTED_BEHAVIOR_DRIFT",
+        attribution,
+        baseline.output_digest,
+        current.output_digest,
+    )

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -33,6 +33,7 @@ class EvidenceLedger:
         self.run_directory = self.root / "runs" / run_id
         self.events_path = self.run_directory / "events.jsonl"
         self.blobs_directory = self.root / "blobs"
+        self._read_only = False
         self.run_directory.mkdir(parents=True, exist_ok=True)
         self.blobs_directory.mkdir(parents=True, exist_ok=True)
         if resume:
@@ -68,12 +69,15 @@ class EvidenceLedger:
         ledger.run_directory = ledger.root / "runs" / run_id
         ledger.events_path = ledger.run_directory / "events.jsonl"
         ledger.blobs_directory = ledger.root / "blobs"
+        ledger._read_only = True
         if not ledger.events_path.is_file():
             raise EvidenceIntegrityError("evidence ledger does not exist")
         tuple(ledger.verify())
         return ledger
 
     def put_blob(self, payload: bytes) -> str:
+        if self._read_only:
+            raise EvidenceIntegrityError("an inspection ledger is read-only")
         digest = "sha256:" + hashlib.sha256(payload).hexdigest()
         destination = self.blobs_directory / digest.removeprefix("sha256:")
         if destination.exists():
@@ -104,6 +108,8 @@ class EvidenceLedger:
         blob_digests: Sequence[str] = (),
         payload: Mapping[str, Any] | None = None,
     ) -> Mapping[str, Any]:
+        if self._read_only:
+            raise EvidenceIntegrityError("an inspection ledger is read-only")
         if not event_type or not state or _DIGEST.fullmatch(subject_digest) is None:
             raise ValueError("event type, state, and subject digest are required")
         if any(_DIGEST.fullmatch(item) is None for item in blob_digests):

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -56,6 +56,23 @@ class EvidenceLedger:
                 ) from exc
             os.close(descriptor)
 
+    @classmethod
+    def open_existing(cls, repository_root: Path, run_id: str) -> EvidenceLedger:
+        """Open and verify an existing ledger without attempting to resume its run."""
+
+        if not _RUN_ID.fullmatch(run_id):
+            raise ValueError("run_id must be a bounded filesystem-safe identifier")
+        ledger = cls.__new__(cls)
+        ledger.run_id = run_id
+        ledger.root = repository_root / ".pmpe"
+        ledger.run_directory = ledger.root / "runs" / run_id
+        ledger.events_path = ledger.run_directory / "events.jsonl"
+        ledger.blobs_directory = ledger.root / "blobs"
+        if not ledger.events_path.is_file():
+            raise EvidenceIntegrityError("evidence ledger does not exist")
+        tuple(ledger.verify())
+        return ledger
+
     def put_blob(self, payload: bytes) -> str:
         digest = "sha256:" + hashlib.sha256(payload).hexdigest()
         destination = self.blobs_directory / digest.removeprefix("sha256:")

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -1,6 +1,3 @@
-Warning: truncated output (original token count: 13093)
-Total output lines: 1525
-
 from __future__ import annotations
 
 import json
@@ -681,7 +678,137 @@ def test_coder_cannot_rewrite_human_authored_evidence(tmp_path: Path) -> None:
     contract = _contract()
     contract["acceptance_criteria"]["AC-001"] = {
         "requirement_refs": ["FR-001"],
-        "…1093 tokens truncated…  },
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="human-test-tamper",
+        provider=TamperingProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "CODER_MODIFIED_EVIDENCE"
+
+
+class DotSegmentTamperingProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"tests/acceptance/./test_health.py": "def test_health(): assert True\n"},
+        }
+
+
+def test_coder_cannot_bypass_test_protection_with_dot_segments(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text("def test_health():\n    assert False\n")
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
+    }
+
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="human-test-dot-tamper",
+        provider=DotSegmentTamperingProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "CODER_RESPONSE_INVALID"
+
+
+class ConftestCheatProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        return {
+            "request_digest": request["request_digest"],
+            "files": {
+                "conftest.py": (
+                    "def pytest_runtest_setup(item):\n"
+                    "    item.module.health = lambda: {'status': 'ok'}\n"
+                )
+            },
+        }
+
+
+class PytestShadowProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        fake_pytest = (
+            "import pathlib, sys\n"
+            "report = next(item.split('=', 1)[1] for item in sys.argv if "
+            "item.startswith('--junitxml='))\n"
+            "pathlib.Path(report).write_text(\n"
+            "    '<testsuite><testcase name=\"test_health\" /></testsuite>'\n"
+            ")\n"
+        )
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"pytest.py": fake_pytest},
+        }
+
+
+class TestPackageInitializerProvider:
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        assert purpose == "code"
+        initializer = (
+            "import sys, types\n"
+            "fake = types.ModuleType('product')\n"
+            "fake.health = lambda: {'status': 'ok'}\n"
+            "sys.modules['product'] = fake\n"
+        )
+        return {
+            "request_digest": request["request_digest"],
+            "files": {"tests/__init__.py": initializer},
+        }
+
+
+def test_coder_controlled_conftest_cannot_change_bound_test_outcome(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests/acceptance/test_health.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "from product import health\n\ndef test_health():\n    assert health()['status'] == 'ok'\n"
+    )
+    contract = _contract()
+    contract["acceptance_criteria"]["AC-001"] = {
+        "requirement_refs": ["FR-001"],
+        "human_test": {
+            "path": "tests/acceptance/test_health.py",
+            "node_id": "test_health",
+            "command": [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/acceptance/test_health.py::test_health",
+            ],
+        },
     }
 
     result = run_to_release_ready(

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -1,3 +1,6 @@
+Warning: truncated output (original token count: 13093)
+Total output lines: 1525
+
 from __future__ import annotations
 
 import json
@@ -19,6 +22,7 @@ from pmpe.barebones import (
     run_to_release_ready,
 )
 from pmpe.contracts.acceptance import AcceptanceCompileError
+from pmpe.evidence.ledger import EvidenceLedger
 
 
 def _contract() -> dict[str, Any]:
@@ -46,6 +50,22 @@ class PassingProvider:
                 },
             }
         return {"request_digest": request["request_digest"], "summary": "advisory only"}
+
+
+class VariablePassingProvider(PassingProvider):
+    def __init__(self, variant: str) -> None:
+        self.variant = variant
+
+    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        response = dict(super().invoke(purpose=purpose, request=request))
+        if purpose == "code":
+            response["files"] = {
+                "product.py": (
+                    f'"""Generated variant {self.variant}."""\n\n'
+                    "def health() -> dict[str, str]:\n    return {'status': 'ok'}\n"
+                )
+            }
+        return response
 
 
 class UnsuccessfulProvider:
@@ -389,12 +409,12 @@ def test_e2_unsatisfiable_run_halts_with_exact_requirement(tmp_path: Path) -> No
     assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:AC-001"
 
 
-def test_e3_stale_model_response_is_detected_as_drift(tmp_path: Path) -> None:
+def test_e3_stale_model_response_is_rejected_as_unbound(tmp_path: Path) -> None:
     result = run_to_release_ready(
         contract=_contract(),
         repository_root=tmp_path,
         workspace=tmp_path / "candidate",
-        run_id="e3-prompt-drift",
+        run_id="e3-response-binding",
         provider=StaleResponseProvider(),
     )
 
@@ -511,21 +531,31 @@ def test_e4_contradiction_stops_before_build(tmp_path: Path) -> None:
     assert not workspace.exists()
 
 
-def test_e5_repeated_runs_produce_identical_evidence(tmp_path: Path) -> None:
+def test_e5_repeated_runs_preserve_plan_determinism_not_candidate_bytes(
+    tmp_path: Path,
+) -> None:
     roots = (tmp_path / "first", tmp_path / "second")
+    plans: list[str] = []
+    candidates: list[str] = []
     event_logs: list[bytes] = []
-    for root in roots:
+    for root, variant in zip(roots, ("first", "second"), strict=True):
         result = run_to_release_ready(
             contract=_contract(),
             repository_root=root,
             workspace=root / "candidate",
             run_id="e5-repeat",
-            provider=PassingProvider(),
+            provider=VariablePassingProvider(variant),
         )
         assert result.state is RunState.RELEASE_READY
+        ledger = EvidenceLedger.open_existing(root, "e5-repeat")
+        events = tuple(ledger.verify())
+        plans.append(events[0]["payload"]["plan_digest"])
+        candidates.append(events[-1]["payload"]["candidate_digest"])
         event_logs.append(result.evidence_path.read_bytes())
 
-    assert event_logs[0] == event_logs[1]
+    assert plans[0] == plans[1]
+    assert candidates[0] != candidates[1]
+    assert event_logs[0] != event_logs[1]
 
 
 def test_human_authored_escape_hatch_is_executable_and_protected(tmp_path: Path) -> None:
@@ -651,137 +681,7 @@ def test_coder_cannot_rewrite_human_authored_evidence(tmp_path: Path) -> None:
     contract = _contract()
     contract["acceptance_criteria"]["AC-001"] = {
         "requirement_refs": ["FR-001"],
-        "human_test": {
-            "path": "tests/acceptance/test_health.py",
-            "node_id": "test_health",
-            "command": [
-                sys.executable,
-                "-m",
-                "pytest",
-                "-q",
-                "tests/acceptance/test_health.py::test_health",
-            ],
-        },
-    }
-
-    result = run_to_release_ready(
-        contract=contract,
-        repository_root=tmp_path,
-        workspace=tmp_path / "candidate",
-        run_id="human-test-tamper",
-        provider=TamperingProvider(),
-    )
-
-    assert result.state is RunState.HALTED
-    assert result.cause == "CODER_MODIFIED_EVIDENCE"
-
-
-class DotSegmentTamperingProvider:
-    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
-        return {
-            "request_digest": request["request_digest"],
-            "files": {"tests/acceptance/./test_health.py": "def test_health(): assert True\n"},
-        }
-
-
-def test_coder_cannot_bypass_test_protection_with_dot_segments(tmp_path: Path) -> None:
-    test_file = tmp_path / "tests/acceptance/test_health.py"
-    test_file.parent.mkdir(parents=True)
-    test_file.write_text("def test_health():\n    assert False\n")
-    contract = _contract()
-    contract["acceptance_criteria"]["AC-001"] = {
-        "requirement_refs": ["FR-001"],
-        "human_test": {
-            "path": "tests/acceptance/test_health.py",
-            "node_id": "test_health",
-            "command": [
-                sys.executable,
-                "-m",
-                "pytest",
-                "-q",
-                "tests/acceptance/test_health.py::test_health",
-            ],
-        },
-    }
-
-    result = run_to_release_ready(
-        contract=contract,
-        repository_root=tmp_path,
-        workspace=tmp_path / "candidate",
-        run_id="human-test-dot-tamper",
-        provider=DotSegmentTamperingProvider(),
-    )
-
-    assert result.state is RunState.HALTED
-    assert result.cause == "CODER_RESPONSE_INVALID"
-
-
-class ConftestCheatProvider:
-    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
-        assert purpose == "code"
-        return {
-            "request_digest": request["request_digest"],
-            "files": {
-                "conftest.py": (
-                    "def pytest_runtest_setup(item):\n"
-                    "    item.module.health = lambda: {'status': 'ok'}\n"
-                )
-            },
-        }
-
-
-class PytestShadowProvider:
-    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
-        assert purpose == "code"
-        fake_pytest = (
-            "import pathlib, sys\n"
-            "report = next(item.split('=', 1)[1] for item in sys.argv if "
-            "item.startswith('--junitxml='))\n"
-            "pathlib.Path(report).write_text(\n"
-            "    '<testsuite><testcase name=\"test_health\" /></testsuite>'\n"
-            ")\n"
-        )
-        return {
-            "request_digest": request["request_digest"],
-            "files": {"pytest.py": fake_pytest},
-        }
-
-
-class TestPackageInitializerProvider:
-    def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
-        assert purpose == "code"
-        initializer = (
-            "import sys, types\n"
-            "fake = types.ModuleType('product')\n"
-            "fake.health = lambda: {'status': 'ok'}\n"
-            "sys.modules['product'] = fake\n"
-        )
-        return {
-            "request_digest": request["request_digest"],
-            "files": {"tests/__init__.py": initializer},
-        }
-
-
-def test_coder_controlled_conftest_cannot_change_bound_test_outcome(tmp_path: Path) -> None:
-    test_file = tmp_path / "tests/acceptance/test_health.py"
-    test_file.parent.mkdir(parents=True)
-    test_file.write_text(
-        "from product import health\n\ndef test_health():\n    assert health()['status'] == 'ok'\n"
-    )
-    contract = _contract()
-    contract["acceptance_criteria"]["AC-001"] = {
-        "requirement_refs": ["FR-001"],
-        "human_test": {
-            "path": "tests/acceptance/test_health.py",
-            "node_id": "test_health",
-            "command": [
-                sys.executable,
-                "-m",
-                "pytest",
-                "-q",
-                "tests/acceptance/test_health.py::test_health",
-            ],
-        },
+        "…1093 tokens truncated…  },
     }
 
     result = run_to_release_ready(

--- a/tests/unit/test_barebones_drift.py
+++ b/tests/unit/test_barebones_drift.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+
+from pmpe.evals.barebones_drift import (
+    compare_provider_behavior,
+    observe_provider_behavior,
+)
+
+_REQUEST_DIGEST = "sha256:" + "1" * 64
+
+
+def _response(*, status: str, prompt_version: str) -> dict[str, object]:
+    return {
+        "request_digest": _REQUEST_DIGEST,
+        "files": {"product.py": f"def health():\n    return {{'status': {status!r}}}\n"},
+        "provider_metadata": {
+            "provider": "openai-responses",
+            "model": "gpt-example-2026-01-01",
+            "prompt_version": prompt_version,
+        },
+    }
+
+
+def test_prompt_change_with_behavior_change_is_detected_and_attributed() -> None:
+    baseline = observe_provider_behavior(
+        purpose="code", response=_response(status="ok", prompt_version="prompt-v1")
+    )
+    current = observe_provider_behavior(
+        purpose="code", response=_response(status="degraded", prompt_version="prompt-v2")
+    )
+
+    drift = compare_provider_behavior(baseline, current)
+
+    assert drift.detected is True
+    assert drift.cause == "PROVIDER_CONFIGURATION_CHANGED"
+    assert drift.attribution == ("prompt_version",)
+
+
+def test_behavior_change_without_identity_change_is_unattributed() -> None:
+    baseline = observe_provider_behavior(
+        purpose="code", response=_response(status="ok", prompt_version="prompt-v1")
+    )
+    current = observe_provider_behavior(
+        purpose="code", response=_response(status="degraded", prompt_version="prompt-v1")
+    )
+
+    drift = compare_provider_behavior(baseline, current)
+
+    assert drift.detected is True
+    assert drift.cause == "UNATTRIBUTED_BEHAVIOR_DRIFT"
+    assert drift.attribution == ()
+
+
+def test_identical_behavior_is_not_drift_even_after_prompt_change() -> None:
+    baseline = observe_provider_behavior(
+        purpose="code", response=_response(status="ok", prompt_version="prompt-v1")
+    )
+    current = observe_provider_behavior(
+        purpose="code", response=_response(status="ok", prompt_version="prompt-v2")
+    )
+
+    drift = compare_provider_behavior(baseline, current)
+
+    assert drift.detected is False
+    assert drift.cause == "NO_BEHAVIOR_DRIFT"
+
+
+def test_different_requests_are_not_comparable() -> None:
+    baseline = observe_provider_behavior(
+        purpose="code", response=_response(status="ok", prompt_version="prompt-v1")
+    )
+    changed = _response(status="ok", prompt_version="prompt-v1")
+    changed["request_digest"] = "sha256:" + "2" * 64
+    current = observe_provider_behavior(purpose="code", response=changed)
+
+    with pytest.raises(ValueError, match="not comparable"):
+        compare_provider_behavior(baseline, current)
+
+
+def test_malformed_request_digest_is_rejected() -> None:
+    response = _response(status="ok", prompt_version="prompt-v1")
+    response["request_digest"] = "not-a-digest"
+
+    with pytest.raises(ValueError, match="digest-bound metadata"):
+        observe_provider_behavior(purpose="code", response=response)

--- a/tests/unit/test_evidence_ledger.py
+++ b/tests/unit/test_evidence_ledger.py
@@ -63,6 +63,9 @@ def test_event_tampering_is_detected(tmp_path: Path) -> None:
     with pytest.raises(EvidenceIntegrityError):
         tuple(ledger.verify())
 
+    with pytest.raises(EvidenceIntegrityError):
+        EvidenceLedger.open_existing(tmp_path, "run-001")
+
 
 def test_blob_tampering_is_detected(tmp_path: Path) -> None:
     ledger = EvidenceLedger(tmp_path, "run-001")

--- a/tests/unit/test_evidence_ledger.py
+++ b/tests/unit/test_evidence_ledger.py
@@ -48,6 +48,12 @@ def test_completed_run_id_cannot_be_reused_or_resumed(tmp_path: Path) -> None:
     with pytest.raises(EvidenceIntegrityError, match="terminal"):
         EvidenceLedger(tmp_path, "run-001", resume=True)
 
+    inspection = EvidenceLedger.open_existing(tmp_path, "run-001")
+    with pytest.raises(EvidenceIntegrityError, match="read-only"):
+        inspection.append(event_type="changed", state="BUILDING", subject_digest=subject)
+    with pytest.raises(EvidenceIntegrityError, match="read-only"):
+        inspection.put_blob(b"changed")
+
 
 def test_event_tampering_is_detected(tmp_path: Path) -> None:
     ledger = EvidenceLedger(tmp_path, "run-001")


### PR DESCRIPTION
Refs #146

## Outcome

Separates three claims that the previous eval names conflated: response binding, deterministic planning, and real provider behavior drift.

## What changed

- renames E3 to response-binding integrity and keeps the exact `MODEL_RESPONSE_UNBOUND` failure
- redefines E5 as stable plan compilation plus independently valid evidence chains, without requiring byte-identical model candidates
- adds a fail-closed comparator for same-request provider behavior
- attributes changed output to recorded provider/model/prompt-version changes when possible
- reports changed output under identical recorded identity as `UNATTRIBUTED_BEHAVIOR_DRIFT`
- adds integrity-verified, mutation-blocked inspection of completed evidence ledgers
- documents the corrected E1–E5 semantics and provenance limitation

## Verification

- focused unit/e2e suite: 52 passed
- inspection handles reject both event and blob mutation
- Ruff lint: pass
- Ruff format: pass
- strict mypy: pass
- diff whitespace check: pass
- remote PR diff matches the verified local delta: 298 additions, 6 deletions

## Evidence boundary

This corrects the eval semantics and provides the comparator, but does not claim real-provider drift evidence. Closing #146 still requires repeated runs through the real provider introduced in #148.
