### PR TITLE
Close remaining public-alpha evidence gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,22 @@ versions: SemVer.
 ## [Unreleased]
 
 ### Added
+- Frozen six-state contract-to-`RELEASE_READY` alpha core with deterministic acceptance compilation, meaningful-RED baseline, one bounded Coder, Bubblewrap verification, and hash-chained evidence (#141).
+- Standard-library OpenAI Responses API reference provider with strict structured output, fixed endpoint handling, redirect rejection, bounded output, and non-secret usage metadata (#148).
+- Response-binding, plan-determinism, read-only ledger inspection, and behavioural-drift comparison evidence separated into distinct claims (#149).
 - Governed personal runtime adapters for exact-payload calendar approval, budgeted and
   allowlisted product workers, digest-bound append-only event/eval evidence, bounded retry
   with verified rollback, and proposal-only outcome learning (#121).
 - `pmpe personal-runtime quickstart` deterministic local demo, synthetic fixture, runtime
   documentation, and unit/integration assurance tests. No real connectors or external writes.
+
+### Changed
+- Public claims now use an evidence-first alpha boundary and an explicit local defective-code threat model; arbitrary generation, production readiness, deployment, and platform validation are not claimed (#147).
+- The default CLI exposes only the frozen barebones journey and an explicit `legacy` compatibility boundary (#150).
+- The 0.2.0 deployment ladder and larger multi-agent lifecycle below are historical legacy behavior, superseded as the default product surface by the frozen alpha core. They are not evidence for current alpha deployment or production-readiness claims.
+
+### Security
+- Candidate execution fails closed without Bubblewrap and `prlimit`, clears the environment, removes network and host filesystem authority, mounts the candidate read-only, and bounds process resources and output. This shares the host kernel and is not a hosted or multi-tenant adversarial boundary (#141, #147).
 
 ## [0.2.0] — 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ versions: SemVer.
 - Frozen six-state contract-to-`RELEASE_READY` alpha core with deterministic acceptance compilation, meaningful-RED baseline, one bounded Coder, Bubblewrap verification, and hash-chained evidence (#141).
 - Standard-library OpenAI Responses API reference provider with strict structured output, fixed endpoint handling, redirect rejection, bounded output, and non-secret usage metadata (#148).
 - Response-binding, plan-determinism, read-only ledger inspection, and behavioural-drift comparison evidence separated into distinct claims (#149).
+
+### Added (legacy compatibility; not part of the default alpha surface)
 - Governed personal runtime adapters for exact-payload calendar approval, budgeted and
   allowlisted product workers, digest-bound append-only event/eval evidence, bounded retry
   with verified rollback, and proposal-only outcome learning (#121).

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ An open-source, local-first reference implementation that compiles a machine-che
 
 | Capability | Evidence status |
 |---|---|
-| Deterministic contract compilation and compile-time rejection | Proven by [exact-head compiler tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/13642bd248cddaed2ee85c7bb3fbc8c2134675e6/tests/unit/test_acceptance_compiler.py) and [CI #818](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32587823069) |
-| Meaningful-RED baseline, bounded repair, and six-state engine | Proven by [exact-head E1/eval tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/13642bd248cddaed2ee85c7bb3fbc8c2134675e6/tests/e2e/test_barebones_e1.py) and [CI #818](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32587823069) |
-| Hash-chained events and content-addressed evidence blobs | Proven by [exact-head ledger tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/13642bd248cddaed2ee85c7bb3fbc8c2134675e6/tests/unit/test_evidence_ledger.py) and [CI #818](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32587823069) |
-| Candidate execution with Bubblewrap, no network, and bounded resources | Proven by [planted isolation tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/13642bd248cddaed2ee85c7bb3fbc8c2134675e6/tests/unit/test_candidate_sandbox.py) in [Linux CI #818](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32587823069) |
-| End-to-end `RELEASE_READY` engine path | Proven by the [scripted exact-head E1 fixture](https://github.com/Abhillashjadhav/production-engineering-os/blob/13642bd248cddaed2ee85c7bb3fbc8c2134675e6/tests/e2e/test_barebones_e1.py) in [CI #818](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32587823069) |
+| Deterministic contract compilation and compile-time rejection | Proven by [exact-head compiler tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/e25c605fb043a64d019938ee8e67c1518337e0a6/tests/unit/test_acceptance_compiler.py) and [CI #842](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32619855405) |
+| Meaningful-RED baseline, bounded repair, and six-state engine | Proven by [exact-head E1/eval tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/e25c605fb043a64d019938ee8e67c1518337e0a6/tests/e2e/test_barebones_e1.py) and [CI #842](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32619855405) |
+| Hash-chained events and content-addressed evidence blobs | Proven by [exact-head ledger tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/e25c605fb043a64d019938ee8e67c1518337e0a6/tests/unit/test_evidence_ledger.py) and [CI #842](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32619855405) |
+| Candidate execution with Bubblewrap, no network, and bounded resources | Proven by [planted isolation tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/e25c605fb043a64d019938ee8e67c1518337e0a6/tests/unit/test_candidate_sandbox.py) in [Linux CI #842](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32619855405) |
+| End-to-end `RELEASE_READY` engine path | Proven by the [scripted exact-head E1 fixture](https://github.com/Abhillashjadhav/production-engineering-os/blob/e25c605fb043a64d019938ee8e67c1518337e0a6/tests/e2e/test_barebones_e1.py) in [CI #842](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32619855405) |
 | Canonical PMOS contract accepted by the grammar | **Not yet proven** |
 | Product built with a real model provider | **Not yet proven** |
+| Repeated real-provider behavioural drift evidence | **Not yet proven** |
 | Reuse across multiple distinct product contracts | **Not yet proven** |
 | macOS or Windows native execution | **Not supported** |
 | Cloud deployment, GitHub mutation, or automatic release | **Out of scope** |
@@ -95,6 +96,8 @@ pmpe barebones examples/barebones/e1-contract.json \
 ```
 
 The example provider returns scripted responses. It proves compiler-to-engine plumbing; it does not prove that an LLM can build the requested software.
+
+For a real-model run, use the documented [OpenAI Responses API reference provider](docs/real-model-provider.md). Its implementation and unit tests prove the adapter boundary only; no live PMOS-to-real-model run is claimed until its complete evidence bundle is published.
 
 A provider receives one JSON object on standard input:
 

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -41,6 +41,8 @@ def test_default_candidate_sandbox_removes_host_authority(
 
     argv = observed["argv"]
     assert isinstance(argv, list)
+    assert "--die-with-parent" in argv
+    assert "--new-session" in argv
     assert "--unshare-all" in argv
     assert "--clearenv" in argv
     assert f"--fsize={64 * 1024 * 1024}" in argv
@@ -49,6 +51,17 @@ def test_default_candidate_sandbox_removes_host_authority(
     ]
     assert not {"/root", "/home"}.intersection(argv)
     assert observed["environment"] == {"LC_ALL": "C", "PATH": "/usr/local/bin:/usr/bin:/bin"}
+
+
+def test_model_file_path_cannot_escape_candidate_root(tmp_path: Path) -> None:
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    escaped = tmp_path / "escaped.py"
+
+    with pytest.raises(ValueError, match="unsafe candidate path"):
+        barebones._write_files(workspace, {"../escaped.py": "HOST_WRITE = True\n"})
+
+    assert not escaped.exists()
 
 
 def test_candidate_execution_fails_closed_without_os_sandbox(


### PR DESCRIPTION
Closes #151

## Outcome
Aligns the repository's trust artifacts and regression evidence with the frozen evidence-first alpha.

## Changes
- records #141 and #147–150 in CHANGELOG and marks the 0.2.0 deployment ladder as superseded legacy behavior
- makes the real OpenAI reference provider discoverable from README
- tracks repeated real-provider drift as not yet proven
- refreshes baseline evidence links to the latest merged alpha revision and green CI
- proves model-proposed path traversal is rejected before any host write
- asserts Bubblewrap parent-death and new-session lifecycle flags

## Remaining settings item
The GitHub repository About description is not file-backed and must be updated through repository settings; it is intentionally not claimed as completed here.

## Verification
Full CI and exact-head Codex review are required before merge.