### PR TITLE
Complete the frozen six-state CLI journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ python3.12 -m venv .venv
 source .venv/bin/activate
 pip install -e ".[dev]"
 
-pmpe barebones examples/barebones/e1-contract.json \
+pmpe barebones run examples/barebones/e1-contract.json \
   --workspace /tmp/pmpe-e1-candidate \
   --run-id e1 \
   --repository-root /tmp/pmpe-e1-evidence \
@@ -96,6 +96,22 @@ pmpe barebones examples/barebones/e1-contract.json \
   --expected-approver fixture-human \
   --provider-command "python examples/barebones/e1-provider.py"
 ```
+
+The default product journey is intentionally small:
+
+```bash
+pmpe barebones compile examples/barebones/e1-contract.json --repository-root .
+pmpe barebones status e1 --repository-root /tmp/pmpe-e1-evidence
+pmpe barebones evidence e1 --repository-root /tmp/pmpe-e1-evidence
+pmpe barebones inspect e1 \
+  --repository-root /tmp/pmpe-e1-evidence \
+  --workspace /tmp/pmpe-e1-candidate
+```
+
+`inspect` reads the candidate manifest from the verified evidence chain. When a
+workspace is supplied, it fails with exit code `3` if any sealed file is changed or
+missing, or if an untracked file or symbolic link appears. Use `--file <path>` to print
+one digest-bound UTF-8 candidate file as escaped JSON before the human release decision.
 
 The example provider returns scripted responses. It proves compiler-to-engine plumbing; it does not prove that an LLM can build the requested software.
 

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -41,7 +41,7 @@ defense in depth, checks `codex login status`, and passes the explicit override
 ### Run
 
 ```bash
-pmpe barebones examples/barebones/e1-contract.json \
+pmpe barebones run examples/barebones/e1-contract.json \
   --workspace /tmp/pmpe-codex-e1-candidate \
   --run-id codex-e1 \
   --repository-root /tmp/pmpe-codex-e1-evidence \

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,21 @@
 # Usage — pmpe CLI
 
+## Default six-state journey
+
+The installed product surface is one command group:
+
+| Command | Purpose | Exit codes |
+|---|---|---|
+| `pmpe barebones compile <contract> --repository-root DIR` | compile acceptance truth and report deterministic coverage without starting a run | 0 valid · 3 halted |
+| `pmpe barebones run <contract> ...` | run an approved contract through the bounded Coder and stop at `RELEASE_READY` or `HALTED` | 0 ready · 3 halted |
+| `pmpe barebones status <run_id> --repository-root DIR` | verify the evidence chain and report its current state | 0 valid · 3 invalid |
+| `pmpe barebones evidence <run_id> --repository-root DIR` | verify and locate the event log and referenced blobs | 0 valid · 3 invalid |
+| `pmpe barebones inspect <run_id> --repository-root DIR [--workspace DIR] [--file PATH]` | inspect the sealed candidate and optionally detect workspace drift | 0 match · 3 invalid/drift |
+
+The historical `pmpe barebones <contract> ...` spelling remains a compatibility alias
+for `pmpe barebones run <contract> ...`, but it is not shown as a second product path.
+All commands emit one JSON object so users and automation see the same state.
+
 ## Legacy-compatible commands
 
 | Command | Purpose | Exit codes |

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -326,6 +326,43 @@ def _write_files(root: Path, files: Mapping[str, str]) -> tuple[str, ...]:
     return tuple(changed)
 
 
+def compile_barebones_plan(
+    *,
+    contract: Mapping[str, Any],
+    repository_root: Path,
+    template: Template | None = None,
+) -> AcceptanceBuildPlan:
+    """Compile the same deterministic plan used by the six-state runtime."""
+
+    active_template = template or default_template()
+    template_test_digests: dict[str, str] = {}
+    for test_id, proof in active_template.proofs.items():
+        if not _SAFE_RELATIVE.fullmatch(proof.path) or any(
+            part in {".", ".."} for part in proof.path.split("/")
+        ):
+            raise ContractInvalidError(f"invalid template proof path: {test_id}")
+        target = f"{proof.path}::{proof.node_id}"
+        if proof.path not in active_template.files or target not in proof.command:
+            raise ContractInvalidError(f"invalid template proof binding: {test_id}")
+        template_test_digests[test_id] = (
+            "sha256:" + hashlib.sha256(active_template.files[proof.path].encode()).hexdigest()
+        )
+    trusted_test_digests = {
+        relative: "sha256:" + hashlib.sha256(content.encode()).hexdigest()
+        for relative, content in active_template.files.items()
+        if relative.startswith("tests/")
+    }
+    return compile_acceptance_plan(
+        contract,
+        repository_root=repository_root,
+        registered_actions=frozenset(active_template.actions),
+        template_version=active_template.version,
+        template_test_digests=template_test_digests,
+        registered_measures=frozenset(active_template.measures),
+        trusted_test_digests=trusted_test_digests,
+    )
+
+
 def _path(value: Any, dotted_path: str) -> Any:
     current = value
     for part in dotted_path.split("."):
@@ -905,29 +942,10 @@ def run_to_release_ready(
             "receipt_digest": receipt_digest,
         }
 
-    template_test_digests: dict[str, str] = {}
-    for test_id, proof in active_template.proofs.items():
-        _safe_path(workspace, proof.path)
-        target = f"{proof.path}::{proof.node_id}"
-        if proof.path not in active_template.files or target not in proof.command:
-            raise ContractInvalidError(f"invalid template proof binding: {test_id}")
-        template_test_digests[test_id] = (
-            "sha256:" + hashlib.sha256(active_template.files[proof.path].encode()).hexdigest()
-        )
-    trusted_test_digests = {
-        relative: "sha256:" + hashlib.sha256(content.encode()).hexdigest()
-        for relative, content in active_template.files.items()
-        if relative.startswith("tests/")
-    }
-
-    plan = compile_acceptance_plan(
-        contract,
+    plan = compile_barebones_plan(
+        contract=contract,
         repository_root=repository_root,
-        registered_actions=frozenset(active_template.actions),
-        template_version=active_template.version,
-        template_test_digests=template_test_digests,
-        registered_measures=frozenset(active_template.measures),
-        trusted_test_digests=trusted_test_digests,
+        template=active_template,
     )
     counters["structured_criteria_count"] = sum(item.form != "human_test" for item in plan.criteria)
     counters["human_test_count"] = sum(item.form == "human_test" for item in plan.criteria)

--- a/src/pmpe/cli/__init__.py
+++ b/src/pmpe/cli/__init__.py
@@ -33,6 +33,7 @@ _LEGACY_COMMANDS = frozenset(
         "support-demo",
     }
 )
+_BAREBONES_COMMANDS = frozenset({"compile", "run", "status", "evidence", "inspect"})
 
 
 class PlatformArgumentParser(argparse.ArgumentParser):
@@ -46,6 +47,13 @@ class PlatformArgumentParser(argparse.ArgumentParser):
         values = list(sys.argv[1:] if args is None else args)
         if self.prog == "pmpe" and values and values[0] in _LEGACY_COMMANDS:
             values.insert(0, "legacy")
+        elif (
+            self.prog == "pmpe"
+            and len(values) > 1
+            and values[0] == "barebones"
+            and values[1] not in _BAREBONES_COMMANDS | {"-h", "--help"}
+        ):
+            values.insert(1, "run")
         return super().parse_known_args(values, namespace)
 
 

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -258,7 +258,10 @@ def _run(args: argparse.Namespace) -> int:
 def _verified_events(
     args: argparse.Namespace,
 ) -> tuple[EvidenceLedger, tuple[Mapping[str, Any], ...]]:
-    ledger = EvidenceLedger.open_existing(Path(args.repository_root).resolve(), args.run_id)
+    try:
+        ledger = EvidenceLedger.open_existing(Path(args.repository_root).resolve(), args.run_id)
+    except ValueError as exc:
+        raise EvidenceIntegrityError(str(exc)) from exc
     events = tuple(ledger.verify())
     if not events:
         raise EvidenceIntegrityError("evidence ledger is empty")
@@ -370,6 +373,14 @@ def _candidate_manifest(
 
 
 def _workspace_comparison(workspace: Path, manifest: Mapping[str, str]) -> dict[str, Any]:
+    if workspace.is_symlink():
+        return {
+            "status": "DRIFT",
+            "missing": sorted(manifest),
+            "changed": [],
+            "untracked": [],
+            "symlinks": ["."],
+        }
     if not workspace.is_dir():
         return {
             "status": "DRIFT",
@@ -428,7 +439,7 @@ def _inspect(args: argparse.Namespace) -> int:
             }
         exit_code = 0
         if args.workspace is not None:
-            comparison = _workspace_comparison(Path(args.workspace).resolve(), manifest)
+            comparison = _workspace_comparison(Path(args.workspace), manifest)
             output["workspace"] = comparison
             if comparison["status"] != "MATCH":
                 exit_code = 3

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -195,6 +195,10 @@ def _require_approved_contract(
 
 
 def _run(args: argparse.Namespace) -> int:
+    try:
+        EvidenceLedger.validate_run_id(args.run_id)
+    except ValueError as exc:
+        return _evidence_invalid(EvidenceIntegrityError(str(exc)))
     contract_path = Path(args.contract)
     try:
         contract = _load_contract(contract_path)

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import selectors
@@ -13,17 +14,79 @@ import tempfile
 import time
 from collections.abc import Mapping
 from contextlib import suppress
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
-from pmpe.barebones import ContractInvalidError, run_to_release_ready
+from pmpe.barebones import ContractInvalidError, compile_barebones_plan, run_to_release_ready
 from pmpe.contracts.acceptance import AcceptanceCompileError
 from pmpe.contracts.authoring import verify_contract_approval
 from pmpe.contracts.canonical import CanonicalInputError, strict_loads
 from pmpe.domain.errors import ContractViolation
-from pmpe.evidence.ledger import EvidenceIntegrityError
+from pmpe.evidence.ledger import EvidenceIntegrityError, EvidenceLedger
 
 _PROVIDER_OUTPUT_LIMIT_BYTES = 1_000_000
+
+
+def _json(payload: Mapping[str, Any]) -> None:
+    print(json.dumps(payload, sort_keys=True))
+
+
+def _load_contract(path: Path) -> Mapping[str, Any]:
+    content_type = (
+        "application/yaml" if path.suffix.lower() in {".yaml", ".yml"} else "application/json"
+    )
+    try:
+        source = path.read_bytes()
+    except OSError as exc:
+        raise ContractInvalidError("cannot read contract") from exc
+    contract = strict_loads(source, content_type)
+    if not isinstance(contract, Mapping):
+        raise ContractInvalidError("contract must be an object")
+    return contract
+
+
+def _compile(args: argparse.Namespace) -> int:
+    try:
+        contract = _load_contract(Path(args.contract))
+        plan = compile_barebones_plan(
+            contract=contract,
+            repository_root=Path(args.repository_root).resolve(),
+        )
+    except CanonicalInputError as exc:
+        _json(
+            {
+                "state": "HALTED",
+                "cause": "CONTRACT_INVALID",
+                "diagnostics": [{"code": exc.code, "message": str(exc)}],
+            }
+        )
+        return 3
+    except AcceptanceCompileError as exc:
+        _json(
+            {
+                "state": "HALTED",
+                "cause": "CONTRACT_INVALID",
+                "diagnostics": [item.__dict__ for item in exc.diagnostics],
+            }
+        )
+        return 3
+    except ContractInvalidError as exc:
+        _json({"state": "HALTED", "cause": "CONTRACT_INVALID", "detail": str(exc)})
+        return 3
+    structured = sum(item.form != "human_test" for item in plan.criteria)
+    human = sum(item.form == "human_test" for item in plan.criteria)
+    _json(
+        {
+            "status": "VALIDATED",
+            "coverage": {
+                "structured": structured,
+                "human_test": human,
+                "total": len(plan.criteria),
+            },
+            "plan": plan.as_dict(),
+        }
+    )
+    return 0
 
 
 def _terminate_provider(process: subprocess.Popen[bytes]) -> None:
@@ -134,20 +197,11 @@ def _require_approved_contract(
 def _run(args: argparse.Namespace) -> int:
     contract_path = Path(args.contract)
     try:
-        content_type = (
-            "application/yaml"
-            if contract_path.suffix.lower() in {".yaml", ".yml"}
-            else "application/json"
-        )
-        try:
-            contract_source = contract_path.read_bytes()
-        except OSError as exc:
-            raise ContractInvalidError("cannot read contract") from exc
+        contract = _load_contract(contract_path)
         try:
             receipt_source = Path(args.approval_receipt).read_bytes()
         except OSError as exc:
             raise ContractInvalidError("cannot read approval receipt") from exc
-        contract = strict_loads(contract_source, content_type)
         receipt = strict_loads(receipt_source, "application/json")
         _require_approved_contract(contract, receipt, args.expected_approver)
         result = run_to_release_ready(
@@ -161,73 +215,276 @@ def _run(args: argparse.Namespace) -> int:
             approval_receipt_bytes=receipt_source,
         )
     except CanonicalInputError as exc:
-        print(
-            json.dumps(
-                {
-                    "state": "HALTED",
-                    "cause": "CONTRACT_INVALID",
-                    "diagnostics": [{"code": exc.code, "message": str(exc)}],
-                },
-                sort_keys=True,
-            )
+        _json(
+            {
+                "state": "HALTED",
+                "cause": "CONTRACT_INVALID",
+                "diagnostics": [{"code": exc.code, "message": str(exc)}],
+            }
         )
         return 3
     except AcceptanceCompileError as exc:
-        print(
-            json.dumps(
-                {
-                    "state": "HALTED",
-                    "cause": "CONTRACT_INVALID",
-                    "diagnostics": [item.__dict__ for item in exc.diagnostics],
-                },
-                sort_keys=True,
-            )
+        _json(
+            {
+                "state": "HALTED",
+                "cause": "CONTRACT_INVALID",
+                "diagnostics": [item.__dict__ for item in exc.diagnostics],
+            }
         )
         return 3
     except ContractInvalidError as exc:
-        print(json.dumps({"state": "HALTED", "cause": "CONTRACT_INVALID", "detail": str(exc)}))
+        _json({"state": "HALTED", "cause": "CONTRACT_INVALID", "detail": str(exc)})
         return 3
     except EvidenceIntegrityError as exc:
-        print(json.dumps({"state": "HALTED", "cause": "EVIDENCE_INVALID", "detail": str(exc)}))
+        _json({"state": "HALTED", "cause": "EVIDENCE_INVALID", "detail": str(exc)})
         return 3
-    print(
-        json.dumps(
-            {
-                "run_id": result.run_id,
-                "state": result.state,
-                "cause": result.cause,
-                "attempts": result.attempts,
-                "model_calls": result.model_calls,
-                "elapsed_ms": result.elapsed_ms,
-                "evidence": str(result.evidence_path),
-                "annotation": result.annotation,
-                "telemetry": result.telemetry,
-            },
-            sort_keys=True,
-        )
+    _json(
+        {
+            "run_id": result.run_id,
+            "state": result.state,
+            "cause": result.cause,
+            "attempts": result.attempts,
+            "model_calls": result.model_calls,
+            "elapsed_ms": result.elapsed_ms,
+            "workspace": str(Path(args.workspace).resolve()),
+            "evidence": str(result.evidence_path),
+            "annotation": result.annotation,
+            "telemetry": result.telemetry,
+        }
     )
     return 0 if result.state == "RELEASE_READY" else 3
+
+
+def _verified_events(
+    args: argparse.Namespace,
+) -> tuple[EvidenceLedger, tuple[Mapping[str, Any], ...]]:
+    ledger = EvidenceLedger.open_existing(Path(args.repository_root).resolve(), args.run_id)
+    events = tuple(ledger.verify())
+    if not events:
+        raise EvidenceIntegrityError("evidence ledger is empty")
+    return ledger, events
+
+
+def _evidence_invalid(exc: EvidenceIntegrityError) -> int:
+    _json({"state": "HALTED", "cause": "EVIDENCE_INVALID", "detail": str(exc)})
+    return 3
+
+
+def _status(args: argparse.Namespace) -> int:
+    try:
+        _, events = _verified_events(args)
+    except EvidenceIntegrityError as exc:
+        return _evidence_invalid(exc)
+    terminal = events[-1]
+    payload = terminal.get("payload")
+    payload = payload if isinstance(payload, Mapping) else {}
+    event_type = terminal.get("event_type")
+    cause = payload.get("cause")
+    if not isinstance(cause, str):
+        cause = "PASS" if event_type == "release_ready" else "IN_PROGRESS"
+    telemetry = payload.get("telemetry")
+    _json(
+        {
+            "run_id": args.run_id,
+            "state": terminal.get("state"),
+            "cause": cause,
+            "events": len(events),
+            "head_event_digest": terminal.get("event_digest"),
+            "telemetry": dict(telemetry) if isinstance(telemetry, Mapping) else {},
+        }
+    )
+    return 0
+
+
+def _evidence(args: argparse.Namespace) -> int:
+    try:
+        ledger, events = _verified_events(args)
+    except EvidenceIntegrityError as exc:
+        return _evidence_invalid(exc)
+    referenced = {
+        digest
+        for event in events
+        for digest in event.get("blob_digests", [])
+        if isinstance(digest, str)
+    }
+    _json(
+        {
+            "run_id": args.run_id,
+            "integrity": "PASS",
+            "events": len(events),
+            "referenced_blobs": len(referenced),
+            "head_event_digest": events[-1].get("event_digest"),
+            "events_path": str(ledger.events_path),
+            "blobs_directory": str(ledger.blobs_directory),
+        }
+    )
+    return 0
+
+
+def _safe_manifest_path(value: str) -> bool:
+    path = PurePosixPath(value)
+    return (
+        bool(value)
+        and "\\" not in value
+        and not path.is_absolute()
+        and path.as_posix() == value
+        and all(part not in {"", ".", ".."} for part in path.parts)
+    )
+
+
+def _candidate_manifest(
+    ledger: EvidenceLedger, terminal: Mapping[str, Any]
+) -> tuple[str, dict[str, str]]:
+    if terminal.get("event_type") != "release_ready" or terminal.get("state") != "RELEASE_READY":
+        raise EvidenceIntegrityError("run has no sealed RELEASE_READY candidate")
+    payload = terminal.get("payload")
+    if not isinstance(payload, Mapping):
+        raise EvidenceIntegrityError("release event payload is malformed")
+    candidate_digest = payload.get("candidate_digest")
+    blob_digests = terminal.get("blob_digests")
+    if (
+        not isinstance(candidate_digest, str)
+        or not isinstance(blob_digests, list)
+        or candidate_digest not in blob_digests
+    ):
+        raise EvidenceIntegrityError("release event does not bind a candidate manifest")
+    try:
+        decoded = strict_loads(ledger.read_blob(candidate_digest), "application/json")
+    except CanonicalInputError as exc:
+        raise EvidenceIntegrityError("candidate manifest is malformed") from exc
+    if not isinstance(decoded, dict):
+        raise EvidenceIntegrityError("candidate manifest must be an object")
+    manifest: dict[str, str] = {}
+    for path, digest in decoded.items():
+        if (
+            not isinstance(path, str)
+            or not _safe_manifest_path(path)
+            or not isinstance(digest, str)
+        ):
+            raise EvidenceIntegrityError("candidate manifest entry is malformed")
+        ledger.read_blob(digest)
+        if digest not in blob_digests:
+            raise EvidenceIntegrityError("release event does not bind every candidate file")
+        manifest[path] = digest
+    return candidate_digest, manifest
+
+
+def _workspace_comparison(workspace: Path, manifest: Mapping[str, str]) -> dict[str, Any]:
+    if not workspace.is_dir():
+        return {
+            "status": "DRIFT",
+            "missing": sorted(manifest),
+            "changed": [],
+            "untracked": [],
+            "symlinks": [],
+        }
+    observed: dict[str, str] = {}
+    symlinks: list[str] = []
+    try:
+        for path in sorted(workspace.rglob("*")):
+            relative = path.relative_to(workspace).as_posix()
+            if path.is_symlink():
+                symlinks.append(relative)
+            elif path.is_file():
+                observed[relative] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise EvidenceIntegrityError("candidate workspace cannot be inspected") from exc
+    missing = sorted(set(manifest) - set(observed))
+    untracked = sorted(set(observed) - set(manifest))
+    changed = sorted(
+        path for path in set(manifest) & set(observed) if manifest[path] != observed[path]
+    )
+    return {
+        "status": "MATCH" if not (missing or changed or untracked or symlinks) else "DRIFT",
+        "missing": missing,
+        "changed": changed,
+        "untracked": untracked,
+        "symlinks": symlinks,
+    }
+
+
+def _inspect(args: argparse.Namespace) -> int:
+    try:
+        ledger, events = _verified_events(args)
+        candidate_digest, manifest = _candidate_manifest(ledger, events[-1])
+        output: dict[str, Any] = {
+            "run_id": args.run_id,
+            "state": "RELEASE_READY",
+            "candidate_digest": candidate_digest,
+            "files": manifest,
+        }
+        if args.file is not None:
+            digest = manifest.get(args.file)
+            if digest is None:
+                raise EvidenceIntegrityError("selected file is not in the sealed candidate")
+            try:
+                content = ledger.read_blob(digest).decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise EvidenceIntegrityError("selected candidate file is not UTF-8") from exc
+            output["selected_file"] = {
+                "path": args.file,
+                "digest": digest,
+                "content": content,
+            }
+        exit_code = 0
+        if args.workspace is not None:
+            comparison = _workspace_comparison(Path(args.workspace).resolve(), manifest)
+            output["workspace"] = comparison
+            if comparison["status"] != "MATCH":
+                exit_code = 3
+        _json(output)
+        return exit_code
+    except EvidenceIntegrityError as exc:
+        return _evidence_invalid(exc)
 
 
 def register(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     parser = sub.add_parser(
         "barebones",
-        help="compile a PMOS contract and stop at RELEASE_READY",
+        help="compile, run, and inspect the six-state contract-to-RELEASE_READY journey",
     )
-    parser.add_argument("contract")
-    parser.add_argument("--workspace", required=True)
-    parser.add_argument("--run-id", required=True)
-    parser.add_argument("--repository-root", default=".")
-    parser.add_argument("--approval-receipt", required=True)
-    parser.add_argument(
+    commands = parser.add_subparsers(dest="barebones_command", required=True)
+
+    compile_parser = commands.add_parser(
+        "compile", help="compile a contract and report deterministic coverage"
+    )
+    compile_parser.add_argument("contract")
+    compile_parser.add_argument("--repository-root", default=".")
+    compile_parser.set_defaults(fn=_compile)
+
+    run_parser = commands.add_parser("run", help="run one approved contract")
+    run_parser.add_argument("contract")
+    run_parser.add_argument("--workspace", required=True)
+    run_parser.add_argument("--run-id", required=True)
+    run_parser.add_argument("--repository-root", default=".")
+    run_parser.add_argument("--approval-receipt", required=True)
+    run_parser.add_argument(
         "--expected-approver",
         required=True,
         help="human identity that must exactly match contract approved_by",
     )
-    parser.add_argument(
+    run_parser.add_argument(
         "--provider-command",
         required=True,
         help="local ModelProvider command; receives and returns JSON over stdio",
     )
-    parser.add_argument("--provider-timeout", type=int, default=120)
-    parser.set_defaults(fn=_run)
+    run_parser.add_argument("--provider-timeout", type=int, default=120)
+    run_parser.set_defaults(fn=_run)
+
+    for name, function, help_text in (
+        ("status", _status, "show the verified state of an existing run"),
+        ("evidence", _evidence, "verify and locate an existing evidence chain"),
+    ):
+        inspection = commands.add_parser(name, help=help_text)
+        inspection.add_argument("run_id")
+        inspection.add_argument("--repository-root", default=".")
+        inspection.set_defaults(fn=function)
+
+    inspect_parser = commands.add_parser(
+        "inspect", help="inspect the sealed candidate and optionally detect workspace drift"
+    )
+    inspect_parser.add_argument("run_id")
+    inspect_parser.add_argument("--repository-root", default=".")
+    inspect_parser.add_argument("--workspace")
+    inspect_parser.add_argument("--file")
+    inspect_parser.set_defaults(fn=_inspect)

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -391,13 +391,36 @@ def _workspace_comparison(workspace: Path, manifest: Mapping[str, str]) -> dict[
         }
     observed: dict[str, str] = {}
     symlinks: list[str] = []
+
+    def fail_scan(exc: OSError) -> None:
+        raise EvidenceIntegrityError("candidate workspace cannot be inspected") from exc
+
     try:
-        for path in sorted(workspace.rglob("*")):
-            relative = path.relative_to(workspace).as_posix()
-            if path.is_symlink():
-                symlinks.append(relative)
-            elif path.is_file():
-                observed[relative] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+        for directory, directory_names, file_names in os.walk(
+            workspace,
+            topdown=True,
+            onerror=fail_scan,
+            followlinks=False,
+        ):
+            directory_names.sort()
+            file_names.sort()
+            root = Path(directory)
+            for name in tuple(directory_names):
+                path = root / name
+                if path.is_symlink():
+                    symlinks.append(path.relative_to(workspace).as_posix())
+                    directory_names.remove(name)
+            for name in file_names:
+                path = root / name
+                relative = path.relative_to(workspace).as_posix()
+                if path.is_symlink():
+                    symlinks.append(relative)
+                elif path.is_file():
+                    observed[relative] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+                else:
+                    raise EvidenceIntegrityError(
+                        "candidate workspace contains an unsupported filesystem entry"
+                    )
     except OSError as exc:
         raise EvidenceIntegrityError("candidate workspace cannot be inspected") from exc
     missing = sorted(set(manifest) - set(observed))
@@ -410,7 +433,7 @@ def _workspace_comparison(workspace: Path, manifest: Mapping[str, str]) -> dict[
         "missing": missing,
         "changed": changed,
         "untracked": untracked,
-        "symlinks": symlinks,
+        "symlinks": sorted(symlinks),
     }
 
 

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -99,6 +99,23 @@ class EvidenceLedger:
             Path(temporary_name).unlink(missing_ok=True)
         return digest
 
+    def read_blob(self, digest: str) -> bytes:
+        """Return one verified content-addressed blob without mutating the ledger."""
+
+        match = _DIGEST.fullmatch(digest)
+        if match is None:
+            raise EvidenceIntegrityError("blob digest is malformed")
+        blob_path = self.blobs_directory / match.group(1)
+        try:
+            if not blob_path.is_file():
+                raise EvidenceIntegrityError("evidence blob does not exist")
+            payload = blob_path.read_bytes()
+        except OSError as exc:
+            raise EvidenceIntegrityError("evidence blob cannot be read") from exc
+        if "sha256:" + hashlib.sha256(payload).hexdigest() != digest:
+            raise EvidenceIntegrityError("blob content does not match its digest")
+        return payload
+
     def append(
         self,
         *,
@@ -155,12 +172,12 @@ class EvidenceLedger:
             ):
                 raise EvidenceIntegrityError(f"broken evidence chain at event {expected_sequence}")
             for digest in event.get("blob_digests", []):
-                match = _DIGEST.fullmatch(digest) if isinstance(digest, str) else None
-                blob_path = self.blobs_directory / (match.group(1) if match else "invalid")
-                if match is None or not blob_path.is_file():
+                if not isinstance(digest, str):
                     raise EvidenceIntegrityError("event references a missing blob")
-                if "sha256:" + hashlib.sha256(blob_path.read_bytes()).hexdigest() != digest:
-                    raise EvidenceIntegrityError("blob content does not match its digest")
+                try:
+                    self.read_blob(digest)
+                except EvidenceIntegrityError as exc:
+                    raise EvidenceIntegrityError("event references an invalid blob") from exc
             restored = {**event, "event_digest": event_digest}
             previous = str(event_digest)
             yield restored

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -171,7 +171,12 @@ class EvidenceLedger:
                 or raw_line != canonical_json_bytes({**event, "event_digest": event_digest})
             ):
                 raise EvidenceIntegrityError(f"broken evidence chain at event {expected_sequence}")
-            for digest in event.get("blob_digests", []):
+            if event.get("run_id") != self.run_id:
+                raise EvidenceIntegrityError(f"event run_id mismatch at event {expected_sequence}")
+            blob_digests = event.get("blob_digests")
+            if not isinstance(blob_digests, list):
+                raise EvidenceIntegrityError("event blob_digests must be a list")
+            for digest in blob_digests:
                 if not isinstance(digest, str):
                     raise EvidenceIntegrityError("event references a missing blob")
                 try:

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -153,10 +153,12 @@ class EvidenceLedger:
     def verify(self) -> Iterator[Mapping[str, Any]]:
         if not self.events_path.exists():
             return
+        try:
+            raw_events = self.events_path.read_bytes().splitlines()
+        except OSError as exc:
+            raise EvidenceIntegrityError("evidence ledger cannot be read") from exc
         previous = GENESIS_DIGEST
-        for expected_sequence, raw_line in enumerate(
-            self.events_path.read_bytes().splitlines(), start=1
-        ):
+        for expected_sequence, raw_line in enumerate(raw_events, start=1):
             try:
                 event = json.loads(raw_line)
             except (UnicodeDecodeError, json.JSONDecodeError) as exc:

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -82,9 +82,15 @@ def _validate_event_schema(event: Mapping[str, Any]) -> None:
 class EvidenceLedger:
     """Append-only JSONL events and SHA-256 blobs under one `.pmpe` directory."""
 
-    def __init__(self, repository_root: Path, run_id: str, *, resume: bool = False) -> None:
-        if not _RUN_ID.fullmatch(run_id):
+    @staticmethod
+    def validate_run_id(run_id: str) -> None:
+        """Validate a run identifier without creating evidence directories."""
+
+        if not isinstance(run_id, str) or not _RUN_ID.fullmatch(run_id):
             raise ValueError("run_id must be a bounded filesystem-safe identifier")
+
+    def __init__(self, repository_root: Path, run_id: str, *, resume: bool = False) -> None:
+        self.validate_run_id(run_id)
         self.run_id = run_id
         self.root = repository_root / ".pmpe"
         self.run_directory = self.root / "runs" / run_id
@@ -118,8 +124,7 @@ class EvidenceLedger:
     def open_existing(cls, repository_root: Path, run_id: str) -> EvidenceLedger:
         """Open and verify an existing ledger without attempting to resume its run."""
 
-        if not _RUN_ID.fullmatch(run_id):
-            raise ValueError("run_id must be a bounded filesystem-safe identifier")
+        cls.validate_run_id(run_id)
         ledger = cls.__new__(cls)
         ledger.run_id = run_id
         ledger.root = repository_root / ".pmpe"

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -161,7 +161,7 @@ class EvidenceLedger:
         for expected_sequence, raw_line in enumerate(raw_events, start=1):
             try:
                 event = json.loads(raw_line)
-            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
                 raise EvidenceIntegrityError("event is not canonical JSON") from exc
             if not isinstance(event, dict):
                 raise EvidenceIntegrityError("event must be an object")

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import os
 import re
 import tempfile
@@ -11,7 +10,11 @@ from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-from pmpe.contracts.canonical import canonical_digest, canonical_json_bytes
+from pmpe.contracts.canonical import (
+    canonical_digest,
+    canonical_json_bytes,
+    strict_loads,
+)
 
 _RUN_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
 _DIGEST = re.compile(r"sha256:([0-9a-f]{64})\Z")
@@ -160,11 +163,9 @@ class EvidenceLedger:
         previous = GENESIS_DIGEST
         for expected_sequence, raw_line in enumerate(raw_events, start=1):
             try:
-                event = json.loads(raw_line)
-            except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+                event = strict_loads(raw_line, "application/json")
+            except ValueError as exc:
                 raise EvidenceIntegrityError("event is not canonical JSON") from exc
-            if not isinstance(event, dict):
-                raise EvidenceIntegrityError("event must be an object")
             event_digest = event.pop("event_digest", None)
             if (
                 event.get("sequence") != expected_sequence

--- a/src/pmpe/evidence/ledger.py
+++ b/src/pmpe/evidence/ledger.py
@@ -19,10 +19,64 @@ from pmpe.contracts.canonical import (
 _RUN_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
 _DIGEST = re.compile(r"sha256:([0-9a-f]{64})\Z")
 GENESIS_DIGEST = "sha256:" + "0" * 64
+_EVENT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "run_id",
+        "sequence",
+        "previous_digest",
+        "event_type",
+        "state",
+        "subject_digest",
+        "blob_digests",
+        "payload",
+        "event_digest",
+    }
+)
+_FROZEN_STATES = frozenset(
+    {"VALIDATED", "BUILDING", "VERIFYING", "RELEASE_READY", "HALTED", "STOPPED"}
+)
 
 
 class EvidenceIntegrityError(ValueError):
     """The evidence ledger is malformed or its hash chain is broken."""
+
+
+def _is_digest(value: object) -> bool:
+    return isinstance(value, str) and _DIGEST.fullmatch(value) is not None
+
+
+def _validate_event_schema(event: Mapping[str, Any]) -> None:
+    """Reject records that could not have been emitted by the v1 ledger writer."""
+
+    if set(event) != _EVENT_FIELDS:
+        raise EvidenceIntegrityError("event fields do not match schema version 1.0.0")
+    if event["schema_version"] != "1.0.0":
+        raise EvidenceIntegrityError("event schema_version is unsupported")
+    if not isinstance(event["run_id"], str) or _RUN_ID.fullmatch(event["run_id"]) is None:
+        raise EvidenceIntegrityError("event run_id is malformed")
+    sequence = event["sequence"]
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 1:
+        raise EvidenceIntegrityError("event sequence is malformed")
+    if not _is_digest(event["previous_digest"]):
+        raise EvidenceIntegrityError("event previous_digest is malformed")
+    if not isinstance(event["event_type"], str) or not event["event_type"]:
+        raise EvidenceIntegrityError("event event_type is malformed")
+    if not isinstance(event["state"], str) or event["state"] not in _FROZEN_STATES:
+        raise EvidenceIntegrityError("event state is not a frozen core state")
+    if not _is_digest(event["subject_digest"]):
+        raise EvidenceIntegrityError("event subject_digest is malformed")
+    blob_digests = event["blob_digests"]
+    if not isinstance(blob_digests, list):
+        raise EvidenceIntegrityError("event blob_digests must be a list")
+    if any(not _is_digest(digest) for digest in blob_digests):
+        raise EvidenceIntegrityError("event blob_digests contain a malformed digest")
+    if blob_digests != sorted(set(blob_digests)):
+        raise EvidenceIntegrityError("event blob_digests must be sorted and unique")
+    if not isinstance(event["payload"], dict):
+        raise EvidenceIntegrityError("event payload must be an object")
+    if not _is_digest(event["event_digest"]):
+        raise EvidenceIntegrityError("event event_digest is malformed")
 
 
 class EvidenceLedger:
@@ -130,9 +184,15 @@ class EvidenceLedger:
     ) -> Mapping[str, Any]:
         if self._read_only:
             raise EvidenceIntegrityError("an inspection ledger is read-only")
-        if not event_type or not state or _DIGEST.fullmatch(subject_digest) is None:
+        if (
+            not isinstance(event_type, str)
+            or not event_type
+            or not isinstance(state, str)
+            or state not in _FROZEN_STATES
+            or not _is_digest(subject_digest)
+        ):
             raise ValueError("event type, state, and subject digest are required")
-        if any(_DIGEST.fullmatch(item) is None for item in blob_digests):
+        if any(not _is_digest(item) for item in blob_digests):
             raise ValueError("blob references must be SHA-256 digests")
         events = tuple(self.verify())
         body: dict[str, Any] = {
@@ -147,6 +207,7 @@ class EvidenceLedger:
             "payload": dict(payload or {}),
         }
         event = {**body, "event_digest": canonical_digest(body)}
+        _validate_event_schema(event)
         with self.events_path.open("ab") as stream:
             stream.write(canonical_json_bytes(event) + b"\n")
             stream.flush()
@@ -166,12 +227,14 @@ class EvidenceLedger:
                 event = strict_loads(raw_line, "application/json")
             except ValueError as exc:
                 raise EvidenceIntegrityError("event is not canonical JSON") from exc
-            event_digest = event.pop("event_digest", None)
+            _validate_event_schema(event)
+            event_digest = event["event_digest"]
+            body = {key: value for key, value in event.items() if key != "event_digest"}
             if (
                 event.get("sequence") != expected_sequence
                 or event.get("previous_digest") != previous
-                or event_digest != canonical_digest(event)
-                or raw_line != canonical_json_bytes({**event, "event_digest": event_digest})
+                or event_digest != canonical_digest(body)
+                or raw_line != canonical_json_bytes(event)
             ):
                 raise EvidenceIntegrityError(f"broken evidence chain at event {expected_sequence}")
             if event.get("run_id") != self.run_id:
@@ -186,6 +249,5 @@ class EvidenceLedger:
                     self.read_blob(digest)
                 except EvidenceIntegrityError as exc:
                     raise EvidenceIntegrityError("event references an invalid blob") from exc
-            restored = {**event, "event_digest": event_digest}
             previous = str(event_digest)
-            yield restored
+            yield event

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -119,6 +119,40 @@ def test_missing_approval_receipt_is_structured_contract_error(
     assert output["detail"] == "cannot read approval receipt"
 
 
+def test_invalid_run_id_is_rejected_before_contract_or_provider(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = build_parser().parse_args(
+        [
+            "barebones",
+            "run",
+            str(_REPOSITORY / "examples/barebones/e1-contract.json"),
+            "--workspace",
+            str(tmp_path / "candidate"),
+            "--run-id",
+            "../bad",
+            "--repository-root",
+            str(tmp_path),
+            "--approval-receipt",
+            str(_REPOSITORY / "examples/barebones/e1-approval-receipt.json"),
+            "--expected-approver",
+            "fixture-human",
+            "--provider-command",
+            "must-not-run",
+        ]
+    )
+
+    assert args.fn(args) == 3
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert json.loads(captured.out) == {
+        "cause": "EVIDENCE_INVALID",
+        "detail": "run_id must be a bounded filesystem-safe identifier",
+        "state": "HALTED",
+    }
+    assert not (tmp_path / ".pmpe").exists()
+
+
 def test_contract_changed_after_approval_is_rejected(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit/test_barebones_cli_journey.py
+++ b/tests/unit/test_barebones_cli_journey.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pmpe.cli import main
+from pmpe.evidence.ledger import EvidenceLedger
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _sealed_run(repository_root: Path, run_id: str = "sealed") -> tuple[str, str]:
+    ledger = EvidenceLedger(repository_root, run_id)
+    content = b"def health():\n    return {'status': 'ok'}\n"
+    file_digest = ledger.put_blob(content)
+    manifest_digest = ledger.put_blob(
+        json.dumps({"product.py": file_digest}, sort_keys=True, separators=(",", ":")).encode()
+    )
+    ledger.append(
+        event_type="release_ready",
+        state="RELEASE_READY",
+        subject_digest="sha256:" + "1" * 64,
+        blob_digests=(manifest_digest, file_digest),
+        payload={
+            "candidate_digest": manifest_digest,
+            "telemetry": {"model_calls": 2, "elapsed_ms": 10},
+        },
+    )
+    return manifest_digest, file_digest
+
+
+def test_compile_reports_the_deterministic_plan_without_starting_a_run(
+    tmp_path: Path, capsys
+) -> None:  # type: ignore[no-untyped-def]
+    result = main(
+        [
+            "barebones",
+            "compile",
+            str(ROOT / "examples" / "barebones" / "e1-contract.json"),
+            "--repository-root",
+            str(ROOT),
+        ]
+    )
+
+    assert result == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "VALIDATED"
+    assert output["plan"]["plan_digest"].startswith("sha256:")
+    assert output["coverage"] == {
+        "human_test": 0,
+        "structured": 1,
+        "total": 1,
+    }
+    assert not (tmp_path / ".pmpe").exists()
+
+
+def test_status_and_evidence_verify_the_sealed_chain(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    _sealed_run(tmp_path)
+
+    assert main(["barebones", "status", "sealed", "--repository-root", str(tmp_path)]) == 0
+    status = json.loads(capsys.readouterr().out)
+    assert status["state"] == "RELEASE_READY"
+    assert status["cause"] == "PASS"
+    assert status["events"] == 1
+
+    assert main(["barebones", "evidence", "sealed", "--repository-root", str(tmp_path)]) == 0
+    evidence = json.loads(capsys.readouterr().out)
+    assert evidence["integrity"] == "PASS"
+    assert evidence["events"] == 1
+    assert evidence["referenced_blobs"] == 2
+    assert evidence["head_event_digest"].startswith("sha256:")
+
+
+def test_inspect_reads_only_the_sealed_candidate_and_checks_workspace_drift(
+    tmp_path: Path, capsys
+) -> None:  # type: ignore[no-untyped-def]
+    manifest_digest, file_digest = _sealed_run(tmp_path)
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    content = "def health():\n    return {'status': 'ok'}\n"
+    (workspace / "product.py").write_text(content)
+
+    result = main(
+        [
+            "barebones",
+            "inspect",
+            "sealed",
+            "--repository-root",
+            str(tmp_path),
+            "--workspace",
+            str(workspace),
+            "--file",
+            "product.py",
+        ]
+    )
+
+    assert result == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["candidate_digest"] == manifest_digest
+    assert output["files"] == {"product.py": file_digest}
+    assert output["workspace"] == {
+        "changed": [],
+        "missing": [],
+        "symlinks": [],
+        "status": "MATCH",
+        "untracked": [],
+    }
+    assert output["selected_file"] == {
+        "content": content,
+        "digest": file_digest,
+        "path": "product.py",
+    }
+
+    (workspace / "product.py").write_text("changed\n")
+    assert (
+        main(
+            [
+                "barebones",
+                "inspect",
+                "sealed",
+                "--repository-root",
+                str(tmp_path),
+                "--workspace",
+                str(workspace),
+            ]
+        )
+        == 3
+    )
+    drift = json.loads(capsys.readouterr().out)
+    assert drift["workspace"]["status"] == "DRIFT"
+    assert drift["workspace"]["changed"] == ["product.py"]
+
+
+def test_inspection_fails_closed_when_evidence_is_mutated(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    _, file_digest = _sealed_run(tmp_path)
+    blob = tmp_path / ".pmpe" / "blobs" / file_digest.removeprefix("sha256:")
+    blob.write_bytes(b"mutated")
+
+    result = main(["barebones", "evidence", "sealed", "--repository-root", str(tmp_path)])
+
+    assert result == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["state"] == "HALTED"
+    assert output["cause"] == "EVIDENCE_INVALID"
+
+
+def test_inspection_rejects_duplicate_candidate_manifest_members(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    ledger = EvidenceLedger(tmp_path, "duplicate-manifest")
+    file_digest = ledger.put_blob(b"first")
+    manifest_digest = ledger.put_blob(
+        ('{"product.py":"' + file_digest + '","product.py":"' + file_digest + '"}').encode()
+    )
+    ledger.append(
+        event_type="release_ready",
+        state="RELEASE_READY",
+        subject_digest="sha256:" + "2" * 64,
+        blob_digests=(manifest_digest, file_digest),
+        payload={"candidate_digest": manifest_digest},
+    )
+
+    result = main(
+        [
+            "barebones",
+            "inspect",
+            "duplicate-manifest",
+            "--repository-root",
+            str(tmp_path),
+        ]
+    )
+
+    assert result == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["cause"] == "EVIDENCE_INVALID"
+    assert output["detail"] == "candidate manifest is malformed"

--- a/tests/unit/test_barebones_cli_journey.py
+++ b/tests/unit/test_barebones_cli_journey.py
@@ -225,27 +225,36 @@ def test_inspection_commands_report_invalid_run_ids_as_json(tmp_path: Path, caps
         }
 
 
-def test_status_rejects_a_recursively_nested_event_log_as_json(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
-    ledger = EvidenceLedger(tmp_path, "recursive")
+def test_status_rejects_adversarial_event_json_as_a_controlled_error(
+    tmp_path: Path, capsys
+) -> None:  # type: ignore[no-untyped-def]
     depth = 10_000
-    ledger.events_path.write_text('{"nested":' * depth + "null" + "}" * depth)
-
-    result = main(
-        [
-            "barebones",
-            "status",
-            "recursive",
-            "--repository-root",
-            str(tmp_path),
-        ]
+    hostile_sources = (
+        '{"nested":' * depth + "null" + "}" * depth,
+        '{"integer":' + "1" * 5_000 + "}",
+        '{"number":NaN}',
     )
+    for index, source in enumerate(hostile_sources):
+        run_id = f"hostile-{index}"
+        ledger = EvidenceLedger(tmp_path, run_id)
+        ledger.events_path.write_text(source)
 
-    assert result == 3
-    assert json.loads(capsys.readouterr().out) == {
-        "cause": "EVIDENCE_INVALID",
-        "detail": "event is not canonical JSON",
-        "state": "HALTED",
-    }
+        result = main(
+            [
+                "barebones",
+                "status",
+                run_id,
+                "--repository-root",
+                str(tmp_path),
+            ]
+        )
+
+        assert result == 3
+        assert json.loads(capsys.readouterr().out) == {
+            "cause": "EVIDENCE_INVALID",
+            "detail": "event is not canonical JSON",
+            "state": "HALTED",
+        }
 
 
 def test_inspection_fails_closed_when_evidence_is_mutated(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]

--- a/tests/unit/test_barebones_cli_journey.py
+++ b/tests/unit/test_barebones_cli_journey.py
@@ -225,6 +225,29 @@ def test_inspection_commands_report_invalid_run_ids_as_json(tmp_path: Path, caps
         }
 
 
+def test_status_rejects_a_recursively_nested_event_log_as_json(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    ledger = EvidenceLedger(tmp_path, "recursive")
+    depth = 10_000
+    ledger.events_path.write_text('{"nested":' * depth + "null" + "}" * depth)
+
+    result = main(
+        [
+            "barebones",
+            "status",
+            "recursive",
+            "--repository-root",
+            str(tmp_path),
+        ]
+    )
+
+    assert result == 3
+    assert json.loads(capsys.readouterr().out) == {
+        "cause": "EVIDENCE_INVALID",
+        "detail": "event is not canonical JSON",
+        "state": "HALTED",
+    }
+
+
 def test_inspection_fails_closed_when_evidence_is_mutated(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
     _, file_digest = _sealed_run(tmp_path)
     blob = tmp_path / ".pmpe" / "blobs" / file_digest.removeprefix("sha256:")

--- a/tests/unit/test_barebones_cli_journey.py
+++ b/tests/unit/test_barebones_cli_journey.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from pmpe.cli import main
@@ -159,6 +160,46 @@ def test_inspect_rejects_a_symlinked_workspace_root(tmp_path: Path, capsys) -> N
         "symlinks": ["."],
         "status": "DRIFT",
         "untracked": [],
+    }
+
+
+def test_inspect_fails_closed_when_a_workspace_subtree_cannot_be_scanned(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    _sealed_run(tmp_path)
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    (workspace / "product.py").write_text("def health():\n    return {'status': 'ok'}\n")
+    blocked = workspace / "blocked"
+    blocked.mkdir()
+    (blocked / "untracked.py").write_text("hidden = True\n")
+    original_scandir = os.scandir
+
+    def guarded_scandir(path):  # type: ignore[no-untyped-def]
+        if Path(path) == blocked:
+            raise PermissionError("denied")
+        return original_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", guarded_scandir)
+
+    result = main(
+        [
+            "barebones",
+            "inspect",
+            "sealed",
+            "--repository-root",
+            str(tmp_path),
+            "--workspace",
+            str(workspace),
+        ]
+    )
+
+    assert result == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output == {
+        "cause": "EVIDENCE_INVALID",
+        "detail": "candidate workspace cannot be inspected",
+        "state": "HALTED",
     }
 
 

--- a/tests/unit/test_barebones_cli_journey.py
+++ b/tests/unit/test_barebones_cli_journey.py
@@ -131,6 +131,59 @@ def test_inspect_reads_only_the_sealed_candidate_and_checks_workspace_drift(
     assert drift["workspace"]["changed"] == ["product.py"]
 
 
+def test_inspect_rejects_a_symlinked_workspace_root(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    _sealed_run(tmp_path)
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    (workspace / "product.py").write_text("def health():\n    return {'status': 'ok'}\n")
+    workspace_link = tmp_path / "candidate-link"
+    workspace_link.symlink_to(workspace, target_is_directory=True)
+
+    result = main(
+        [
+            "barebones",
+            "inspect",
+            "sealed",
+            "--repository-root",
+            str(tmp_path),
+            "--workspace",
+            str(workspace_link),
+        ]
+    )
+
+    assert result == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["workspace"] == {
+        "changed": [],
+        "missing": ["product.py"],
+        "symlinks": ["."],
+        "status": "DRIFT",
+        "untracked": [],
+    }
+
+
+def test_inspection_commands_report_invalid_run_ids_as_json(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    for command in ("status", "evidence", "inspect"):
+        result = main(
+            [
+                "barebones",
+                command,
+                "../bad",
+                "--repository-root",
+                str(tmp_path),
+            ]
+        )
+
+        assert result == 3
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert json.loads(captured.out) == {
+            "cause": "EVIDENCE_INVALID",
+            "detail": "run_id must be a bounded filesystem-safe identifier",
+            "state": "HALTED",
+        }
+
+
 def test_inspection_fails_closed_when_evidence_is_mutated(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
     _, file_digest = _sealed_run(tmp_path)
     blob = tmp_path / ".pmpe" / "blobs" / file_digest.removeprefix("sha256:")

--- a/tests/unit/test_default_cli_surface.py
+++ b/tests/unit/test_default_cli_surface.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import argparse
+
 from pmpe.cli import build_parser
 
 
@@ -11,6 +13,12 @@ def test_default_cli_exposes_only_alpha_and_explicit_legacy_boundary() -> None:
 
     assert set(subparsers.choices) == {"barebones", "legacy"}
     assert "deployable software" not in parser.description
+
+    barebones = subparsers.choices["barebones"]
+    lifecycle = next(
+        action for action in barebones._actions if isinstance(action, argparse._SubParsersAction)
+    )
+    assert set(lifecycle.choices) == {"compile", "run", "status", "evidence", "inspect"}
 
 
 def test_legacy_commands_require_the_legacy_prefix() -> None:
@@ -29,3 +37,27 @@ def test_historical_top_level_invocation_is_a_compatibility_alias() -> None:
 
     assert args.command == "legacy"
     assert args.legacy_command == "status"
+
+
+def test_historical_barebones_invocation_is_a_compatibility_alias() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(
+        [
+            "barebones",
+            "contract.json",
+            "--workspace",
+            "/tmp/candidate",
+            "--run-id",
+            "example",
+            "--approval-receipt",
+            "receipt.json",
+            "--expected-approver",
+            "human",
+            "--provider-command",
+            "provider",
+        ]
+    )
+
+    assert args.command == "barebones"
+    assert args.barebones_command == "run"

--- a/tests/unit/test_evidence_ledger.py
+++ b/tests/unit/test_evidence_ledger.py
@@ -107,6 +107,28 @@ def test_verify_rejects_a_hash_consistent_non_list_blob_container(tmp_path: Path
         tuple(ledger.verify())
 
 
+def test_verify_translates_event_log_read_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ledger = EvidenceLedger(tmp_path, "run-001")
+    ledger.append(
+        event_type="validated",
+        state="VALIDATED",
+        subject_digest=canonical_digest({"candidate": 1}),
+    )
+    original_read_bytes = Path.read_bytes
+
+    def guarded_read_bytes(path: Path) -> bytes:
+        if path == ledger.events_path:
+            raise PermissionError("denied")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", guarded_read_bytes)
+
+    with pytest.raises(EvidenceIntegrityError, match="ledger cannot be read"):
+        tuple(ledger.verify())
+
+
 def test_blob_tampering_is_detected(tmp_path: Path) -> None:
     ledger = EvidenceLedger(tmp_path, "run-001")
     blob = ledger.put_blob(b"original")

--- a/tests/unit/test_evidence_ledger.py
+++ b/tests/unit/test_evidence_ledger.py
@@ -86,3 +86,14 @@ def test_blob_tampering_is_detected(tmp_path: Path) -> None:
 
     with pytest.raises(EvidenceIntegrityError):
         tuple(ledger.verify())
+
+
+def test_read_blob_verifies_content_address_before_returning_bytes(tmp_path: Path) -> None:
+    ledger = EvidenceLedger(tmp_path, "run-001")
+    blob = ledger.put_blob(b"sealed candidate file")
+
+    assert ledger.read_blob(blob) == b"sealed candidate file"
+
+    (ledger.blobs_directory / blob.removeprefix("sha256:")).write_bytes(b"changed")
+    with pytest.raises(EvidenceIntegrityError, match="does not match"):
+        ledger.read_blob(blob)

--- a/tests/unit/test_evidence_ledger.py
+++ b/tests/unit/test_evidence_ledger.py
@@ -107,6 +107,56 @@ def test_verify_rejects_a_hash_consistent_non_list_blob_container(tmp_path: Path
         tuple(ledger.verify())
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    (
+        ("schema_version", "2.0.0", "schema_version is unsupported"),
+        ("sequence", True, "sequence is malformed"),
+        ("event_type", None, "event_type is malformed"),
+        ("state", "UNKNOWN", "state is not a frozen core state"),
+        ("subject_digest", None, "subject_digest is malformed"),
+        ("payload", [], "payload must be an object"),
+    ),
+)
+def test_verify_rejects_hash_consistent_events_with_invalid_required_fields(
+    tmp_path: Path, field: str, value: object, message: str
+) -> None:
+    ledger = EvidenceLedger(tmp_path, "run-001")
+    ledger.append(
+        event_type="validated",
+        state="VALIDATED",
+        subject_digest=canonical_digest({"candidate": 1}),
+    )
+    event = json.loads(ledger.events_path.read_text())
+    event.pop("event_digest")
+    event[field] = value
+    event["event_digest"] = canonical_digest(event)
+    ledger.events_path.write_bytes(canonical_json_bytes(event) + b"\n")
+
+    with pytest.raises(EvidenceIntegrityError, match=message):
+        tuple(ledger.verify())
+
+
+@pytest.mark.parametrize("field", ("event_type", "state", "subject_digest", "payload"))
+def test_verify_rejects_hash_consistent_events_missing_required_fields(
+    tmp_path: Path, field: str
+) -> None:
+    ledger = EvidenceLedger(tmp_path, "run-001")
+    ledger.append(
+        event_type="validated",
+        state="VALIDATED",
+        subject_digest=canonical_digest({"candidate": 1}),
+    )
+    event = json.loads(ledger.events_path.read_text())
+    event.pop("event_digest")
+    event.pop(field)
+    event["event_digest"] = canonical_digest(event)
+    ledger.events_path.write_bytes(canonical_json_bytes(event) + b"\n")
+
+    with pytest.raises(EvidenceIntegrityError, match="fields do not match schema"):
+        tuple(ledger.verify())
+
+
 def test_verify_translates_event_log_read_failures(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_evidence_ledger.py
+++ b/tests/unit/test_evidence_ledger.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from pmpe.contracts.canonical import canonical_digest
+from pmpe.contracts.canonical import canonical_digest, canonical_json_bytes
 from pmpe.evidence.ledger import EvidenceIntegrityError, EvidenceLedger
 
 
@@ -71,6 +71,40 @@ def test_event_tampering_is_detected(tmp_path: Path) -> None:
 
     with pytest.raises(EvidenceIntegrityError):
         EvidenceLedger.open_existing(tmp_path, "run-001")
+
+
+def test_open_existing_rejects_an_event_chain_copied_from_another_run(
+    tmp_path: Path,
+) -> None:
+    source = EvidenceLedger(tmp_path, "source")
+    source.append(
+        event_type="validated",
+        state="VALIDATED",
+        subject_digest=canonical_digest({"candidate": 1}),
+    )
+    target_events = tmp_path / ".pmpe" / "runs" / "target" / "events.jsonl"
+    target_events.parent.mkdir(parents=True)
+    target_events.write_bytes(source.events_path.read_bytes())
+
+    with pytest.raises(EvidenceIntegrityError, match="run_id mismatch"):
+        EvidenceLedger.open_existing(tmp_path, "target")
+
+
+def test_verify_rejects_a_hash_consistent_non_list_blob_container(tmp_path: Path) -> None:
+    ledger = EvidenceLedger(tmp_path, "run-001")
+    ledger.append(
+        event_type="validated",
+        state="VALIDATED",
+        subject_digest=canonical_digest({"candidate": 1}),
+    )
+    event = json.loads(ledger.events_path.read_text())
+    event.pop("event_digest")
+    event["blob_digests"] = None
+    event["event_digest"] = canonical_digest(event)
+    ledger.events_path.write_bytes(canonical_json_bytes(event) + b"\n")
+
+    with pytest.raises(EvidenceIntegrityError, match="blob_digests must be a list"):
+        tuple(ledger.verify())
 
 
 def test_blob_tampering_is_detected(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #145.

## Outcome

Completes the frozen six-state CLI journey without adding another engine or product surface.

## What changed

- turns `pmpe barebones` into one `compile | run | status | evidence | inspect` command group
- keeps the historical `pmpe barebones <contract> ...` invocation as a hidden compatibility alias for `run`
- uses one shared deterministic compiler path for both `compile` and `run`
- verifies the complete v1 event schema, hash chain, and every referenced blob before reporting status or evidence
- rejects malformed run IDs before contract/provider/evidence side effects
- inspects only the sealed `RELEASE_READY` candidate manifest
- optionally compares a retained workspace against the sealed manifest and fails on changed, missing, untracked, unreadable, unsupported, or symlinked paths
- supports digest-bound UTF-8 file inspection through JSON
- documents the single default journey and updates real-provider commands

## Architecture guard

No new lifecycle state, worker, provider, database, service, UI, GitHub mutation, deployment, or platform abstraction. Historical packages remain behind the explicit legacy boundary because their test consumers still exist; this PR does not use deletion to manufacture progress.

## Review record

Eight independent Codex P2 threads were accepted, fixed, regression-tested, replied to, and resolved:

1. symlinked workspace root normalization
2. invalid inspection run IDs
3. malformed `blob_digests`
4. unreadable workspace subtrees
5. unreadable event logs
6. recursively nested event JSON
7. incomplete/mistyped event schemas
8. invalid execution run IDs

Additional proactive regressions cover copied cross-run chains, strict JSON limits (deep nesting, oversized integers, and non-finite numbers), and deterministic candidate integrity.

## Verification

- focused CLI/evidence/integration/E1–E5 suite: 117 passed
- Ruff format and lint: passed
- strict mypy on changed sources: passed
- compileall and `git diff --check`: passed
- GitHub CI run `32879401369`: 13/13 jobs passed on exact head
- independent Codex review: clean on exact head `67e50ca264f1b2ef81ac16db778e883a29e7a905`
- corrected trusted-base review rerun: success; checked out main `7525c9fe99dbf6f187b39c949bd264090f8d5536` and emitted `CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD 67e50ca264f1b2ef81ac16db778e883a29e7a905`
- no current unresolved review threads
- remote tree: `18e20cb28e897ce901205a485b4c2acde20d054c`

GitHub's Linux matrix is authoritative for durability tests unavailable in the managed shell because it has no `/proc`.

## Claim boundary

This completes the single default CLI and sealed-candidate inspection surface. It is a functioning local-first alpha reference implementation. It does not prove a real PMOS/model run, cross-contract reuse, deployment, repeated behavior stability, or platform status; #143 and #146 remain the evidence gates.