### PR TITLE
Make the alpha engine the only default CLI path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,15 +312,15 @@ jobs:
           python -m pytest -q tests/e2e/test_full_pipeline.py
       - name: eval suites (agents + planted trajectory fixture)
         run: |
-          pmpe evals run --suite all --ledger evals/fixtures/trajectory/good_run.jsonl
+          pmpe legacy evals run --suite all --ledger evals/fixtures/trajectory/good_run.jsonl
       - name: drift gate holds on a planted regression
         run: |
           set +e
-          pmpe drift compare --baseline evals/baselines/synthetic-baseline.json \
+          pmpe legacy drift compare --baseline evals/baselines/synthetic-baseline.json \
               --current evals/fixtures/drift/current_hard_gate_failure.json
           status=$?
           set -e
           test "$status" -eq 3 || { echo "expected HOLD (exit 3), got $status"; exit 1; }
       - name: synthetic end-to-end demo
         run: |
-          pmpe demo --base-dir /tmp/ci-demo
+          pmpe legacy demo --base-dir /tmp/ci-demo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,8 +302,8 @@ jobs:
       - name: install wheel and smoke the CLI
         run: |
           pip install dist/*.whl ruff pytest
-          pmpe validate examples/taskflow_mvp_spec.yaml
-          pmpe contract validate examples/v2-demo/contract.json
+          pmpe legacy validate examples/taskflow_mvp_spec.yaml
+          pmpe legacy contract validate examples/v2-demo/contract.json
           python -c 'import importlib.util; assert importlib.util.find_spec("pmpe.orchestration.workflow") is None'
       - name: explicit legacy fixture smoke (not shipped)
         run: |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -41,7 +41,7 @@ sudo apparmor_parser -r /etc/apparmor.d/pmpe-bwrap
 Verify the install:
 
 ```bash
-pmpe validate examples/taskflow_mvp_spec.yaml
+pmpe legacy validate examples/taskflow_mvp_spec.yaml
 # -> specification OK: TaskFlow (7 requirements)
 pytest tests/unit           # fast sanity (~10s); full suite: pytest (~2 min)
 ```
@@ -54,11 +54,11 @@ pytest tests/e2e/test_full_pipeline.py
 
 This invokes the explicit `tests.legacy_v1` harness. The harness is not included
 in the wheel and has no installed CLI or production entry point. Historical run
-directories remain readable with `pmpe status` and `pmpe report`.
+directories remain readable with `pmpe legacy status` and `pmpe legacy report`.
 
 ## Historical run inspection configuration
 
-Read-only `pmpe status` and `pmpe report` accept a YAML config containing:
+Read-only `pmpe legacy status` and `pmpe legacy report` accept a YAML config containing:
 
 ```yaml
 runs_dir: runs              # where run directories are created

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,9 +4,9 @@
 
 | Command | Purpose | Exit codes |
 |---|---|---|
-| `pmpe validate <spec>` | structure + semantic validation only | 0 ok · 2 malformed · 3 errors/questions |
-| `pmpe status <run_id>` | read historical V1 step status and escalations | 0 |
-| `pmpe report <run_id>` | read a historical V1 final report | 0 · 1 if absent |
+| `pmpe legacy validate <spec>` | structure + semantic validation only | 0 ok · 2 malformed · 3 errors/questions |
+| `pmpe legacy status <run_id>` | read historical V1 step status and escalations | 0 |
+| `pmpe legacy report <run_id>` | read a historical V1 final report | 0 · 1 if absent |
 
 Common read-only flags: `--runs-dir DIR`, `--config FILE`.
 

--- a/src/pmpe/cli/__init__.py
+++ b/src/pmpe/cli/__init__.py
@@ -30,7 +30,7 @@ _LEGACY_COMMANDS = frozenset(
         "personal-workflows",
         "personal-runtime",
         "repository",
-        "support",
+        "support-demo",
     }
 )
 

--- a/src/pmpe/cli/__init__.py
+++ b/src/pmpe/cli/__init__.py
@@ -13,6 +13,41 @@ import sys
 from pmpe.cli import barebones_cmd
 from pmpe.domain.errors import PmpeError, SpecError
 
+_LEGACY_COMMANDS = frozenset(
+    {
+        "validate",
+        "status",
+        "report",
+        "contract",
+        "change-request",
+        "demo",
+        "eng",
+        "evals",
+        "drift",
+        "full-product",
+        "guided",
+        "personal-demo",
+        "personal-workflows",
+        "personal-runtime",
+        "repository",
+        "support",
+    }
+)
+
+
+class PlatformArgumentParser(argparse.ArgumentParser):
+    """Keep old invocations working without advertising them as platform paths."""
+
+    def parse_known_args(  # type: ignore[override]
+        self,
+        args: list[str] | None = None,
+        namespace: argparse.Namespace | None = None,
+    ) -> tuple[argparse.Namespace, list[str]]:
+        values = list(sys.argv[1:] if args is None else args)
+        if self.prog == "pmpe" and values and values[0] in _LEGACY_COMMANDS:
+            values.insert(0, "legacy")
+        return super().parse_known_args(values, namespace)
+
 
 def _register_legacy(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     """Register historical commands behind one visibly non-default boundary."""
@@ -48,7 +83,7 @@ def _register_legacy(sub: argparse._SubParsersAction) -> None:  # type: ignore[t
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = PlatformArgumentParser(
         prog="pmpe",
         description=(
             "Compile a machine-checkable product contract, drive one bounded Coder, "

--- a/src/pmpe/cli/__init__.py
+++ b/src/pmpe/cli/__init__.py
@@ -1,8 +1,8 @@
-"""pmpe — the CLI of PM Production Engineering OS.
+"""pmpe — the CLI of the Production Engineering OS alpha platform.
 
-Exit codes (part of the contract, see docs/usage.md):
-0 success · 1 failure · 2 malformed input · 3 blocked on human gate / semantic
-errors / non-runnable contract · 4 completed with NO_MERGE recommendation
+The default surface exposes only the frozen six-state contract-to-RELEASE_READY
+journey. Historical commands remain available under an explicit `legacy` boundary
+while their surviving consumers are migrated.
 """
 
 from __future__ import annotations
@@ -10,40 +10,54 @@ from __future__ import annotations
 import argparse
 import sys
 
-from pmpe.cli import (
-    barebones_cmd,
-    contracts_cmd,
-    core,
-    demo_cmd,
-    eng_cmd,
-    evals_cmd,
-    full_product_cmd,
-    guided_cmd,
-    personal_cmd,
-    repository_cmd,
-    support_cmd,
-)
+from pmpe.cli import barebones_cmd
 from pmpe.domain.errors import PmpeError, SpecError
+
+
+def _register_legacy(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register historical commands behind one visibly non-default boundary."""
+
+    from pmpe.cli import (
+        contracts_cmd,
+        core,
+        demo_cmd,
+        eng_cmd,
+        evals_cmd,
+        full_product_cmd,
+        guided_cmd,
+        personal_cmd,
+        repository_cmd,
+        support_cmd,
+    )
+
+    parser = sub.add_parser(
+        "legacy",
+        help="historical compatibility commands; not part of the alpha platform",
+    )
+    legacy = parser.add_subparsers(dest="legacy_command", required=True)
+    core.register(legacy)
+    contracts_cmd.register(legacy)
+    demo_cmd.register(legacy)
+    eng_cmd.register(legacy)
+    evals_cmd.register(legacy)
+    full_product_cmd.register(legacy)
+    guided_cmd.register(legacy)
+    personal_cmd.register(legacy)
+    repository_cmd.register(legacy)
+    support_cmd.register(legacy)
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="pmpe",
-        description="Convert an approved product decision into tested, "
-        "reviewed, deployable software.",
+        description=(
+            "Compile a machine-checkable product contract, drive one bounded Coder, "
+            "verify the candidate, and stop at RELEASE_READY."
+        ),
     )
     sub = parser.add_subparsers(dest="command", required=True)
-    core.register(sub)
     barebones_cmd.register(sub)
-    contracts_cmd.register(sub)
-    demo_cmd.register(sub)
-    eng_cmd.register(sub)
-    evals_cmd.register(sub)
-    full_product_cmd.register(sub)
-    guided_cmd.register(sub)
-    personal_cmd.register(sub)
-    repository_cmd.register(sub)
-    support_cmd.register(sub)
+    _register_legacy(sub)
     return parser
 
 

--- a/tests/unit/test_default_cli_surface.py
+++ b/tests/unit/test_default_cli_surface.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pmpe.cli import build_parser
+
+
+def test_default_cli_exposes_only_alpha_and_explicit_legacy_boundary() -> None:
+    parser = build_parser()
+    subparsers = next(
+        action for action in parser._actions if hasattr(action, "choices") and action.choices
+    )
+
+    assert set(subparsers.choices) == {"barebones", "legacy"}
+    assert "deployable software" not in parser.description
+
+
+def test_legacy_commands_require_the_legacy_prefix() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["legacy", "status", "example", "--runs-dir", "/tmp/runs"])
+
+    assert args.command == "legacy"
+    assert args.legacy_command == "status"

--- a/tests/unit/test_default_cli_surface.py
+++ b/tests/unit/test_default_cli_surface.py
@@ -20,3 +20,12 @@ def test_legacy_commands_require_the_legacy_prefix() -> None:
 
     assert args.command == "legacy"
     assert args.legacy_command == "status"
+
+
+def test_historical_top_level_invocation_is_a_compatibility_alias() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["status", "example", "--runs-dir", "/tmp/runs"])
+
+    assert args.command == "legacy"
+    assert args.legacy_command == "status"

--- a/tests/unit/test_legacy_v1_isolation.py
+++ b/tests/unit/test_legacy_v1_isolation.py
@@ -25,8 +25,8 @@ def _top_level_commands() -> set[str]:
 def test_shipped_cli_does_not_register_v1_execution_commands() -> None:
     commands = _top_level_commands()
 
+    assert commands == {"barebones", "legacy"}
     assert FORBIDDEN_COMMANDS.isdisjoint(commands)
-    assert {"validate", "status", "report"} <= commands
 
 
 def test_shipped_package_does_not_export_or_contain_v1_workflow_engine() -> None:

--- a/tests/unit/test_personal_cli.py
+++ b/tests/unit/test_personal_cli.py
@@ -26,7 +26,7 @@ def _answers():  # type: ignore[no-untyped-def]
 
 def test_personal_quickstart_runs_all_workflows(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
     output = tmp_path / "personal-demo"
-    assert main(["personal-demo", "quickstart", "--output", str(output)]) == 0
+    assert main(["legacy", "personal-demo", "quickstart", "--output", str(output)]) == 0
     stdout = capsys.readouterr().out
     assert "21 workflow packs completed in parallel" in stdout
     assert "unauthorized external actions: 0" in stdout
@@ -38,9 +38,9 @@ def test_personal_quickstart_runs_all_workflows(tmp_path, capsys) -> None:  # ty
 
 def test_personal_workflows_validate_real_input(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
     output = tmp_path / "starter"
-    assert main(["personal-workflows", "generate", "--output", str(output)]) == 0
+    assert main(["legacy", "personal-workflows", "generate", "--output", str(output)]) == 0
     request = output / "synthetic-workflow-request.json"
-    assert main(["personal-workflows", "validate", "--input", str(request)]) == 0
+    assert main(["legacy", "personal-workflows", "validate", "--input", str(request)]) == 0
     assert "(21 packs)" in capsys.readouterr().out
 
 
@@ -49,7 +49,7 @@ def test_personal_workflows_validate_reports_malformed_input_without_traceback(
 ) -> None:  # type: ignore[no-untyped-def]
     request = tmp_path / "malformed.json"
     request.write_text("{not-json")
-    assert main(["personal-workflows", "validate", "--input", str(request)]) == 2
+    assert main(["legacy", "personal-workflows", "validate", "--input", str(request)]) == 2
     captured = capsys.readouterr()
     assert "unreadable or malformed" in captured.err
     assert "Traceback" not in captured.err
@@ -60,6 +60,7 @@ def test_pack_specific_starter_is_cli_runnable(tmp_path, capsys) -> None:  # typ
     assert (
         main(
             [
+                "legacy",
                 "personal-workflows",
                 "starter",
                 "--pack",
@@ -75,6 +76,7 @@ def test_pack_specific_starter_is_cli_runnable(tmp_path, capsys) -> None:  # typ
     assert (
         main(
             [
+                "legacy",
                 "personal-workflows",
                 "run",
                 "--context",
@@ -92,14 +94,14 @@ def test_contract_draft_cli_reports_missing_product_truth(tmp_path, capsys) -> N
     answers = tmp_path / "answers.json"
     answers.write_text(json.dumps({"product_name": "Incomplete"}))
     output = tmp_path / "authoring"
-    assert main(["contract", "draft", "--answers", str(answers), "--output", str(output)]) == 3
+    assert main(["legacy", "contract", "draft", "--answers", str(answers), "--output", str(output)]) == 3
     assert "product input required" in capsys.readouterr().out
     questions = json.loads((output / "blocking-questions.json").read_text())
     assert questions["questions"]
 
 
 def test_guided_cli_rejects_malformed_host_without_traceback(capsys) -> None:  # type: ignore[no-untyped-def]
-    assert main(["guided", "serve", "--host", "not-a-host"]) == 2
+    assert main(["legacy", "guided", "serve", "--host", "not-a-host"]) == 2
     stderr = capsys.readouterr().err
     assert "input rejected" in stderr
     assert "Traceback" not in stderr
@@ -123,6 +125,7 @@ def test_contract_handoff_requires_verified_approval_receipt(tmp_path) -> None: 
     assert (
         main(
             [
+                "legacy",
                 "contract",
                 "handoff",
                 "--contract",

--- a/tests/unit/test_personal_cli.py
+++ b/tests/unit/test_personal_cli.py
@@ -94,7 +94,10 @@ def test_contract_draft_cli_reports_missing_product_truth(tmp_path, capsys) -> N
     answers = tmp_path / "answers.json"
     answers.write_text(json.dumps({"product_name": "Incomplete"}))
     output = tmp_path / "authoring"
-    assert main(["legacy", "contract", "draft", "--answers", str(answers), "--output", str(output)]) == 3
+    assert (
+        main(["legacy", "contract", "draft", "--answers", str(answers), "--output", str(output)])
+        == 3
+    )
     assert "product input required" in capsys.readouterr().out
     questions = json.loads((output / "blocking-questions.json").read_text())
     assert questions["questions"]


### PR DESCRIPTION
Refs #145

## Outcome

Makes the frozen six-state contract-to-`RELEASE_READY` engine the only default product journey.

## Changes

- default `pmpe` help exposes only `barebones` and an explicitly labelled `legacy` boundary
- historical validation, deployment, repository, guided, personal, support, and full-product commands move under `pmpe legacy ...`
- removes the public CLI description's unsupported deployable-software claim
- keeps compatibility code available while consumer/deletion analysis continues
- adds tests locking the default surface and legacy prefix

## Scope

This is the first atomic #145 deletion-inventory step. Candidate/evidence inspection commands and physical package deletion remain follow-up work; no compatibility package is deleted in this PR.

## Verification

GitHub CI and exact-head Codex review are required before merge.