### PR TITLE
Require PMOS approval and record provider evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ pmpe barebones examples/barebones/e1-contract.json \
   --workspace /tmp/pmpe-e1-candidate \
   --run-id e1 \
   --repository-root /tmp/pmpe-e1-evidence \
+  --approval-receipt examples/barebones/e1-approval-receipt.json \
   --expected-approver fixture-human \
   --provider-command "python examples/barebones/e1-provider.py"
 ```
@@ -106,6 +107,7 @@ A provider receives one JSON object on standard input:
 {"purpose": "code|advisory_review", "request": {}}
 ```
 
+  --approval-receipt examples/barebones/e1-approval-receipt.json \
 The contract must contain `contract_status: APPROVED` and `approved_by`; the CLI requires an exact `--expected-approver` match before invoking the provider. The provider must return one UTF-8 JSON object containing the same `request_digest`. Do not record provider credentials in contracts, commands, candidate workspaces, or evidence.
 
 ## Current evidence gap

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ A provider receives one JSON object on standard input:
 {"purpose": "code|advisory_review", "request": {}}
 ```
 
-  --approval-receipt examples/barebones/e1-approval-receipt.json \
 The contract must contain `contract_status: APPROVED` and `approved_by`; the CLI requires an exact `--expected-approver` match before invoking the provider. The provider must return one UTF-8 JSON object containing the same `request_digest`. Do not record provider credentials in contracts, commands, candidate workspaces, or evidence.
 
 ## Current evidence gap

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ A provider receives one JSON object on standard input:
 {"purpose": "code|advisory_review", "request": {}}
 ```
 
-It must return one UTF-8 JSON object containing the same `request_digest`. Do not record provider credentials in contracts, commands, candidate workspaces, or evidence.
+The contract must contain `contract_status: APPROVED` and `approved_by`; the CLI requires an exact `--expected-approver` match before invoking the provider. The provider must return one UTF-8 JSON object containing the same `request_digest`. Do not record provider credentials in contracts, commands, candidate workspaces, or evidence.
 
 ## Current evidence gap
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An open-source, local-first reference implementation that compiles a machine-che
 | Hash-chained events and content-addressed evidence blobs | Proven by [exact-head ledger tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/e25c605fb043a64d019938ee8e67c1518337e0a6/tests/unit/test_evidence_ledger.py) and [CI #842](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32619855405) |
 | Candidate execution with Bubblewrap, no network, and bounded resources | Proven by [planted isolation tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/e25c605fb043a64d019938ee8e67c1518337e0a6/tests/unit/test_candidate_sandbox.py) in [Linux CI #842](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32619855405) |
 | End-to-end `RELEASE_READY` engine path | Proven by the [scripted exact-head E1 fixture](https://github.com/Abhillashjadhav/production-engineering-os/blob/e25c605fb043a64d019938ee8e67c1518337e0a6/tests/e2e/test_barebones_e1.py) in [CI #842](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32619855405) |
-| Canonical PMOS contract accepted by the grammar | **Not yet proven** |
+| Canonical PMOS contract and digest-bound approval receipt accepted by the boundary | Proven by the [PMOS executable compatibility gate](https://github.com/Abhillashjadhav/PM-agent-OS/blob/5fa7af8207143194eb242f2edd9f7edfca8bb969/tests/decision-to-contract/validate_contract.py), including a planted post-approval tampering rejection |
 | Product built with a real model provider | **Not yet proven** |
 | Repeated real-provider behavioural drift evidence | **Not yet proven** |
 | Reuse across multiple distinct product contracts | **Not yet proven** |
@@ -112,7 +112,7 @@ The contract must contain `contract_status: APPROVED` and `approved_by`; the CLI
 
 ## Current evidence gap
 
-The canonical PMOS fixture contains prose that resembles Given/When/Then but does not identify a registered action or typed output paths. The compiler correctly refuses to guess. A real E1 begins only when PMOS emits the structured grammar or binds a requirement to an admitted human-authored test.
+PMOS now publishes a compiler-shaped health contract plus an approval receipt bound to the exact contract digest; its pinned compatibility gate verifies the receipt, accepts the valid contract, rejects a post-approval edit, and rejects prose-only criteria. This proves the PMOS-to-PEOS handoff shape. It does not prove live-model contract-authoring reliability or a real provider build. A real E1 begins when that approved boundary is exercised with a configured provider and its complete evidence bundle is published.
 
 The next promotion gate is one real PMOS-authored contract reaching `RELEASE_READY` through a real provider with:
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ pmpe barebones examples/barebones/e1-contract.json \
   --workspace /tmp/pmpe-e1-candidate \
   --run-id e1 \
   --repository-root /tmp/pmpe-e1-evidence \
+  --expected-approver fixture-human \\
   --provider-command "python examples/barebones/e1-provider.py"
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pmpe barebones examples/barebones/e1-contract.json \
   --workspace /tmp/pmpe-e1-candidate \
   --run-id e1 \
   --repository-root /tmp/pmpe-e1-evidence \
-  --expected-approver fixture-human \\
+  --expected-approver fixture-human \
   --provider-command "python examples/barebones/e1-provider.py"
 ```
 

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -35,6 +35,7 @@ pmpe barebones examples/barebones/e1-contract.json \
   --workspace /tmp/pmpe-real-e1-candidate \
   --run-id real-e1 \
   --repository-root /tmp/pmpe-real-e1-evidence \
+  --expected-approver fixture-human \\
   --provider-command "python examples/barebones/openai-responses-provider.py"
 ```
 

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -19,6 +19,8 @@ mandatory OpenAI dependency in `pmpe`.
 ```bash
 export OPENAI_API_KEY='<set outside the repository>'
 export PMPE_OPENAI_MODEL='<an available structured-output-capable model>'
+export PMPE_OPENAI_INPUT_USD_PER_MILLION='<current input-token price>'
+export PMPE_OPENAI_OUTPUT_USD_PER_MILLION='<current output-token price>'
 ```
 
 The reference adapter sends credentials only to
@@ -37,7 +39,9 @@ pmpe barebones examples/barebones/e1-contract.json \
 ```
 
 The provider records non-secret metadata returned through the protocol: provider,
-resolved model name, prompt version, response id, and usage. The core still owns the
+resolved model name, prompt version, response id, usage, and estimated cost when both
+current per-million-token prices are configured. Prices are never hard-coded because
+they change; the operator must supply the rates used for the evidence bundle. The core still owns the
 request digest, output limits, candidate-path validation, deterministic verification,
 and evidence chain.
 

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -45,7 +45,11 @@ resolved model name, prompt version, response id, usage, and estimated cost when
 current per-million-token prices are configured. Prices are never hard-coded because
 they change; the operator must supply the rates used for the evidence bundle. The core
 still owns the request digest, output limits, candidate-path validation, deterministic verification,
-and evidence chain.
+and evidence chain. Successful provider calls with complete non-secret provider metadata
+also emit normalized `provider_behavior` observations (request, output, provider, model,
+and prompt-version digests) into the hash-chained events. Those observations enable
+cross-run drift comparison; repeated real-provider drift remains unproven until P1 runs
+publish comparable observations.
 
 ## Evidence rule
 

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -35,6 +35,7 @@ pmpe barebones examples/barebones/e1-contract.json \
   --workspace /tmp/pmpe-real-e1-candidate \
   --run-id real-e1 \
   --repository-root /tmp/pmpe-real-e1-evidence \
+  --approval-receipt examples/barebones/e1-approval-receipt.json \
   --expected-approver fixture-human \
   --provider-command "python examples/barebones/openai-responses-provider.py"
 ```

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -35,15 +35,15 @@ pmpe barebones examples/barebones/e1-contract.json \
   --workspace /tmp/pmpe-real-e1-candidate \
   --run-id real-e1 \
   --repository-root /tmp/pmpe-real-e1-evidence \
-  --expected-approver fixture-human \\
+  --expected-approver fixture-human \
   --provider-command "python examples/barebones/openai-responses-provider.py"
 ```
 
 The provider records non-secret metadata returned through the protocol: provider,
 resolved model name, prompt version, response id, usage, and estimated cost when both
 current per-million-token prices are configured. Prices are never hard-coded because
-they change; the operator must supply the rates used for the evidence bundle. The core still owns the
-request digest, output limits, candidate-path validation, deterministic verification,
+they change; the operator must supply the rates used for the evidence bundle. The core
+still owns the request digest, output limits, candidate-path validation, deterministic verification,
 and evidence chain.
 
 ## Evidence rule

--- a/examples/barebones/e1-approval-receipt.json
+++ b/examples/barebones/e1-approval-receipt.json
@@ -1,0 +1,11 @@
+{
+  "approved_at": "2026-08-23T00:00:00Z",
+  "approved_by": "fixture-human",
+  "approved_contract_digest": "sha256:725b55871b9d082cb76309e1d85bfa7b35e4591ff4873c301175e3ec36c97f57",
+  "contract_id": "PMOS-E1",
+  "contract_version": 1,
+  "decision": "APPROVED",
+  "draft_digest": "sha256:e1ce2545a4d74a665866a35c00e7ba32cc7cfaf9c0f658f379b384e7b76c7bf7",
+  "schema_version": "1.0.0",
+  "receipt_digest": "sha256:6c65d2b3e388b8bcc861833ce557c135ba2c13eec439986a60a86ccad699b04d"
+}

--- a/examples/barebones/e1-contract.json
+++ b/examples/barebones/e1-contract.json
@@ -30,5 +30,7 @@
         }
       ]
     }
-  }
+  },
+  "contract_status": "APPROVED",
+  "approved_by": "fixture-human"
 }

--- a/examples/barebones/e1-contract.json
+++ b/examples/barebones/e1-contract.json
@@ -32,5 +32,6 @@
     }
   },
   "contract_status": "APPROVED",
-  "approved_by": "fixture-human"
+  "approved_by": "fixture-human",
+  "approved_at": "2026-08-23T00:00:00Z"
 }

--- a/examples/barebones/e1-provider.py
+++ b/examples/barebones/e1-provider.py
@@ -6,9 +6,15 @@ import sys
 
 message = json.load(sys.stdin)
 request = message["request"]
+metadata = {
+    "provider": "scripted-fixture",
+    "model": "deterministic-e1",
+    "prompt_version": "e1-v1",
+}
 if message["purpose"] == "code":
     response = {
         "request_digest": request["request_digest"],
+        "provider_metadata": metadata,
         "files": {
             "product.py": (
                 '"""E1 health product."""\n\n'
@@ -21,5 +27,6 @@ else:
     response = {
         "request_digest": request["request_digest"],
         "summary": "Deterministic evidence passed; human may release.",
+        "provider_metadata": metadata,
     }
 json.dump(response, sys.stdout)

--- a/examples/barebones/openai-responses-provider.py
+++ b/examples/barebones/openai-responses-provider.py
@@ -223,7 +223,19 @@ def _provider_response(
         result = {"request_digest": request_digest, "summary": summary}
     result["provider_metadata"] = metadata
     if isinstance(usage, Mapping):
-        result["usage"] = dict(usage)
+        recorded_usage = dict(usage)
+        input_rate = os.environ.get("PMPE_OPENAI_INPUT_USD_PER_MILLION", "").strip()
+        output_rate = os.environ.get("PMPE_OPENAI_OUTPUT_USD_PER_MILLION", "").strip()
+        if input_rate and output_rate:
+            try:
+                input_cost = float(input_rate) * int(usage.get("input_tokens", 0)) / 1_000_000
+                output_cost = float(output_rate) * int(usage.get("output_tokens", 0)) / 1_000_000
+            except (TypeError, ValueError):
+                _fail("configured OpenAI token prices must be non-negative numbers")
+            if input_cost < 0 or output_cost < 0:
+                _fail("configured OpenAI token prices must be non-negative numbers")
+            recorded_usage["estimated_cost_usd"] = round(input_cost + output_cost, 12)
+        result["usage"] = recorded_usage
     return result
 
 

--- a/examples/barebones/openai-responses-provider.py
+++ b/examples/barebones/openai-responses-provider.py
@@ -9,6 +9,7 @@ Credentials are read from the environment and are never copied into the response
 from __future__ import annotations
 
 import json
+import math
 import os
 import sys
 import urllib.error
@@ -236,10 +237,17 @@ def _provider_response(
                 output_cost = (
                     output_rate_value * int(usage.get("output_tokens", 0)) / 1_000_000
                 )
-            except (TypeError, ValueError):
-                _fail("configured OpenAI token prices must be non-negative numbers")
-            if input_cost < 0 or output_cost < 0:
-                _fail("configured OpenAI token prices must be non-negative numbers")
+            except (OverflowError, TypeError, ValueError):
+                _fail("configured OpenAI token prices must be finite non-negative numbers")
+            if (
+                not math.isfinite(input_rate_value)
+                or not math.isfinite(output_rate_value)
+                or not math.isfinite(input_cost)
+                or not math.isfinite(output_cost)
+                or input_cost < 0
+                or output_cost < 0
+            ):
+                _fail("configured OpenAI token prices must be finite non-negative numbers")
             recorded_usage["pricing"] = {
                 "input_usd_per_million_tokens": input_rate_value,
                 "output_usd_per_million_tokens": output_rate_value,

--- a/examples/barebones/openai-responses-provider.py
+++ b/examples/barebones/openai-responses-provider.py
@@ -228,12 +228,23 @@ def _provider_response(
         output_rate = os.environ.get("PMPE_OPENAI_OUTPUT_USD_PER_MILLION", "").strip()
         if input_rate and output_rate:
             try:
-                input_cost = float(input_rate) * int(usage.get("input_tokens", 0)) / 1_000_000
-                output_cost = float(output_rate) * int(usage.get("output_tokens", 0)) / 1_000_000
+                input_rate_value = float(input_rate)
+                output_rate_value = float(output_rate)
+                input_cost = (
+                    input_rate_value * int(usage.get("input_tokens", 0)) / 1_000_000
+                )
+                output_cost = (
+                    output_rate_value * int(usage.get("output_tokens", 0)) / 1_000_000
+                )
             except (TypeError, ValueError):
                 _fail("configured OpenAI token prices must be non-negative numbers")
             if input_cost < 0 or output_cost < 0:
                 _fail("configured OpenAI token prices must be non-negative numbers")
+            recorded_usage["pricing"] = {
+                "input_usd_per_million_tokens": input_rate_value,
+                "output_usd_per_million_tokens": output_rate_value,
+                "source": "operator_environment",
+            }
             recorded_usage["estimated_cost_usd"] = round(input_cost + output_cost, 12)
         result["usage"] = recorded_usage
     return result

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -24,8 +24,10 @@ from pmpe.contracts.acceptance import (
     PropertyAssertion,
     compile_acceptance_plan,
 )
+from pmpe.contracts.authoring import verify_contract_approval
 from pmpe.contracts.canonical import canonical_digest
 from pmpe.evals.barebones_drift import observe_provider_behavior
+from pmpe.domain.errors import ContractViolation
 from pmpe.evidence.ledger import EvidenceLedger
 from pmpe.model_provider import ModelProvider
 
@@ -834,6 +836,8 @@ def run_to_release_ready(
     budget: BudgetCaps | None = None,
     stop_requested: Callable[[], bool] = lambda: False,
     candidate_sandbox: CandidateSandbox | None = None,
+    approval_receipt: Mapping[str, Any] | None = None,
+    approval_authority: str | None = None,
 ) -> RunResult:
     """Run the frozen core. It never deploys and stops at RELEASE_READY."""
 
@@ -852,6 +856,23 @@ def run_to_release_ready(
         "human_test_count": 0,
     }
     subject_digest = canonical_digest(contract)
+    if (approval_receipt is None) != (approval_authority is None):
+        raise ContractInvalidError("approval receipt and authority must be supplied together")
+    approval_payload: dict[str, Any] = {"status": "UNVERIFIED_DIRECT_CALL"}
+    if approval_receipt is not None and approval_authority is not None:
+        try:
+            receipt_digest = verify_contract_approval(
+                dict(contract),
+                dict(approval_receipt),
+                expected_approver=approval_authority,
+            )
+        except ContractViolation as exc:
+            raise ContractInvalidError(str(exc)) from exc
+        approval_payload = {
+            "status": "VERIFIED",
+            "authority": approval_authority,
+            "receipt_digest": receipt_digest,
+        }
 
     template_test_digests: dict[str, str] = {}
     for test_id, proof in active_template.proofs.items():
@@ -913,12 +934,23 @@ def run_to_release_ready(
     contract_blob = ledger.put_blob(
         json.dumps(contract, sort_keys=True, separators=(",", ":")).encode()
     )
+    validation_blobs = [contract_blob, plan_blob]
+    if approval_receipt is not None:
+        receipt_blob = ledger.put_blob(
+            json.dumps(approval_receipt, sort_keys=True, separators=(",", ":")).encode()
+        )
+        validation_blobs.append(receipt_blob)
+        approval_payload["receipt_blob_digest"] = receipt_blob
     ledger.append(
         event_type="contract_validated",
         state=RunState.VALIDATED,
         subject_digest=subject_digest,
-        blob_digests=(contract_blob, plan_blob),
-        payload={"contract_digest": contract_blob, "plan_digest": plan.plan_digest},
+        blob_digests=tuple(validation_blobs),
+        payload={
+            "approval": approval_payload,
+            "contract_digest": contract_blob,
+            "plan_digest": plan.plan_digest,
+        },
     )
     if stop_requested():
         ledger.append(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -104,6 +104,7 @@ _SANDBOX_PATH = "/usr/local/bin:/usr/bin:/bin"
 _PYTEST_RESULT_PREFIX = "__PMPE_PYTEST_RESULT__:"
 
 _PROVIDER_ERROR_CODE = re.compile(r"[A-Z][A-Z0-9_]*\Z")
+_MAX_SAFE_JSON_INTEGER = (1 << 53) - 1
 
 
 def _classify_provider_error(error: RuntimeError) -> str:
@@ -804,18 +805,25 @@ def _invoke_bound(
     if isinstance(usage, Mapping):
         for source, target in (("input_tokens", "tokens_in"), ("output_tokens", "tokens_out")):
             value = usage.get(source)
-            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
-                counters[target] += value
+            if value is None:
+                continue
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise RuntimeError("MODEL_PROVIDER_USAGE_INVALID")
+            accumulated_tokens = counters[target] + value
+            if accumulated_tokens > _MAX_SAFE_JSON_INTEGER:
+                raise RuntimeError("MODEL_PROVIDER_USAGE_INVALID")
+            counters[target] = accumulated_tokens
         estimated = usage.get("estimated_cost_usd")
         if estimated is not None:
-            if (
-                not isinstance(estimated, (int, float))
-                or isinstance(estimated, bool)
-                or not math.isfinite(float(estimated))
-                or estimated < 0
-            ):
+            if not isinstance(estimated, (int, float)) or isinstance(estimated, bool):
                 raise RuntimeError("MODEL_PROVIDER_USAGE_INVALID")
-            accumulated_cost = counters["estimated_cost_usd"] + float(estimated)
+            try:
+                estimated_value = float(estimated)
+            except (OverflowError, ValueError) as exc:
+                raise RuntimeError("MODEL_PROVIDER_USAGE_INVALID") from exc
+            if not math.isfinite(estimated_value) or estimated_value < 0:
+                raise RuntimeError("MODEL_PROVIDER_USAGE_INVALID")
+            accumulated_cost = counters["estimated_cost_usd"] + estimated_value
             if not math.isfinite(accumulated_cost):
                 raise RuntimeError("MODEL_PROVIDER_USAGE_INVALID")
             counters["estimated_cost_usd"] = accumulated_cost

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import operator as comparison
 import re
 import shutil
@@ -806,11 +807,14 @@ def _invoke_bound(
             if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
                 counters[target] += value
         estimated = usage.get("estimated_cost_usd")
-        if (
-            isinstance(estimated, (int, float))
-            and not isinstance(estimated, bool)
-            and estimated >= 0
-        ):
+        if estimated is not None:
+            if (
+                not isinstance(estimated, (int, float))
+                or isinstance(estimated, bool)
+                or not math.isfinite(float(estimated))
+                or estimated < 0
+            ):
+                raise RuntimeError("MODEL_PROVIDER_USAGE_INVALID")
             counters["estimated_cost_usd"] += float(estimated)
     metadata = response.get("provider_metadata")
     if isinstance(metadata, Mapping):

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -25,7 +25,7 @@ from pmpe.contracts.acceptance import (
     compile_acceptance_plan,
 )
 from pmpe.contracts.authoring import verify_contract_approval
-from pmpe.contracts.canonical import canonical_digest
+from pmpe.contracts.canonical import CanonicalInputError, canonical_digest, strict_loads
 from pmpe.evals.barebones_drift import observe_provider_behavior
 from pmpe.domain.errors import ContractViolation
 from pmpe.evidence.ledger import EvidenceLedger
@@ -836,6 +836,7 @@ def run_to_release_ready(
     candidate_sandbox: CandidateSandbox | None = None,
     approval_receipt: Mapping[str, Any] | None = None,
     approval_authority: str | None = None,
+    approval_receipt_bytes: bytes | None = None,
 ) -> RunResult:
     """Run the frozen core. It never deploys and stops at RELEASE_READY."""
 
@@ -854,10 +855,25 @@ def run_to_release_ready(
         "human_test_count": 0,
     }
     subject_digest = canonical_digest(contract)
-    if (approval_receipt is None) != (approval_authority is None):
-        raise ContractInvalidError("approval receipt and authority must be supplied together")
+    approval_inputs = (approval_receipt, approval_authority, approval_receipt_bytes)
+    if any(item is None for item in approval_inputs) and not all(
+        item is None for item in approval_inputs
+    ):
+        raise ContractInvalidError(
+            "approval receipt, authority, and submitted bytes must be supplied together"
+        )
     approval_payload: dict[str, Any] = {"status": "UNVERIFIED_DIRECT_CALL"}
-    if approval_receipt is not None and approval_authority is not None:
+    if (
+        approval_receipt is not None
+        and approval_authority is not None
+        and approval_receipt_bytes is not None
+    ):
+        try:
+            submitted_receipt = strict_loads(approval_receipt_bytes, "application/json")
+        except CanonicalInputError as exc:
+            raise ContractInvalidError("submitted approval receipt is malformed") from exc
+        if canonical_digest(submitted_receipt) != canonical_digest(approval_receipt):
+            raise ContractInvalidError("submitted approval receipt bytes do not match receipt")
         try:
             receipt_digest = verify_contract_approval(
                 dict(contract),
@@ -933,10 +949,8 @@ def run_to_release_ready(
         json.dumps(contract, sort_keys=True, separators=(",", ":")).encode()
     )
     validation_blobs = [contract_blob, plan_blob]
-    if approval_receipt is not None:
-        receipt_blob = ledger.put_blob(
-            json.dumps(approval_receipt, sort_keys=True, separators=(",", ":")).encode()
-        )
+    if approval_receipt_bytes is not None:
+        receipt_blob = ledger.put_blob(approval_receipt_bytes)
         validation_blobs.append(receipt_blob)
         approval_payload["receipt_blob_digest"] = receipt_blob
     ledger.append(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -867,9 +867,7 @@ def run_to_release_ready(
         registered_measures=frozenset(active_template.measures),
         trusted_test_digests=trusted_test_digests,
     )
-    counters["structured_criteria_count"] = sum(
-        item.form != "human_test" for item in plan.criteria
-    )
+    counters["structured_criteria_count"] = sum(item.form != "human_test" for item in plan.criteria)
     counters["human_test_count"] = sum(item.form == "human_test" for item in plan.criteria)
     workspace_root = workspace.resolve()
     evidence_root = (repository_root / ".pmpe").resolve()

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -817,6 +817,8 @@ def _invoke_bound(
         if estimated is not None:
             if not isinstance(estimated, (int, float)) or isinstance(estimated, bool):
                 raise RuntimeError("MODEL_PROVIDER_USAGE_INVALID")
+            if isinstance(estimated, int) and abs(estimated) > _MAX_SAFE_JSON_INTEGER:
+                raise RuntimeError("MODEL_PROVIDER_USAGE_INVALID")
             try:
                 estimated_value = float(estimated)
             except (OverflowError, ValueError) as exc:

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -80,6 +80,7 @@ class RunResult:
     elapsed_ms: int
     evidence_path: Path
     annotation: Mapping[str, Any] = field(default_factory=dict)
+    telemetry: Mapping[str, Any] = field(default_factory=dict)
 
 
 class ContractInvalidError(ValueError):
@@ -88,7 +89,7 @@ class ContractInvalidError(ValueError):
 
 _SAFE_RELATIVE = re.compile(r"[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\Z")
 _MODULE_TARGET = re.compile(r"([A-Za-z_][A-Za-z0-9_.]*):([A-Za-z_][A-Za-z0-9_]*)\Z")
-_CREDENTIAL = re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|AKIA[0-9A-Z]{16}")
+_CREDENTIAL = re.compile(\n    r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|AKIA[0-9A-Z]{16}|sk-[A-Za-z0-9_-]{20,}"\n)
 _HIGH_RISK_CODE = re.compile(r"\b(?:eval|exec)\s*\(")
 _ACTION_TIMEOUT_SECONDS = 10.0
 _PYTEST_TIMEOUT_SECONDS = 30.0
@@ -762,18 +763,42 @@ def _invoke_bound(
     purpose: str,
     request: Mapping[str, Any],
     budget: BudgetCaps,
-    counters: dict[str, int],
+    counters: dict[str, Any],
 ) -> Mapping[str, Any]:
     if counters["calls"] >= budget.max_model_calls:
         raise RuntimeError("MODEL_CALL_BUDGET_EXHAUSTED")
     response = provider.invoke(purpose=purpose, request=request)
     counters["calls"] += 1
-    size = len(json.dumps(response, sort_keys=True, separators=(",", ":")).encode())
+    serialized = json.dumps(response, sort_keys=True, separators=(",", ":"))
+    if _CREDENTIAL.search(serialized):
+        raise RuntimeError("MODEL_RESPONSE_CONTAINS_CREDENTIAL")
+    size = len(serialized.encode())
     counters["bytes"] += size
     if counters["bytes"] > budget.max_model_output_bytes:
         raise RuntimeError("MODEL_OUTPUT_BUDGET_EXHAUSTED")
     if response.get("request_digest") != request.get("request_digest"):
         raise RuntimeError("MODEL_RESPONSE_UNBOUND")
+    usage = response.get("usage")
+    if isinstance(usage, Mapping):
+        for source, target in (("input_tokens", "tokens_in"), ("output_tokens", "tokens_out")):
+            value = usage.get(source)
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                counters[target] += value
+        estimated = usage.get("estimated_cost_usd")
+        if (
+            isinstance(estimated, (int, float))
+            and not isinstance(estimated, bool)
+            and estimated >= 0
+        ):
+            counters["estimated_cost_usd"] += float(estimated)
+    metadata = response.get("provider_metadata")
+    if isinstance(metadata, Mapping):
+        model = metadata.get("model")
+        if isinstance(model, str) and model:
+            observed = counters.get("provider_model_id")
+            counters["provider_model_id"] = (
+                model if not observed or observed == model else "multiple"
+            )
     return response
 
 
@@ -795,7 +820,16 @@ def run_to_release_ready(
     active_template = template or default_template()
     active_budget = budget or BudgetCaps()
     active_sandbox = candidate_sandbox or BubblewrapCandidateSandbox()
-    counters = {"calls": 0, "bytes": 0}
+    counters: dict[str, Any] = {
+        "calls": 0,
+        "bytes": 0,
+        "tokens_in": 0,
+        "tokens_out": 0,
+        "estimated_cost_usd": 0.0,
+        "provider_model_id": "",
+        "structured_criteria_count": 0,
+        "human_test_count": 0,
+    }
     subject_digest = canonical_digest(contract)
 
     template_test_digests: dict[str, str] = {}
@@ -822,6 +856,10 @@ def run_to_release_ready(
         registered_measures=frozenset(active_template.measures),
         trusted_test_digests=trusted_test_digests,
     )
+    counters["structured_criteria_count"] = sum(
+        item.form != "human_test" for item in plan.criteria
+    )
+    counters["human_test_count"] = sum(item.form == "human_test" for item in plan.criteria)
     workspace_root = workspace.resolve()
     evidence_root = (repository_root / ".pmpe").resolve()
     if workspace_root.is_relative_to(evidence_root) or evidence_root.is_relative_to(workspace_root):
@@ -835,14 +873,15 @@ def run_to_release_ready(
         state: RunState, cause: str, attempts: int, annotation: Mapping[str, Any] | None = None
     ) -> RunResult:
         return RunResult(
-            run_id,
-            state,
-            cause,
-            attempts,
-            counters["calls"],
-            int((time.monotonic() - started) * 1000),
-            ledger.events_path,
-            dict(annotation or {}),
+            run_id=run_id,
+            state=state,
+            cause=cause,
+            attempts=attempts,
+            model_calls=int(counters["calls"]),
+            elapsed_ms=int((time.monotonic() - started) * 1000),
+            evidence_path=ledger.events_path,
+            annotation=dict(annotation or {}),
+            telemetry=dict(counters),
         )
 
     plan_blob = ledger.put_blob(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -89,8 +89,7 @@ class ContractInvalidError(ValueError):
 
 _SAFE_RELATIVE = re.compile(r"[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\Z")
 _MODULE_TARGET = re.compile(r"([A-Za-z_][A-Za-z0-9_.]*):([A-Za-z_][A-Za-z0-9_]*)\Z")
-_CREDENTIAL = re.compile(\n    r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|AKIA[0-9A-Z]{16}|sk-[A-Za-z0-9_-]{20,}"\n)
-_HIGH_RISK_CODE = re.compile(r"\b(?:eval|exec)\s*\(")
+_CREDENTIAL = re.compile(\n    r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|AKIA[0-9A-Z]{16}|sk-[A-Za-z0-9_-]{20,}"\n)\n_HIGH_RISK_CODE = re.compile(r"\b(?:eval|exec)\s*\(")
 _ACTION_TIMEOUT_SECONDS = 10.0
 _PYTEST_TIMEOUT_SECONDS = 30.0
 _CANDIDATE_OUTPUT_LIMIT_BYTES = 1_000_000

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -778,8 +778,8 @@ def _invoke_bound(
 ) -> Mapping[str, Any]:
     if counters["calls"] >= budget.max_model_calls:
         raise RuntimeError("MODEL_CALL_BUDGET_EXHAUSTED")
-    response = provider.invoke(purpose=purpose, request=request)
     counters["calls"] += 1
+    response = provider.invoke(purpose=purpose, request=request)
     serialized = json.dumps(response, sort_keys=True, separators=(",", ":"))
     if _CREDENTIAL.search(serialized):
         raise RuntimeError("MODEL_RESPONSE_CONTAINS_CREDENTIAL")

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -112,9 +112,7 @@ def _classify_provider_error(error: RuntimeError) -> str:
     return message
 
 
-def _provider_behavior_payload(
-    purpose: str, response: Mapping[str, Any]
-) -> dict[str, Any] | None:
+def _provider_behavior_payload(purpose: str, response: Mapping[str, Any]) -> dict[str, Any] | None:
     try:
         return asdict(observe_provider_behavior(purpose=purpose, response=response))
     except ValueError:

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -26,8 +26,8 @@ from pmpe.contracts.acceptance import (
 )
 from pmpe.contracts.authoring import verify_contract_approval
 from pmpe.contracts.canonical import CanonicalInputError, canonical_digest, strict_loads
-from pmpe.evals.barebones_drift import observe_provider_behavior
 from pmpe.domain.errors import ContractViolation
+from pmpe.evals.barebones_drift import observe_provider_behavior
 from pmpe.evidence.ledger import EvidenceLedger
 from pmpe.model_provider import ModelProvider
 

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -878,6 +878,10 @@ def run_to_release_ready(
     workspace.mkdir(parents=True, exist_ok=True)
     ledger = EvidenceLedger(repository_root, run_id)
 
+    def _terminal_telemetry() -> dict[str, Any]:
+        counters["elapsed_ms"] = int((time.monotonic() - started) * 1000)
+        return dict(counters)
+
     def finish(
         state: RunState, cause: str, attempts: int, annotation: Mapping[str, Any] | None = None
     ) -> RunResult:
@@ -887,10 +891,10 @@ def run_to_release_ready(
             cause=cause,
             attempts=attempts,
             model_calls=int(counters["calls"]),
-            elapsed_ms=int((time.monotonic() - started) * 1000),
+            elapsed_ms=int(counters.get("elapsed_ms", (time.monotonic() - started) * 1000)),
             evidence_path=ledger.events_path,
             annotation=dict(annotation or {}),
-            telemetry=dict(counters),
+            telemetry=_terminal_telemetry(),
         )
 
     plan_blob = ledger.put_blob(
@@ -911,7 +915,7 @@ def run_to_release_ready(
             event_type="stopped",
             state=RunState.STOPPED,
             subject_digest=subject_digest,
-            payload={"cause": "STOP_REQUESTED", "telemetry": dict(counters)},
+            payload={"cause": "STOP_REQUESTED", "telemetry": _terminal_telemetry()},
         )
         return finish(RunState.STOPPED, "STOP_REQUESTED", 0)
 
@@ -975,7 +979,7 @@ def run_to_release_ready(
                 event_type="stopped",
                 state=RunState.STOPPED,
                 subject_digest=subject_digest,
-                payload={"cause": "STOP_REQUESTED", "telemetry": dict(counters)},
+                payload={"cause": "STOP_REQUESTED", "telemetry": _terminal_telemetry()},
             )
             return finish(RunState.STOPPED, "STOP_REQUESTED", attempt - 1)
         request = _model_request(
@@ -998,7 +1002,7 @@ def run_to_release_ready(
                 event_type="halted",
                 state=RunState.HALTED,
                 subject_digest=subject_digest,
-                payload={"cause": cause, "telemetry": dict(counters)},
+                payload={"cause": cause, "telemetry": _terminal_telemetry()},
             )
             return finish(RunState.HALTED, cause, attempt - 1)
         files = response.get("files")
@@ -1007,7 +1011,7 @@ def run_to_release_ready(
                 event_type="halted",
                 state=RunState.HALTED,
                 subject_digest=subject_digest,
-                payload={"cause": "CODER_RESPONSE_INVALID", "telemetry": dict(counters)},
+                payload={"cause": "CODER_RESPONSE_INVALID", "telemetry": _terminal_telemetry()},
             )
             return finish(RunState.HALTED, "CODER_RESPONSE_INVALID", attempt)
         try:
@@ -1021,7 +1025,7 @@ def run_to_release_ready(
                 event_type="halted",
                 state=RunState.HALTED,
                 subject_digest=subject_digest,
-                payload={"cause": "CODER_RESPONSE_INVALID", "telemetry": dict(counters)},
+                payload={"cause": "CODER_RESPONSE_INVALID", "telemetry": _terminal_telemetry()},
             )
             return finish(RunState.HALTED, "CODER_RESPONSE_INVALID", attempt)
         if protected_tests.intersection(response_paths):
@@ -1029,7 +1033,7 @@ def run_to_release_ready(
                 event_type="halted",
                 state=RunState.HALTED,
                 subject_digest=subject_digest,
-                payload={"cause": "CODER_MODIFIED_EVIDENCE", "telemetry": dict(counters)},
+                payload={"cause": "CODER_MODIFIED_EVIDENCE", "telemetry": _terminal_telemetry()},
             )
             return finish(RunState.HALTED, "CODER_MODIFIED_EVIDENCE", attempt)
         try:
@@ -1039,7 +1043,7 @@ def run_to_release_ready(
                 event_type="halted",
                 state=RunState.HALTED,
                 subject_digest=subject_digest,
-                payload={"cause": "CODER_RESPONSE_INVALID", "telemetry": dict(counters)},
+                payload={"cause": "CODER_RESPONSE_INVALID", "telemetry": _terminal_telemetry()},
             )
             return finish(RunState.HALTED, "CODER_RESPONSE_INVALID", attempt)
         coder_blob = ledger.put_blob(
@@ -1076,7 +1080,7 @@ def run_to_release_ready(
                 payload={
                     "cause": cause,
                     "findings": [asdict(item) for item in findings],
-                    "telemetry": dict(counters),
+                    "telemetry": _terminal_telemetry(),
                 },
             )
             return finish(RunState.HALTED, cause, attempt)
@@ -1175,7 +1179,7 @@ def run_to_release_ready(
                     payload={
                         "annotation": dict(annotation),
                         "candidate_digest": candidate_blob,
-                        "telemetry": dict(counters),
+                        "telemetry": _terminal_telemetry(),
                     },
                 )
                 return finish(RunState.RELEASE_READY, "PASS", attempt, annotation)
@@ -1202,7 +1206,7 @@ def run_to_release_ready(
         payload={
             "cause": "ATTEMPT_BUDGET_EXHAUSTED",
             "findings": [asdict(item) for item in findings],
-            "telemetry": dict(counters),
+            "telemetry": _terminal_telemetry(),
         },
     )
     return finish(RunState.HALTED, "ATTEMPT_BUDGET_EXHAUSTED", active_budget.max_attempts)

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -894,7 +894,7 @@ def run_to_release_ready(
             elapsed_ms=int(counters.get("elapsed_ms", (time.monotonic() - started) * 1000)),
             evidence_path=ledger.events_path,
             annotation=dict(annotation or {}),
-            telemetry=_terminal_telemetry(),
+            telemetry=dict(counters),
         )
 
     plan_blob = ledger.put_blob(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -25,6 +25,7 @@ from pmpe.contracts.acceptance import (
     compile_acceptance_plan,
 )
 from pmpe.contracts.canonical import canonical_digest
+from pmpe.evals.barebones_drift import observe_provider_behavior
 from pmpe.evidence.ledger import EvidenceLedger
 from pmpe.model_provider import ModelProvider
 
@@ -107,6 +108,15 @@ def _classify_provider_error(error: RuntimeError) -> str:
     if _CREDENTIAL.search(message) or not _PROVIDER_ERROR_CODE.fullmatch(message):
         return "MODEL_PROVIDER_FAILED"
     return message
+
+
+def _provider_behavior_payload(
+    purpose: str, response: Mapping[str, Any]
+) -> dict[str, Any] | None:
+    try:
+        return asdict(observe_provider_behavior(purpose=purpose, response=response))
+    except ValueError:
+        return None
 
 
 class CandidateSandbox(Protocol):
@@ -1049,12 +1059,16 @@ def run_to_release_ready(
         coder_blob = ledger.put_blob(
             json.dumps(response, sort_keys=True, separators=(",", ":")).encode()
         )
+        coder_payload: dict[str, Any] = {"attempt": attempt, "changed": list(changed)}
+        coder_behavior = _provider_behavior_payload("code", response)
+        if coder_behavior is not None:
+            coder_payload["provider_behavior"] = coder_behavior
         ledger.append(
             event_type="coder_completed",
             state=RunState.BUILDING,
             subject_digest=subject_digest,
             blob_digests=(coder_blob,),
-            payload={"attempt": attempt, "changed": list(changed)},
+            payload=coder_payload,
         )
         finding_digest = canonical_digest([asdict(item) for item in findings])
         implicated = {path for item in findings for path in item.files}
@@ -1171,16 +1185,20 @@ def run_to_release_ready(
                     )
                 except RuntimeError as exc:
                     annotation = {"status": "unavailable", "cause": _classify_provider_error(exc)}
+                release_payload: dict[str, Any] = {
+                    "annotation": dict(annotation),
+                    "candidate_digest": candidate_blob,
+                    "telemetry": _terminal_telemetry(),
+                }
+                advisory_behavior = _provider_behavior_payload("advisory_review", annotation)
+                if advisory_behavior is not None:
+                    release_payload["provider_behavior"] = advisory_behavior
                 ledger.append(
                     event_type="release_ready",
                     state=RunState.RELEASE_READY,
                     subject_digest=subject_digest,
                     blob_digests=(blob, candidate_blob, *candidate_file_blobs),
-                    payload={
-                        "annotation": dict(annotation),
-                        "candidate_digest": candidate_blob,
-                        "telemetry": _terminal_telemetry(),
-                    },
+                    payload=release_payload,
                 )
                 return finish(RunState.RELEASE_READY, "PASS", attempt, annotation)
             finding_blob = ledger.put_blob(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -815,7 +815,10 @@ def _invoke_bound(
                 or estimated < 0
             ):
                 raise RuntimeError("MODEL_PROVIDER_USAGE_INVALID")
-            counters["estimated_cost_usd"] += float(estimated)
+            accumulated_cost = counters["estimated_cost_usd"] + float(estimated)
+            if not math.isfinite(accumulated_cost):
+                raise RuntimeError("MODEL_PROVIDER_USAGE_INVALID")
+            counters["estimated_cost_usd"] = accumulated_cost
     metadata = response.get("provider_metadata")
     if isinstance(metadata, Mapping):
         model = metadata.get("model")

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -89,12 +89,24 @@ class ContractInvalidError(ValueError):
 
 _SAFE_RELATIVE = re.compile(r"[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\Z")
 _MODULE_TARGET = re.compile(r"([A-Za-z_][A-Za-z0-9_.]*):([A-Za-z_][A-Za-z0-9_]*)\Z")
-_CREDENTIAL = re.compile(\n    r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|AKIA[0-9A-Z]{16}|sk-[A-Za-z0-9_-]{20,}"\n)\n_HIGH_RISK_CODE = re.compile(r"\b(?:eval|exec)\s*\(")
+_CREDENTIAL = re.compile(
+    r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|AKIA[0-9A-Z]{16}|sk-[A-Za-z0-9_-]{20,}"
+)
+_HIGH_RISK_CODE = re.compile(r"\b(?:eval|exec)\s*\(")
 _ACTION_TIMEOUT_SECONDS = 10.0
 _PYTEST_TIMEOUT_SECONDS = 30.0
 _CANDIDATE_OUTPUT_LIMIT_BYTES = 1_000_000
 _SANDBOX_PATH = "/usr/local/bin:/usr/bin:/bin"
 _PYTEST_RESULT_PREFIX = "__PMPE_PYTEST_RESULT__:"
+
+_PROVIDER_ERROR_CODE = re.compile(r"[A-Z][A-Z0-9_]*\Z")
+
+
+def _classify_provider_error(error: RuntimeError) -> str:
+    message = str(error)
+    if _CREDENTIAL.search(message) or not _PROVIDER_ERROR_CODE.fullmatch(message):
+        return "MODEL_PROVIDER_FAILED"
+    return message
 
 
 class CandidateSandbox(Protocol):
@@ -897,7 +909,12 @@ def run_to_release_ready(
         payload={"contract_digest": contract_blob, "plan_digest": plan.plan_digest},
     )
     if stop_requested():
-        ledger.append(event_type="stopped", state=RunState.STOPPED, subject_digest=subject_digest)
+        ledger.append(
+            event_type="stopped",
+            state=RunState.STOPPED,
+            subject_digest=subject_digest,
+            payload={"cause": "STOP_REQUESTED", "telemetry": dict(counters)},
+        )
         return finish(RunState.STOPPED, "STOP_REQUESTED", 0)
 
     _write_files(workspace, active_template.files)
@@ -957,7 +974,10 @@ def run_to_release_ready(
     for attempt in range(1, active_budget.max_attempts + 1):
         if stop_requested():
             ledger.append(
-                event_type="stopped", state=RunState.STOPPED, subject_digest=subject_digest
+                event_type="stopped",
+                state=RunState.STOPPED,
+                subject_digest=subject_digest,
+                payload={"cause": "STOP_REQUESTED", "telemetry": dict(counters)},
             )
             return finish(RunState.STOPPED, "STOP_REQUESTED", attempt - 1)
         request = _model_request(
@@ -975,20 +995,21 @@ def run_to_release_ready(
                 counters=counters,
             )
         except RuntimeError as exc:
+            cause = _classify_provider_error(exc)
             ledger.append(
                 event_type="halted",
                 state=RunState.HALTED,
                 subject_digest=subject_digest,
-                payload={"cause": str(exc)},
+                payload={"cause": cause, "telemetry": dict(counters)},
             )
-            return finish(RunState.HALTED, str(exc), attempt - 1)
+            return finish(RunState.HALTED, cause, attempt - 1)
         files = response.get("files")
         if not isinstance(files, Mapping):
             ledger.append(
                 event_type="halted",
                 state=RunState.HALTED,
                 subject_digest=subject_digest,
-                payload={"cause": "CODER_RESPONSE_INVALID"},
+                payload={"cause": "CODER_RESPONSE_INVALID", "telemetry": dict(counters)},
             )
             return finish(RunState.HALTED, "CODER_RESPONSE_INVALID", attempt)
         try:
@@ -1002,7 +1023,7 @@ def run_to_release_ready(
                 event_type="halted",
                 state=RunState.HALTED,
                 subject_digest=subject_digest,
-                payload={"cause": "CODER_RESPONSE_INVALID"},
+                payload={"cause": "CODER_RESPONSE_INVALID", "telemetry": dict(counters)},
             )
             return finish(RunState.HALTED, "CODER_RESPONSE_INVALID", attempt)
         if protected_tests.intersection(response_paths):
@@ -1010,7 +1031,7 @@ def run_to_release_ready(
                 event_type="halted",
                 state=RunState.HALTED,
                 subject_digest=subject_digest,
-                payload={"cause": "CODER_MODIFIED_EVIDENCE"},
+                payload={"cause": "CODER_MODIFIED_EVIDENCE", "telemetry": dict(counters)},
             )
             return finish(RunState.HALTED, "CODER_MODIFIED_EVIDENCE", attempt)
         try:
@@ -1020,7 +1041,7 @@ def run_to_release_ready(
                 event_type="halted",
                 state=RunState.HALTED,
                 subject_digest=subject_digest,
-                payload={"cause": "CODER_RESPONSE_INVALID"},
+                payload={"cause": "CODER_RESPONSE_INVALID", "telemetry": dict(counters)},
             )
             return finish(RunState.HALTED, "CODER_RESPONSE_INVALID", attempt)
         coder_blob = ledger.put_blob(
@@ -1054,7 +1075,11 @@ def run_to_release_ready(
                 event_type="halted",
                 state=RunState.HALTED,
                 subject_digest=subject_digest,
-                payload={"cause": cause, "findings": [asdict(item) for item in findings]},
+                payload={
+                    "cause": cause,
+                    "findings": [asdict(item) for item in findings],
+                    "telemetry": dict(counters),
+                },
             )
             return finish(RunState.HALTED, cause, attempt)
 
@@ -1143,7 +1168,7 @@ def run_to_release_ready(
                         counters=counters,
                     )
                 except RuntimeError as exc:
-                    annotation = {"status": "unavailable", "cause": str(exc)}
+                    annotation = {"status": "unavailable", "cause": _classify_provider_error(exc)}
                 ledger.append(
                     event_type="release_ready",
                     state=RunState.RELEASE_READY,
@@ -1179,6 +1204,7 @@ def run_to_release_ready(
         payload={
             "cause": "ATTEMPT_BUDGET_EXHAUSTED",
             "findings": [asdict(item) for item in findings],
+            "telemetry": dict(counters),
         },
     )
     return finish(RunState.HALTED, "ATTEMPT_BUDGET_EXHAUSTED", active_budget.max_attempts)

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -126,9 +126,7 @@ def _require_approved_contract(
     if approved_by != expected_approver:
         raise ContractInvalidError("approved_by does not match --expected-approver")
     try:
-        verify_contract_approval(
-            dict(contract), dict(receipt), expected_approver=expected_approver
-        )
+        verify_contract_approval(dict(contract), dict(receipt), expected_approver=expected_approver)
     except ContractViolation as exc:
         raise ContractInvalidError(str(exc)) from exc
 

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -18,7 +18,9 @@ from typing import Any
 
 from pmpe.barebones import ContractInvalidError, run_to_release_ready
 from pmpe.contracts.acceptance import AcceptanceCompileError
+from pmpe.contracts.authoring import verify_contract_approval
 from pmpe.contracts.canonical import CanonicalInputError, strict_loads
+from pmpe.domain.errors import ContractViolation
 from pmpe.evidence.ledger import EvidenceIntegrityError
 
 _PROVIDER_OUTPUT_LIMIT_BYTES = 1_000_000
@@ -112,7 +114,9 @@ class CommandModelProvider:
         return response
 
 
-def _require_approved_contract(contract: Mapping[str, Any], expected_approver: str) -> None:
+def _require_approved_contract(
+    contract: Mapping[str, Any], receipt: Mapping[str, Any], expected_approver: str
+) -> None:
     status = contract.get("contract_status")
     approved_by = contract.get("approved_by")
     if status != "APPROVED":
@@ -121,6 +125,12 @@ def _require_approved_contract(contract: Mapping[str, Any], expected_approver: s
         raise ContractInvalidError("approved_by is required")
     if approved_by != expected_approver:
         raise ContractInvalidError("approved_by does not match --expected-approver")
+    try:
+        verify_contract_approval(
+            dict(contract), dict(receipt), expected_approver=expected_approver
+        )
+    except ContractViolation as exc:
+        raise ContractInvalidError(str(exc)) from exc
 
 
 def _run(args: argparse.Namespace) -> int:
@@ -132,7 +142,8 @@ def _run(args: argparse.Namespace) -> int:
             else "application/json"
         )
         contract = strict_loads(contract_path.read_bytes(), content_type)
-        _require_approved_contract(contract, args.expected_approver)
+        receipt = strict_loads(Path(args.approval_receipt).read_bytes(), "application/json")
+        _require_approved_contract(contract, receipt, args.expected_approver)
         result = run_to_release_ready(
             contract=contract,
             repository_root=Path(args.repository_root).resolve(),
@@ -198,6 +209,7 @@ def register(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     parser.add_argument("--workspace", required=True)
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--repository-root", default=".")
+    parser.add_argument("--approval-receipt", required=True)
     parser.add_argument(
         "--expected-approver",
         required=True,

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -158,6 +158,7 @@ def _run(args: argparse.Namespace) -> int:
             provider=CommandModelProvider(args.provider_command, args.provider_timeout),
             approval_receipt=receipt,
             approval_authority=args.expected_approver,
+            approval_receipt_bytes=receipt_source,
         )
     except CanonicalInputError as exc:
         print(

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -139,8 +139,16 @@ def _run(args: argparse.Namespace) -> int:
             if contract_path.suffix.lower() in {".yaml", ".yml"}
             else "application/json"
         )
-        contract = strict_loads(contract_path.read_bytes(), content_type)
-        receipt = strict_loads(Path(args.approval_receipt).read_bytes(), "application/json")
+        try:
+            contract_source = contract_path.read_bytes()
+        except OSError as exc:
+            raise ContractInvalidError("cannot read contract") from exc
+        try:
+            receipt_source = Path(args.approval_receipt).read_bytes()
+        except OSError as exc:
+            raise ContractInvalidError("cannot read approval receipt") from exc
+        contract = strict_loads(contract_source, content_type)
+        receipt = strict_loads(receipt_source, "application/json")
         _require_approved_contract(contract, receipt, args.expected_approver)
         result = run_to_release_ready(
             contract=contract,
@@ -148,6 +156,8 @@ def _run(args: argparse.Namespace) -> int:
             workspace=Path(args.workspace).resolve(),
             run_id=args.run_id,
             provider=CommandModelProvider(args.provider_command, args.provider_timeout),
+            approval_receipt=receipt,
+            approval_authority=args.expected_approver,
         )
     except CanonicalInputError as exc:
         print(

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -104,8 +104,7 @@ class CommandModelProvider:
             self.timeout_seconds,
         )
         if completed.returncode != 0:
-            detail = completed.stderr.decode("utf-8", errors="replace").strip()
-            raise RuntimeError("model provider failed: " + detail)
+            raise RuntimeError("MODEL_PROVIDER_FAILED")
         try:
             response = strict_loads(completed.stdout, "application/json")
         except CanonicalInputError as exc:
@@ -113,9 +112,7 @@ class CommandModelProvider:
         return response
 
 
-def _require_approved_contract(
-    contract: Mapping[str, Any], expected_approver: str
-) -> None:
+def _require_approved_contract(contract: Mapping[str, Any], expected_approver: str) -> None:
     status = contract.get("contract_status")
     approved_by = contract.get("approved_by")
     if status != "APPROVED":

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -113,6 +113,19 @@ class CommandModelProvider:
         return response
 
 
+def _require_approved_contract(
+    contract: Mapping[str, Any], expected_approver: str
+) -> None:
+    status = contract.get("contract_status")
+    approved_by = contract.get("approved_by")
+    if status != "APPROVED":
+        raise ContractInvalidError("contract_status must be APPROVED")
+    if not isinstance(approved_by, str) or not approved_by.strip():
+        raise ContractInvalidError("approved_by is required")
+    if approved_by != expected_approver:
+        raise ContractInvalidError("approved_by does not match --expected-approver")
+
+
 def _run(args: argparse.Namespace) -> int:
     contract_path = Path(args.contract)
     try:
@@ -122,6 +135,7 @@ def _run(args: argparse.Namespace) -> int:
             else "application/json"
         )
         contract = strict_loads(contract_path.read_bytes(), content_type)
+        _require_approved_contract(contract, args.expected_approver)
         result = run_to_release_ready(
             contract=contract,
             repository_root=Path(args.repository_root).resolve(),
@@ -170,6 +184,7 @@ def _run(args: argparse.Namespace) -> int:
                 "elapsed_ms": result.elapsed_ms,
                 "evidence": str(result.evidence_path),
                 "annotation": result.annotation,
+                "telemetry": result.telemetry,
             },
             sort_keys=True,
         )
@@ -186,6 +201,11 @@ def register(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     parser.add_argument("--workspace", required=True)
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--repository-root", default=".")
+    parser.add_argument(
+        "--expected-approver",
+        required=True,
+        help="human identity that must exactly match contract approved_by",
+    )
     parser.add_argument(
         "--provider-command",
         required=True,

--- a/tests/e2e/test_barebones_e1.py
+++ b/tests/e2e/test_barebones_e1.py
@@ -67,6 +67,7 @@ def test_e1_real_contract_reaches_release_ready(tmp_path: Path) -> None:
     events = [json.loads(line) for line in result.evidence_path.read_text().splitlines()]
     coder = next(event for event in events if event["event_type"] == "coder_completed")
     release = next(event for event in events if event["event_type"] == "release_ready")
+    assert events[0]["payload"]["approval"]["status"] == "UNVERIFIED_DIRECT_CALL"
     assert coder["payload"]["provider_behavior"]["purpose"] == "code"
     assert release["payload"]["provider_behavior"]["purpose"] == "advisory_review"
     assert coder["payload"]["provider_behavior"]["request_digest"].startswith("sha256:")

--- a/tests/e2e/test_barebones_e1.py
+++ b/tests/e2e/test_barebones_e1.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from pmpe.barebones import RunState, run_to_release_ready
 
-
 _METADATA = {
     "provider": "scripted-fixture",
     "model": "deterministic-e1",

--- a/tests/e2e/test_barebones_e1.py
+++ b/tests/e2e/test_barebones_e1.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -7,11 +8,19 @@ from typing import Any
 from pmpe.barebones import RunState, run_to_release_ready
 
 
+_METADATA = {
+    "provider": "scripted-fixture",
+    "model": "deterministic-e1",
+    "prompt_version": "e1-v1",
+}
+
+
 class E1Provider:
     def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
         if purpose == "code":
             return {
                 "request_digest": request["request_digest"],
+                "provider_metadata": _METADATA,
                 "files": {
                     "product.py": (
                         '"""E1 health product."""\n\n'
@@ -23,6 +32,7 @@ class E1Provider:
         return {
             "request_digest": request["request_digest"],
             "summary": "Deterministic evidence passed; human may release.",
+            "provider_metadata": _METADATA,
         }
 
 
@@ -54,3 +64,10 @@ def test_e1_real_contract_reaches_release_ready(tmp_path: Path) -> None:
     assert result.model_calls == 2
     assert result.evidence_path.is_file()
     assert "status" not in result.annotation
+    events = [json.loads(line) for line in result.evidence_path.read_text().splitlines()]
+    coder = next(event for event in events if event["event_type"] == "coder_completed")
+    release = next(event for event in events if event["event_type"] == "release_ready")
+    assert coder["payload"]["provider_behavior"]["purpose"] == "code"
+    assert release["payload"]["provider_behavior"]["purpose"] == "advisory_review"
+    assert coder["payload"]["provider_behavior"]["request_digest"].startswith("sha256:")
+    assert release["payload"]["provider_behavior"]["output_digest"].startswith("sha256:")

--- a/tests/e2e/test_barebones_evals.py
+++ b/tests/e2e/test_barebones_evals.py
@@ -1418,7 +1418,8 @@ def test_credential_material_is_blocked_in_non_python_files(tmp_path: Path) -> N
     )
 
     assert result.state is RunState.HALTED
-    assert result.cause == "REPEAT_FINDING_WITHOUT_RELEVANT_CHANGE:.env"
+    assert result.cause == "MODEL_RESPONSE_CONTAINS_CREDENTIAL"
+    assert "AKIAABCDEFGHIJKLMNOP" not in result.evidence_path.read_text()
 
 
 @pytest.mark.parametrize("operator,value", [("lte", 2), ("gt", 0)])

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -47,9 +47,7 @@ def test_barebones_cli_runs_a_contract_without_cloud_services(
     approval = events[0]["payload"]["approval"]
     assert approval["status"] == "VERIFIED"
     assert approval["authority"] == "fixture-human"
-    receipt = json.loads(
-        (_REPOSITORY / "examples/barebones/e1-approval-receipt.json").read_text()
-    )
+    receipt = json.loads((_REPOSITORY / "examples/barebones/e1-approval-receipt.json").read_text())
     assert approval["receipt_digest"] == receipt["receipt_digest"]
     assert approval["receipt_blob_digest"].startswith("sha256:")
 

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -165,7 +165,7 @@ def test_malformed_contract_is_reported_without_a_traceback(
             "malformed-contract",
             "--repository-root",
             str(tmp_path),
-            "--provider-command",
+            "--expected-approver",\n            "fixture-human",\n            "--provider-command",
             "provider",
         ]
     )
@@ -194,7 +194,7 @@ def test_non_empty_workspace_is_rejected_before_evidence_is_created(
             "occupied-workspace",
             "--repository-root",
             str(tmp_path),
-            "--provider-command",
+            "--expected-approver",\n            "fixture-human",\n            "--provider-command",
             "provider",
         ]
     )
@@ -223,7 +223,7 @@ def test_workspace_cannot_overlap_evidence_storage(
             "overlapping-roots",
             "--repository-root",
             str(workspace),
-            "--provider-command",
+            "--expected-approver",\n            "fixture-human",\n            "--provider-command",
             "provider",
         ]
     )

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -203,6 +203,33 @@ def test_model_response_credentials_are_rejected_before_evidence() -> None:
         )
 
 
+def test_non_finite_provider_cost_is_classified_before_evidence(tmp_path: Path) -> None:
+    class NonFiniteCostProvider:
+        def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+            return {
+                "request_digest": request["request_digest"],
+                "files": {},
+                "usage": {"estimated_cost_usd": float("inf")},
+            }
+
+    contract = json.loads((_REPOSITORY / "examples/barebones/e1-contract.json").read_text())
+    result = run_to_release_ready(
+        contract=contract,
+        repository_root=tmp_path,
+        workspace=tmp_path / "candidate",
+        run_id="non-finite-provider-cost",
+        provider=NonFiniteCostProvider(),
+    )
+
+    assert result.state is RunState.HALTED
+    assert result.cause == "MODEL_PROVIDER_USAGE_INVALID"
+    assert result.model_calls == 1
+    assert result.telemetry["estimated_cost_usd"] == 0.0
+    event = json.loads(result.evidence_path.read_text().splitlines()[-1])
+    assert event["payload"]["cause"] == "MODEL_PROVIDER_USAGE_INVALID"
+    assert event["payload"]["telemetry"]["estimated_cost_usd"] == 0.0
+
+
 def test_provider_error_credentials_are_classified_without_persisting_secret() -> None:
     secret = "sk-" + "a" * 24
 

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -155,6 +155,7 @@ def test_provider_timeout_is_a_classified_halt(
     event = json.loads(result.evidence_path.read_text().splitlines()[-1])
     assert event["event_type"] == "halted"
     assert event["payload"]["cause"] == "MODEL_PROVIDER_TIMEOUT"
+    assert event["payload"]["telemetry"] == result.telemetry
 
 
 def test_malformed_contract_is_reported_without_a_traceback(

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -203,13 +203,16 @@ def test_model_response_credentials_are_rejected_before_evidence() -> None:
         )
 
 
-def test_non_finite_provider_cost_is_classified_before_evidence(tmp_path: Path) -> None:
-    class NonFiniteCostProvider:
+@pytest.mark.parametrize("invalid_cost", [float("inf"), 10**400])
+def test_invalid_provider_cost_is_classified_before_evidence(
+    tmp_path: Path, invalid_cost: int | float
+) -> None:
+    class InvalidCostProvider:
         def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
             return {
                 "request_digest": request["request_digest"],
                 "files": {},
-                "usage": {"estimated_cost_usd": float("inf")},
+                "usage": {"estimated_cost_usd": invalid_cost},
             }
 
     contract = json.loads((_REPOSITORY / "examples/barebones/e1-contract.json").read_text())
@@ -217,8 +220,8 @@ def test_non_finite_provider_cost_is_classified_before_evidence(tmp_path: Path) 
         contract=contract,
         repository_root=tmp_path,
         workspace=tmp_path / "candidate",
-        run_id="non-finite-provider-cost",
-        provider=NonFiniteCostProvider(),
+        run_id="invalid-provider-cost",
+        provider=InvalidCostProvider(),
     )
 
     assert result.state is RunState.HALTED
@@ -267,6 +270,45 @@ def test_accumulated_provider_cost_overflow_is_rejected_before_assignment() -> N
         )
 
     assert counters["estimated_cost_usd"] == 1e308
+
+
+def test_accumulated_provider_tokens_outside_json_range_are_rejected() -> None:
+    class HugeTokenProvider:
+        def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+            return {
+                "request_digest": request["request_digest"],
+                "files": {},
+                "usage": {"input_tokens": (1 << 53) - 1},
+            }
+
+    counters: dict[str, Any] = {
+        "calls": 0,
+        "bytes": 0,
+        "tokens_in": 0,
+        "tokens_out": 0,
+        "estimated_cost_usd": 0.0,
+        "provider_model_id": "",
+    }
+    provider = HugeTokenProvider()
+    request = {"request_digest": "bound"}
+    barebones_runtime._invoke_bound(
+        provider,
+        purpose="code",
+        request=request,
+        budget=BudgetCaps(),
+        counters=counters,
+    )
+
+    with pytest.raises(RuntimeError, match="MODEL_PROVIDER_USAGE_INVALID"):
+        barebones_runtime._invoke_bound(
+            provider,
+            purpose="advisory_review",
+            request=request,
+            budget=BudgetCaps(),
+            counters=counters,
+        )
+
+    assert counters["tokens_in"] == (1 << 53) - 1
 
 
 def test_provider_error_credentials_are_classified_without_persisting_secret() -> None:

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from pmpe.barebones import RunState, run_to_release_ready
+from pmpe import barebones as barebones_runtime
+from pmpe.barebones import BudgetCaps, RunState, run_to_release_ready
 from pmpe.cli import barebones_cmd, build_parser
 from pmpe.cli.barebones_cmd import CommandModelProvider
 
@@ -25,6 +26,8 @@ def test_barebones_cli_runs_a_contract_without_cloud_services(
             "cli-e1",
             "--repository-root",
             str(tmp_path),
+            "--expected-approver",
+            "fixture-human",
             "--provider-command",
             f"{sys.executable} {repository / 'examples/barebones/e1-provider.py'}",
         ]
@@ -34,6 +37,93 @@ def test_barebones_cli_runs_a_contract_without_cloud_services(
     output = json.loads(capsys.readouterr().out)
     assert output["state"] == "RELEASE_READY"
     assert output["model_calls"] == 2
+
+
+def test_unapproved_contract_is_rejected_before_provider(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    contract = tmp_path / "unapproved.json"
+    contract.write_text(
+        json.dumps(
+            {
+                "contract_id": "PMOS-UNAPPROVED",
+                "contract_status": "DRAFT",
+                "approved_by": "fixture-human",
+            }
+        )
+    )
+    args = build_parser().parse_args(
+        [
+            "barebones",
+            str(contract),
+            "--workspace",
+            str(tmp_path / "candidate"),
+            "--run-id",
+            "unapproved",
+            "--repository-root",
+            str(tmp_path),
+            "--expected-approver",
+            "fixture-human",
+            "--provider-command",
+            "must-not-run",
+        ]
+    )
+
+    assert args.fn(args) == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["detail"] == "contract_status must be APPROVED"
+
+
+def test_approver_mismatch_is_rejected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository = Path(__file__).parents[2]
+    args = build_parser().parse_args(
+        [
+            "barebones",
+            str(repository / "examples/barebones/e1-contract.json"),
+            "--workspace",
+            str(tmp_path / "candidate"),
+            "--run-id",
+            "wrong-approver",
+            "--repository-root",
+            str(tmp_path),
+            "--expected-approver",
+            "different-human",
+            "--provider-command",
+            "must-not-run",
+        ]
+    )
+
+    assert args.fn(args) == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["detail"] == "approved_by does not match --expected-approver"
+
+
+def test_model_response_credentials_are_rejected_before_evidence() -> None:
+    class CredentialProvider:
+        def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+            return {
+                "request_digest": request["request_digest"],
+                "summary": "sk-" + "a" * 24,
+            }
+
+    counters: dict[str, Any] = {
+        "calls": 0,
+        "bytes": 0,
+        "tokens_in": 0,
+        "tokens_out": 0,
+        "estimated_cost_usd": 0.0,
+        "provider_model_id": "",
+    }
+    with pytest.raises(RuntimeError, match="MODEL_RESPONSE_CONTAINS_CREDENTIAL"):
+        barebones_runtime._invoke_bound(
+            CredentialProvider(),
+            purpose="advisory_review",
+            request={"request_digest": "bound"},
+            budget=BudgetCaps(),
+            counters=counters,
+        )
 
 
 def test_provider_timeout_is_a_classified_halt(

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -230,6 +230,45 @@ def test_non_finite_provider_cost_is_classified_before_evidence(tmp_path: Path) 
     assert event["payload"]["telemetry"]["estimated_cost_usd"] == 0.0
 
 
+def test_accumulated_provider_cost_overflow_is_rejected_before_assignment() -> None:
+    class HugeFiniteCostProvider:
+        def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+            return {
+                "request_digest": request["request_digest"],
+                "files": {},
+                "usage": {"estimated_cost_usd": 1e308},
+            }
+
+    counters: dict[str, Any] = {
+        "calls": 0,
+        "bytes": 0,
+        "tokens_in": 0,
+        "tokens_out": 0,
+        "estimated_cost_usd": 0.0,
+        "provider_model_id": "",
+    }
+    provider = HugeFiniteCostProvider()
+    request = {"request_digest": "bound"}
+    barebones_runtime._invoke_bound(
+        provider,
+        purpose="code",
+        request=request,
+        budget=BudgetCaps(),
+        counters=counters,
+    )
+
+    with pytest.raises(RuntimeError, match="MODEL_PROVIDER_USAGE_INVALID"):
+        barebones_runtime._invoke_bound(
+            provider,
+            purpose="advisory_review",
+            request=request,
+            budget=BudgetCaps(),
+            counters=counters,
+        )
+
+    assert counters["estimated_cost_usd"] == 1e308
+
+
 def test_provider_error_credentials_are_classified_without_persisting_secret() -> None:
     secret = "sk-" + "a" * 24
 

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -47,9 +47,11 @@ def test_barebones_cli_runs_a_contract_without_cloud_services(
     approval = events[0]["payload"]["approval"]
     assert approval["status"] == "VERIFIED"
     assert approval["authority"] == "fixture-human"
-    assert approval["receipt_digest"] == approval["receipt_blob_digest"] or approval[
-        "receipt_blob_digest"
-    ].startswith("sha256:")
+    receipt = json.loads(
+        (_REPOSITORY / "examples/barebones/e1-approval-receipt.json").read_text()
+    )
+    assert approval["receipt_digest"] == receipt["receipt_digest"]
+    assert approval["receipt_blob_digest"].startswith("sha256:")
 
 
 def test_unapproved_contract_is_rejected_before_provider(

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -74,9 +74,7 @@ def test_unapproved_contract_is_rejected_before_provider(
     assert output["detail"] == "contract_status must be APPROVED"
 
 
-def test_approver_mismatch_is_rejected(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_approver_mismatch_is_rejected(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     repository = Path(__file__).parents[2]
     args = build_parser().parse_args(
         [
@@ -129,7 +127,9 @@ def test_model_response_credentials_are_rejected_before_evidence() -> None:
 def test_provider_error_credentials_are_classified_without_persisting_secret() -> None:
     secret = "sk-" + "a" * 24
 
-    assert barebones_runtime._classify_provider_error(RuntimeError(secret)) == "MODEL_PROVIDER_FAILED"
+    assert (
+        barebones_runtime._classify_provider_error(RuntimeError(secret)) == "MODEL_PROVIDER_FAILED"
+    )
     assert secret not in barebones_runtime._classify_provider_error(RuntimeError(secret))
 
 

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -13,6 +13,8 @@ from pmpe.barebones import BudgetCaps, RunState, run_to_release_ready
 from pmpe.cli import barebones_cmd, build_parser
 from pmpe.cli.barebones_cmd import CommandModelProvider
 
+_REPOSITORY = Path(__file__).parents[2]
+
 
 def test_barebones_cli_runs_a_contract_without_cloud_services(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -29,7 +31,7 @@ def test_barebones_cli_runs_a_contract_without_cloud_services(
             "--repository-root",
             str(tmp_path),
             "--approval-receipt",
-            str(repository / "examples/barebones/e1-approval-receipt.json"),
+            str(_REPOSITORY / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "fixture-human",
             "--provider-command",
@@ -67,7 +69,7 @@ def test_unapproved_contract_is_rejected_before_provider(
             "--repository-root",
             str(tmp_path),
             "--approval-receipt",
-            str(repository / "examples/barebones/e1-approval-receipt.json"),
+            str(_REPOSITORY / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "fixture-human",
             "--provider-command",
@@ -99,7 +101,7 @@ def test_contract_changed_after_approval_is_rejected(
             "--repository-root",
             str(tmp_path),
             "--approval-receipt",
-            str(repository / "examples/barebones/e1-approval-receipt.json"),
+            str(_REPOSITORY / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "fixture-human",
             "--provider-command",
@@ -125,7 +127,7 @@ def test_approver_mismatch_is_rejected(tmp_path: Path, capsys: pytest.CaptureFix
             "--repository-root",
             str(tmp_path),
             "--approval-receipt",
-            str(repository / "examples/barebones/e1-approval-receipt.json"),
+            str(_REPOSITORY / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "different-human",
             "--provider-command",
@@ -215,7 +217,7 @@ def test_malformed_contract_is_reported_without_a_traceback(
             "--repository-root",
             str(tmp_path),
             "--approval-receipt",
-            str(repository / "examples/barebones/e1-approval-receipt.json"),
+            str(_REPOSITORY / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "fixture-human",
             "--provider-command",
@@ -248,7 +250,7 @@ def test_non_empty_workspace_is_rejected_before_evidence_is_created(
             "--repository-root",
             str(tmp_path),
             "--approval-receipt",
-            str(repository / "examples/barebones/e1-approval-receipt.json"),
+            str(_REPOSITORY / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "fixture-human",
             "--provider-command",
@@ -281,7 +283,7 @@ def test_workspace_cannot_overlap_evidence_storage(
             "--repository-root",
             str(workspace),
             "--approval-receipt",
-            str(repository / "examples/barebones/e1-approval-receipt.json"),
+            str(_REPOSITORY / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "fixture-human",
             "--provider-command",

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import pytest
 

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -28,6 +28,8 @@ def test_barebones_cli_runs_a_contract_without_cloud_services(
             "cli-e1",
             "--repository-root",
             str(tmp_path),
+            "--approval-receipt",
+            str(repository / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "fixture-human",
             "--provider-command",
@@ -64,6 +66,8 @@ def test_unapproved_contract_is_rejected_before_provider(
             "unapproved",
             "--repository-root",
             str(tmp_path),
+            "--approval-receipt",
+            str(repository / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "fixture-human",
             "--provider-command",
@@ -74,6 +78,38 @@ def test_unapproved_contract_is_rejected_before_provider(
     assert args.fn(args) == 3
     output = json.loads(capsys.readouterr().out)
     assert output["detail"] == "contract_status must be APPROVED"
+
+
+def test_contract_changed_after_approval_is_rejected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository = Path(__file__).parents[2]
+    contract = json.loads((repository / "examples/barebones/e1-contract.json").read_text())
+    contract["functional_requirements"]["FR-001"]["statement"] = "Unapproved change"
+    changed = tmp_path / "changed.json"
+    changed.write_text(json.dumps(contract))
+    args = build_parser().parse_args(
+        [
+            "barebones",
+            str(changed),
+            "--workspace",
+            str(tmp_path / "candidate"),
+            "--run-id",
+            "changed-after-approval",
+            "--repository-root",
+            str(tmp_path),
+            "--approval-receipt",
+            str(repository / "examples/barebones/e1-approval-receipt.json"),
+            "--expected-approver",
+            "fixture-human",
+            "--provider-command",
+            "must-not-run",
+        ]
+    )
+
+    assert args.fn(args) == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["detail"] == "approval receipt is not bound to the approved contract"
 
 
 def test_approver_mismatch_is_rejected(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -88,6 +124,8 @@ def test_approver_mismatch_is_rejected(tmp_path: Path, capsys: pytest.CaptureFix
             "wrong-approver",
             "--repository-root",
             str(tmp_path),
+            "--approval-receipt",
+            str(repository / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "different-human",
             "--provider-command",
@@ -154,6 +192,7 @@ def test_provider_timeout_is_a_classified_halt(
 
     assert result.state is RunState.HALTED
     assert result.cause == "MODEL_PROVIDER_TIMEOUT"
+    assert result.model_calls == 1
     event = json.loads(result.evidence_path.read_text().splitlines()[-1])
     assert event["event_type"] == "halted"
     assert event["payload"]["cause"] == "MODEL_PROVIDER_TIMEOUT"
@@ -175,6 +214,8 @@ def test_malformed_contract_is_reported_without_a_traceback(
             "malformed-contract",
             "--repository-root",
             str(tmp_path),
+            "--approval-receipt",
+            str(repository / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "fixture-human",
             "--provider-command",
@@ -206,6 +247,8 @@ def test_non_empty_workspace_is_rejected_before_evidence_is_created(
             "occupied-workspace",
             "--repository-root",
             str(tmp_path),
+            "--approval-receipt",
+            str(repository / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "fixture-human",
             "--provider-command",
@@ -237,6 +280,8 @@ def test_workspace_cannot_overlap_evidence_storage(
             "overlapping-roots",
             "--repository-root",
             str(workspace),
+            "--approval-receipt",
+            str(repository / "examples/barebones/e1-approval-receipt.json"),
             "--expected-approver",
             "fixture-human",
             "--provider-command",

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -126,6 +126,13 @@ def test_model_response_credentials_are_rejected_before_evidence() -> None:
         )
 
 
+def test_provider_error_credentials_are_classified_without_persisting_secret() -> None:
+    secret = "sk-" + "a" * 24
+
+    assert barebones_runtime._classify_provider_error(RuntimeError(secret)) == "MODEL_PROVIDER_FAILED"
+    assert secret not in barebones_runtime._classify_provider_error(RuntimeError(secret))
+
+
 def test_provider_timeout_is_a_classified_halt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -165,7 +172,9 @@ def test_malformed_contract_is_reported_without_a_traceback(
             "malformed-contract",
             "--repository-root",
             str(tmp_path),
-            "--expected-approver",\n            "fixture-human",\n            "--provider-command",
+            "--expected-approver",
+            "fixture-human",
+            "--provider-command",
             "provider",
         ]
     )
@@ -194,7 +203,9 @@ def test_non_empty_workspace_is_rejected_before_evidence_is_created(
             "occupied-workspace",
             "--repository-root",
             str(tmp_path),
-            "--expected-approver",\n            "fixture-human",\n            "--provider-command",
+            "--expected-approver",
+            "fixture-human",
+            "--provider-command",
             "provider",
         ]
     )
@@ -223,7 +234,9 @@ def test_workspace_cannot_overlap_evidence_storage(
             "overlapping-roots",
             "--repository-root",
             str(workspace),
-            "--expected-approver",\n            "fixture-human",\n            "--provider-command",
+            "--expected-approver",
+            "fixture-human",
+            "--provider-command",
             "provider",
         ]
     )

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 from collections.abc import Mapping
@@ -48,8 +49,10 @@ def test_barebones_cli_runs_a_contract_without_cloud_services(
     assert approval["status"] == "VERIFIED"
     assert approval["authority"] == "fixture-human"
     receipt = json.loads((_REPOSITORY / "examples/barebones/e1-approval-receipt.json").read_text())
+    receipt_path = _REPOSITORY / "examples/barebones/e1-approval-receipt.json"
+    submitted_digest = "sha256:" + hashlib.sha256(receipt_path.read_bytes()).hexdigest()
     assert approval["receipt_digest"] == receipt["receipt_digest"]
-    assert approval["receipt_blob_digest"].startswith("sha256:")
+    assert approval["receipt_blob_digest"] == submitted_digest
 
 
 def test_unapproved_contract_is_rejected_before_provider(

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -43,6 +43,13 @@ def test_barebones_cli_runs_a_contract_without_cloud_services(
     output = json.loads(capsys.readouterr().out)
     assert output["state"] == "RELEASE_READY"
     assert output["model_calls"] == 2
+    events = [json.loads(line) for line in Path(output["evidence"]).read_text().splitlines()]
+    approval = events[0]["payload"]["approval"]
+    assert approval["status"] == "VERIFIED"
+    assert approval["authority"] == "fixture-human"
+    assert approval["receipt_digest"] == approval["receipt_blob_digest"] or approval[
+        "receipt_blob_digest"
+    ].startswith("sha256:")
 
 
 def test_unapproved_contract_is_rejected_before_provider(
@@ -80,6 +87,33 @@ def test_unapproved_contract_is_rejected_before_provider(
     assert args.fn(args) == 3
     output = json.loads(capsys.readouterr().out)
     assert output["detail"] == "contract_status must be APPROVED"
+
+
+def test_missing_approval_receipt_is_structured_contract_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = build_parser().parse_args(
+        [
+            "barebones",
+            str(_REPOSITORY / "examples/barebones/e1-contract.json"),
+            "--workspace",
+            str(tmp_path / "candidate"),
+            "--run-id",
+            "missing-receipt",
+            "--repository-root",
+            str(tmp_path),
+            "--approval-receipt",
+            str(tmp_path / "missing.json"),
+            "--expected-approver",
+            "fixture-human",
+            "--provider-command",
+            "must-not-run",
+        ]
+    )
+
+    assert args.fn(args) == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["detail"] == "cannot read approval receipt"
 
 
 def test_contract_changed_after_approval_is_rejected(

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -203,7 +203,7 @@ def test_model_response_credentials_are_rejected_before_evidence() -> None:
         )
 
 
-@pytest.mark.parametrize("invalid_cost", [float("inf"), 10**400])
+@pytest.mark.parametrize("invalid_cost", [float("inf"), 10**400, (1 << 53) + 1])
 def test_invalid_provider_cost_is_classified_before_evidence(
     tmp_path: Path, invalid_cost: int | float
 ) -> None:

--- a/tests/unit/test_openai_responses_provider.py
+++ b/tests/unit/test_openai_responses_provider.py
@@ -120,6 +120,11 @@ def test_configured_token_prices_record_estimated_cost(
     )
 
     assert result["usage"]["estimated_cost_usd"] == pytest.approx(0.00036)
+    assert result["usage"]["pricing"] == {
+        "input_usd_per_million_tokens": 2.0,
+        "output_usd_per_million_tokens": 8.0,
+        "source": "operator_environment",
+    }
 
 
 def test_advisory_output_remains_non_blocking_and_bound() -> None:

--- a/tests/unit/test_openai_responses_provider.py
+++ b/tests/unit/test_openai_responses_provider.py
@@ -127,6 +127,25 @@ def test_configured_token_prices_record_estimated_cost(
     }
 
 
+@pytest.mark.parametrize(
+    ("input_rate", "output_rate"),
+    [("nan", "1"), ("1", "inf"), ("-inf", "1")],
+)
+def test_non_finite_token_prices_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, input_rate: str, output_rate: str
+) -> None:
+    provider = _provider_module()
+    monkeypatch.setenv("PMPE_OPENAI_INPUT_USD_PER_MILLION", input_rate)
+    monkeypatch.setenv("PMPE_OPENAI_OUTPUT_USD_PER_MILLION", output_rate)
+
+    with pytest.raises(SystemExit):
+        provider._provider_response(
+            _message(),
+            _api_response({"files": []}),
+            "gpt-test",
+        )
+
+
 def test_advisory_output_remains_non_blocking_and_bound() -> None:
     provider = _provider_module()
     message = _message("advisory_review")

--- a/tests/unit/test_openai_responses_provider.py
+++ b/tests/unit/test_openai_responses_provider.py
@@ -106,6 +106,22 @@ def test_code_output_is_adapted_to_digest_bound_file_mapping() -> None:
     assert result["usage"]["total_tokens"] == 120
 
 
+def test_configured_token_prices_record_estimated_cost(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _provider_module()
+    monkeypatch.setenv("PMPE_OPENAI_INPUT_USD_PER_MILLION", "2.0")
+    monkeypatch.setenv("PMPE_OPENAI_OUTPUT_USD_PER_MILLION", "8.0")
+
+    result = provider._provider_response(
+        _message(),
+        _api_response({"files": []}),
+        "gpt-test",
+    )
+
+    assert result["usage"]["estimated_cost_usd"] == pytest.approx(0.00036)
+
+
 def test_advisory_output_remains_non_blocking_and_bound() -> None:
     provider = _provider_module()
     message = _message("advisory_review")


### PR DESCRIPTION
Closes #155

## Outcome
Makes the frozen CLI consume only explicitly approved PMOS contracts and records the evidence needed for a real-provider P1 run.

## Changes
- requires `contract_status=APPROVED`, non-empty `approved_by`, and exact `--expected-approver` match before provider invocation
- exposes run telemetry in `RunResult`, CLI JSON, and `release_ready` evidence
- aggregates calls, bytes, input/output tokens, resolved model ID, configured estimated cost, structured criteria, and human tests
- rejects credential-shaped provider responses before evidence blobbing
- computes cost only from operator-supplied current token prices; no volatile prices are hard-coded
- adds planted approval, credential, and cost tests

## Verification
Exact-head CI and Codex review are required before merge.

## Drift artifact wiring (partial #146)
- successful provider calls with complete metadata now emit normalized provider-behavior observations into hash-chained run events
- E1 proves both coder and advisory observations are recorded
- repeated real-provider comparison remains an explicit P1 evidence requirement; this PR does not close #146
