### PR TITLE
Prove the engine through the real candidate sandbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           pytest \
             tests/unit/test_candidate_sandbox.py::test_real_candidate_sandbox_has_no_host_credentials_network_or_write_access \
             tests/unit/test_candidate_sandbox.py::test_engine_fails_closed_when_candidate_sandbox_is_unavailable \
+            tests/unit/test_candidate_sandbox.py::test_model_file_path_cannot_escape_through_symlink \
             tests/e2e/test_barebones_e1.py::test_e1_real_contract_reaches_release_ready \
             -q
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,13 +77,15 @@ jobs:
           EOF
           sudo apparmor_parser -r /etc/apparmor.d/pmpe-bwrap
       - run: pip install -e ".[dev]"
-      - name: prove candidate isolation
+      - name: prove candidate isolation and engine composition
         env:
           PMPE_TEST_REAL_SANDBOX: "true"
-        run: >-
-          pytest
-          tests/unit/test_candidate_sandbox.py::test_real_candidate_sandbox_has_no_host_credentials_network_or_write_access
-          -q
+        run: |
+          pytest \
+            tests/unit/test_candidate_sandbox.py::test_real_candidate_sandbox_has_no_host_credentials_network_or_write_access \
+            tests/unit/test_candidate_sandbox.py::test_engine_fails_closed_when_candidate_sandbox_is_unavailable \
+            tests/e2e/test_barebones_e1.py::test_e1_real_contract_reaches_release_ready \
+            -q
 
   security:
     runs-on: ubuntu-latest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,11 @@ def local_candidate_sandbox_for_barebones_tests(
         "test_barebones_evals.py",
     }:
         return
+    if (
+        request.path.name == "test_barebones_e1.py"
+        and os.environ.get("PMPE_TEST_REAL_SANDBOX") == "true"
+    ):
+        return
     from pmpe import barebones
 
     monkeypatch.setattr(barebones, "BubblewrapCandidateSandbox", _LocalCandidateTestSandbox)

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -4,12 +4,18 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from pmpe import barebones
-from pmpe.barebones import BubblewrapCandidateSandbox, ContractInvalidError
+from pmpe.barebones import (
+    BubblewrapCandidateSandbox,
+    ContractInvalidError,
+    run_to_release_ready,
+)
 
 
 def test_default_candidate_sandbox_removes_host_authority(
@@ -64,6 +70,19 @@ def test_model_file_path_cannot_escape_candidate_root(tmp_path: Path) -> None:
     assert not escaped.exists()
 
 
+def test_model_file_path_cannot_escape_through_symlink(tmp_path: Path) -> None:
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (workspace / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="escapes workspace"):
+        barebones._write_files(workspace, {"linked/escaped.py": "HOST_WRITE = True\n"})
+
+    assert not (outside / "escaped.py").exists()
+
+
 def test_candidate_execution_fails_closed_without_os_sandbox(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -75,6 +94,37 @@ def test_candidate_execution_fails_closed_without_os_sandbox(
             ("/usr/bin/python3", "-V"),
             timeout_seconds=2,
             environment={},
+        )
+
+
+def test_engine_fails_closed_when_candidate_sandbox_is_unavailable(tmp_path: Path) -> None:
+    class ProviderMustNotRun:
+        def invoke(
+            self, *, purpose: str, request: Mapping[str, Any]
+        ) -> Mapping[str, Any]:
+            raise AssertionError("provider must not run before sandbox verification")
+
+    contract = {
+        "contract_id": "PMOS-FAIL-CLOSED",
+        "functional_requirements": {"FR-001": {"statement": "health reports ok"}},
+        "acceptance_criteria": {
+            "AC-001": {
+                "requirement_refs": ["FR-001"],
+                "given": [{"path": "service.running", "operator": "eq", "value": True}],
+                "when": {"action": "health", "arguments": {}},
+                "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+            }
+        },
+    }
+
+    with pytest.raises(ContractInvalidError, match="sandbox is unavailable"):
+        run_to_release_ready(
+            contract=contract,
+            repository_root=tmp_path,
+            workspace=tmp_path / "candidate",
+            run_id="sandbox-unavailable",
+            provider=ProviderMustNotRun(),
+            candidate_sandbox=BubblewrapCandidateSandbox(executable="pmpe-missing-bwrap"),
         )
 
 

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -99,9 +99,7 @@ def test_candidate_execution_fails_closed_without_os_sandbox(
 
 def test_engine_fails_closed_when_candidate_sandbox_is_unavailable(tmp_path: Path) -> None:
     class ProviderMustNotRun:
-        def invoke(
-            self, *, purpose: str, request: Mapping[str, Any]
-        ) -> Mapping[str, Any]:
+        def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
             raise AssertionError("provider must not run before sandbox verification")
 
     contract = {


### PR DESCRIPTION
Closes #153

## Outcome
Closes the composition gap between the verified Bubblewrap primitive and the verified six-state engine.

## Changes
- the dedicated isolation job now runs the full scripted E1 through `run_to_release_ready` with real Bubblewrap
- the fast local sandbox fixture steps aside only for that gated real-sandbox E1
- a composed engine test proves missing Bubblewrap fails before the provider runs
- a symlink-escape regression proves model-authored writes cannot leave the candidate root

## Verification
Exact-head CI and Codex review are required before merge.