### PR TITLE
Wait for stable Codex review surfaces

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -58,4 +58,6 @@ jobs:
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CODEX_EVIDENCE_WAIT_SECONDS: 300
+          CODEX_EVIDENCE_STABILITY_SECONDS: 10
+          CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS: 60
         run: python scripts/verify_codex_review.py

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -57,7 +57,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          CODEX_EVIDENCE_WAIT_SECONDS: 300
+          CODEX_EVIDENCE_WAIT_SECONDS: 900
           CODEX_EVIDENCE_STABILITY_SECONDS: 10
           CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS: 60
         run: python scripts/verify_codex_review.py

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - name: Refuse skipped review admission
         env:
@@ -58,6 +58,7 @@ jobs:
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CODEX_EVIDENCE_WAIT_SECONDS: 900
-          CODEX_EVIDENCE_STABILITY_SECONDS: 10
-          CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS: 60
+          CODEX_EVIDENCE_STABILITY_SECONDS: 60
+          CODEX_EVIDENCE_POLL_SECONDS: 10
+          CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS: 180
         run: python scripts/verify_codex_review.py

--- a/docs/PR-REVIEW-AGENT.md
+++ b/docs/PR-REVIEW-AGENT.md
@@ -26,12 +26,14 @@ evidence surfaces and rejects any current exact-head Codex review body or
 non-outdated review thread containing P0/P1/P2. Before admission, it requires
 up to fifteen minutes for the asynchronous deep review to publish, then requires
 the conversation comments, review objects, and complete inline-thread surface
-to remain byte-for-byte stable across two observations ten seconds apart. This
-closes the GitHub publication window where a review object can appear before
-its inline findings. GitHub may represent a clean
-result as a conversation comment or a pull-request review; it is recorded truthfully as
-`CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD`. Missing, stale, owner-authored,
-trigger-only, or finding-bearing evidence fails closed.
+to remain byte-for-byte stable for a full sixty-second quiescence window,
+observed every ten seconds. Any surface change resets the window; failure to
+stabilize within three minutes fails closed. This closes the GitHub publication
+window where a review object can appear before its inline findings. GitHub may
+represent a clean result as a conversation comment or a pull-request review; it
+is recorded truthfully as `CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD`.
+Missing, stale, owner-authored, trigger-only, or finding-bearing evidence fails
+closed.
 
 Draft pull requests are not reviewed. A synchronize event is a new candidate
 and requires a fresh successful exact-head review. Review comments, reactions,

--- a/docs/PR-REVIEW-AGENT.md
+++ b/docs/PR-REVIEW-AGENT.md
@@ -9,12 +9,12 @@ approval.
 `.github/workflows/pr-review.yml` runs only when a same-repository pull request
 is non-draft and is opened, reopened, marked ready, or receives `synchronize`.
 Its concurrency key is the pull request number, so a newer eligible head
-cancels the previous run. The workflow checks out the event SHA (not a branch
-name), then re-observes the current PR head immediately before review; a
-mismatch fails closed. The reviewer is read-only: it cannot commit audit
-records, lessons, or fixes to the candidate branch. The exact-SHA check and
-retained GitHub job log are automated advisory evidence; accepted fixes use
-the normal governed correction loop and receive a new review.
+cancels the previous run. The workflow checks out the protected default branch,
+never candidate code, then re-observes the current PR head immediately before
+admission; a mismatch fails closed. The reviewer is read-only: it cannot commit
+audit records, lessons, or fixes to the candidate branch. The exact-SHA check
+and retained GitHub job log are automated advisory evidence; accepted fixes
+use the normal governed correction loop and receive a new review.
 
 ## Codex evidence policy
 
@@ -24,6 +24,7 @@ GitHub-visible conversation comment identifies the current exact SHA or its
 authenticated pull-request review is bound to that exact SHA. It paginates both
 evidence surfaces and rejects any current exact-head Codex review body or
 non-outdated review thread containing P0/P1/P2. Before admission, it requires
+up to fifteen minutes for the asynchronous deep review to publish, then requires
 the conversation comments, review objects, and complete inline-thread surface
 to remain byte-for-byte stable across two observations ten seconds apart. This
 closes the GitHub publication window where a review object can appear before

--- a/docs/PR-REVIEW-AGENT.md
+++ b/docs/PR-REVIEW-AGENT.md
@@ -23,7 +23,11 @@ head and accepts a clean result only from the Codex bot when either its
 GitHub-visible conversation comment identifies the current exact SHA or its
 authenticated pull-request review is bound to that exact SHA. It paginates both
 evidence surfaces and rejects any current exact-head Codex review body or
-non-outdated review thread containing P0/P1/P2. GitHub may represent a clean
+non-outdated review thread containing P0/P1/P2. Before admission, it requires
+the conversation comments, review objects, and complete inline-thread surface
+to remain byte-for-byte stable across two observations ten seconds apart. This
+closes the GitHub publication window where a review object can appear before
+its inline findings. GitHub may represent a clean
 result as a conversation comment or a pull-request review; it is recorded truthfully as
 `CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD`. Missing, stale, owner-authored,
 trigger-only, or finding-bearing evidence fails closed.

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -211,6 +211,8 @@ def main() -> int:
     deadline = time.monotonic() + wait_seconds
     first_observation = True
     while True:
+        if not first_observation and time.monotonic() >= deadline:
+            raise SystemExit("missing clean exact-head Codex advisory evidence")
         pr = _gh("api", f"repos/{repository}/pulls/{number}")
         if pr["head"]["sha"] != expected:
             raise SystemExit("current PR head changed during Codex evidence verification")
@@ -237,6 +239,8 @@ def main() -> int:
     previous_snapshot: tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]] | None = None
     stable_since: float | None = None
     while True:
+        if previous_snapshot is not None and time.monotonic() >= stability_deadline:
+            raise SystemExit("Codex review surfaces did not stabilize before timeout")
         comments = _all_issue_comments(repository, number)
         reviews = _all_reviews(repository, number)
         threads = _all_review_threads(repository, number)

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -219,13 +219,16 @@ def main() -> int:
         if time.monotonic() >= deadline:
             raise SystemExit("missing clean exact-head Codex advisory evidence")
         time.sleep(10)
-    # GitHub may expose a review object before its inline threads. Admit only
-    # after two separated, identical observations of every review surface.
-    stability_interval = max(0, int(os.environ.get("CODEX_EVIDENCE_STABILITY_SECONDS", "10")))
+    # GitHub may expose a review object before its inline threads. Require a
+    # full quiescence window, resetting it whenever any review surface changes.
+    stability_window = max(0, int(os.environ.get("CODEX_EVIDENCE_STABILITY_SECONDS", "60")))
+    poll_interval = max(0, int(os.environ.get("CODEX_EVIDENCE_POLL_SECONDS", "10")))
     stability_deadline = time.monotonic() + max(
-        0, int(os.environ.get("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "60"))
+        stability_window,
+        int(os.environ.get("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "180")),
     )
     previous_snapshot: tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]] | None = None
+    stable_since: float | None = None
     while True:
         comments = _all_issue_comments(repository, number)
         reviews = _all_reviews(repository, number)
@@ -237,13 +240,17 @@ def main() -> int:
         snapshot = _surface_snapshot(comments, reviews, threads)
         observed_at = time.monotonic()
         if previous_snapshot == snapshot:
-            if observed_at > stability_deadline:
-                raise SystemExit("Codex review surfaces did not stabilize before timeout")
-            break
-        previous_snapshot = snapshot
+            if stable_since is not None and observed_at - stable_since >= stability_window:
+                break
+        else:
+            previous_snapshot = snapshot
+            stable_since = observed_at
         if observed_at >= stability_deadline:
             raise SystemExit("Codex review surfaces did not stabilize before timeout")
-        time.sleep(stability_interval)
+        assert stable_since is not None
+        remaining_window = stability_window - (observed_at - stable_since)
+        remaining_deadline = stability_deadline - observed_at
+        time.sleep(max(0, min(poll_interval, remaining_window, remaining_deadline)))
 
     final_pr = _gh("api", f"repos/{repository}/pulls/{number}")
     if final_pr["head"]["sha"] != expected:

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -239,14 +239,14 @@ def main() -> int:
             raise SystemExit("clean exact-head Codex evidence disappeared during stabilization")
         snapshot = _surface_snapshot(comments, reviews, threads)
         observed_at = time.monotonic()
+        if observed_at >= stability_deadline:
+            raise SystemExit("Codex review surfaces did not stabilize before timeout")
         if previous_snapshot == snapshot:
             if stable_since is not None and observed_at - stable_since >= stability_window:
                 break
         else:
             previous_snapshot = snapshot
             stable_since = observed_at
-        if observed_at >= stability_deadline:
-            raise SystemExit("Codex review surfaces did not stabilize before timeout")
         assert stable_since is not None
         remaining_window = stability_window - (observed_at - stable_since)
         remaining_deadline = stability_deadline - observed_at

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -207,18 +207,24 @@ def main() -> int:
     expected = os.environ["EXPECTED_HEAD"]
     number = os.environ["PR_NUMBER"]
     repository = os.environ["GITHUB_REPOSITORY"]
-    deadline = time.monotonic() + int(os.environ.get("CODEX_EVIDENCE_WAIT_SECONDS", "0"))
+    wait_seconds = max(0, int(os.environ.get("CODEX_EVIDENCE_WAIT_SECONDS", "0")))
+    deadline = time.monotonic() + wait_seconds
+    first_observation = True
     while True:
         pr = _gh("api", f"repos/{repository}/pulls/{number}")
         if pr["head"]["sha"] != expected:
             raise SystemExit("current PR head changed during Codex evidence verification")
         comments = _all_issue_comments(repository, number)
         reviews = _all_reviews(repository, number)
+        observed_at = time.monotonic()
+        if observed_at >= deadline and not (first_observation and wait_seconds == 0):
+            raise SystemExit("missing clean exact-head Codex advisory evidence")
         if _has_clean_evidence(repository, expected, comments, reviews):
             break
-        if time.monotonic() >= deadline:
+        if observed_at >= deadline:
             raise SystemExit("missing clean exact-head Codex advisory evidence")
-        time.sleep(10)
+        first_observation = False
+        time.sleep(max(0, min(10, deadline - observed_at)))
     # GitHub may expose a review object before its inline threads. Require a
     # full quiescence window, resetting it whenever any review surface changes.
     stability_window = max(0, int(os.environ.get("CODEX_EVIDENCE_STABILITY_SECONDS", "60")))

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -216,10 +216,11 @@ def main() -> int:
             raise SystemExit("current PR head changed during Codex evidence verification")
         comments = _all_issue_comments(repository, number)
         reviews = _all_reviews(repository, number)
+        clean = _has_clean_evidence(repository, expected, comments, reviews)
         observed_at = time.monotonic()
         if observed_at >= deadline and not (first_observation and wait_seconds == 0):
             raise SystemExit("missing clean exact-head Codex advisory evidence")
-        if _has_clean_evidence(repository, expected, comments, reviews):
+        if clean:
             break
         if observed_at >= deadline:
             raise SystemExit("missing clean exact-head Codex advisory evidence")
@@ -261,6 +262,8 @@ def main() -> int:
     final_pr = _gh("api", f"repos/{repository}/pulls/{number}")
     if final_pr["head"]["sha"] != expected:
         raise SystemExit("current PR head changed during Codex evidence verification")
+    if time.monotonic() >= stability_deadline:
+        raise SystemExit("Codex review surfaces did not stabilize before timeout")
     print(f"CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD {expected}")
     return 0
 

--- a/scripts/verify_codex_review.py
+++ b/scripts/verify_codex_review.py
@@ -55,7 +55,7 @@ def _all_thread_comments(thread: dict[str, Any]) -> list[dict[str, Any]]:
     while page_info["hasNextPage"]:
         query = (
             "query($id:ID!,$after:String){node(id:$id){... on PullRequestReviewThread"
-            "{comments(first:100,after:$after){nodes{author{login} body}"
+            "{comments(first:100,after:$after){nodes{id author{login} body updatedAt}"
             "pageInfo{hasNextPage endCursor}}}}}"
         )
         result = _gh(
@@ -81,7 +81,8 @@ def _all_review_threads(repository: str, number: str) -> list[dict[str, Any]]:
     query = (
         "query($owner:String!,$name:String!,$number:Int!,$after:String){repository("
         "owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,"
-        "after:$after){nodes{id isOutdated isResolved comments(first:100){nodes{author{login} body}"
+        "after:$after){nodes{id isOutdated isResolved comments(first:100){"
+        "nodes{id author{login} body updatedAt}"
         "pageInfo{hasNextPage endCursor}}}pageInfo{hasNextPage endCursor}}}}}"
     )
     while True:
@@ -132,7 +133,8 @@ def _comment_matches_exact_head(repository: str, expected: str, body: str) -> bo
     if f"**Reviewed commit:** `{short}`" not in body:
         return False
     resolved = _gh("api", f"repos/{repository}/commits/{short}")
-    return resolved["sha"] == expected
+    resolved_sha = resolved.get("sha")
+    return isinstance(resolved_sha, str) and resolved_sha == expected
 
 
 def _has_exact_bot_review(reviews: list[dict[str, Any]], expected: str) -> bool:
@@ -163,15 +165,41 @@ def _has_exact_bot_review_blocker(reviews: list[dict[str, Any]], expected: str) 
 
 
 def _review_snapshot_ids(reviews: list[dict[str, Any]]) -> tuple[str, ...]:
-    """Give a deterministic identity to every REST review in an observation."""
+    """Bind review identity and mutable admission-relevant content."""
     return tuple(
-        sorted(
-            str(
-                review.get("id")
-                or f"{review.get('commit_id')}:{review.get('submitted_at')}:{review.get('body')}"
-            )
-            for review in reviews
+        sorted(json.dumps(review, sort_keys=True, separators=(",", ":")) for review in reviews)
+    )
+
+
+def _surface_snapshot(
+    comments: list[dict[str, Any]],
+    reviews: list[dict[str, Any]],
+    threads: list[dict[str, Any]],
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    """Give all three GitHub review surfaces one deterministic observation identity."""
+
+    def identities(records: list[dict[str, Any]]) -> tuple[str, ...]:
+        return tuple(
+            sorted(json.dumps(record, sort_keys=True, separators=(",", ":")) for record in records)
         )
+
+    return identities(comments), _review_snapshot_ids(reviews), identities(threads)
+
+
+def _has_clean_evidence(
+    repository: str,
+    expected: str,
+    comments: list[dict[str, Any]],
+    reviews: list[dict[str, Any]],
+) -> bool:
+    clean_comment = any(
+        (comment.get("user") or {}).get("login") == BOT
+        and "Codex Review: Didn't find any major issues." in (comment.get("body") or "")
+        and _comment_matches_exact_head(repository, expected, comment.get("body") or "")
+        for comment in comments
+    )
+    return (clean_comment or _has_exact_bot_review(reviews, expected)) and not (
+        _has_exact_bot_review_blocker(reviews, expected)
     )
 
 
@@ -186,37 +214,40 @@ def main() -> int:
             raise SystemExit("current PR head changed during Codex evidence verification")
         comments = _all_issue_comments(repository, number)
         reviews = _all_reviews(repository, number)
-        clean_comment = any(
-            comment["user"]["login"] == BOT
-            and "Codex Review: Didn't find any major issues." in comment["body"]
-            and _comment_matches_exact_head(repository, expected, comment["body"])
-            for comment in comments
-        )
-        clean = (clean_comment or _has_exact_bot_review(reviews, expected)) and not (
-            _has_exact_bot_review_blocker(reviews, expected)
-        )
-        if clean:
+        if _has_clean_evidence(repository, expected, comments, reviews):
             break
         if time.monotonic() >= deadline:
             raise SystemExit("missing clean exact-head Codex advisory evidence")
         time.sleep(10)
-    # Reviews discovered while threads are being paginated can contain inline
-    # blockers absent from the first thread scan. Retry until both surfaces
-    # share one stable review set.
+    # GitHub may expose a review object before its inline threads. Admit only
+    # after two separated, identical observations of every review surface.
+    stability_interval = max(0, int(os.environ.get("CODEX_EVIDENCE_STABILITY_SECONDS", "10")))
+    stability_deadline = time.monotonic() + max(
+        0, int(os.environ.get("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "60"))
+    )
+    previous_snapshot: tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]] | None = None
     while True:
+        comments = _all_issue_comments(repository, number)
+        reviews = _all_reviews(repository, number)
         threads = _all_review_threads(repository, number)
-        final_reviews = _all_reviews(repository, number)
-        if _review_snapshot_ids(reviews) == _review_snapshot_ids(final_reviews):
-            reviews = final_reviews
+        if _has_current_blocker(threads) or _has_exact_bot_review_blocker(reviews, expected):
+            raise SystemExit("current Codex P0/P1/P2 finding blocks admission")
+        if not _has_clean_evidence(repository, expected, comments, reviews):
+            raise SystemExit("clean exact-head Codex evidence disappeared during stabilization")
+        snapshot = _surface_snapshot(comments, reviews, threads)
+        observed_at = time.monotonic()
+        if previous_snapshot == snapshot:
+            if observed_at > stability_deadline:
+                raise SystemExit("Codex review surfaces did not stabilize before timeout")
             break
-        reviews = final_reviews
+        previous_snapshot = snapshot
+        if observed_at >= stability_deadline:
+            raise SystemExit("Codex review surfaces did not stabilize before timeout")
+        time.sleep(stability_interval)
 
-    # A top-level review has no review thread, so inspect its final stable set.
     final_pr = _gh("api", f"repos/{repository}/pulls/{number}")
     if final_pr["head"]["sha"] != expected:
         raise SystemExit("current PR head changed during Codex evidence verification")
-    if _has_current_blocker(threads) or _has_exact_bot_review_blocker(reviews, expected):
-        raise SystemExit("current Codex P0/P1/P2 finding blocks admission")
     print(f"CODEX ADVISORY REVIEW — CLEAN — EXACT HEAD {expected}")
     return 0
 

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -13,7 +13,7 @@ def test_workflow_is_codex_only_and_runs_the_exact_head_evidence_gate() -> None:
     assert "CLAUDE_CODE_OAUTH_TOKEN" not in workflow
     assert "Verify Codex exact-head evidence" in workflow
     assert "scripts/verify_codex_review.py" in workflow
-    assert "CODEX_EVIDENCE_WAIT_SECONDS: 300" in workflow
+    assert "CODEX_EVIDENCE_WAIT_SECONDS: 900" in workflow
     assert "CODEX_EVIDENCE_STABILITY_SECONDS: 10" in workflow
     assert "CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS: 60" in workflow
     assert "contents: read" in workflow

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -565,6 +565,44 @@ def test_slow_clean_observation_cannot_cross_the_publication_deadline(
         verifier_module.main()
 
 
+def test_slow_final_head_check_cannot_cross_the_stabilization_deadline(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    expected = "a" * 40
+    clean_review = {
+        "id": 1,
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "state": "COMMENTED",
+        "body": verifier_module.REVIEW_MARKER,
+    }
+    clock = [0.0]
+    pr_observations = [0]
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_POLL_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "180")
+    monkeypatch.setattr(verifier_module.time, "monotonic", lambda: clock[0])
+
+    def observe_pr(*_args):  # type: ignore[no-untyped-def]
+        pr_observations[0] += 1
+        if pr_observations[0] == 2:
+            clock[0] = 181
+        return {"head": {"sha": expected}}
+
+    monkeypatch.setattr(verifier_module, "_gh", observe_pr)
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+    monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: [clean_review])
+    monkeypatch.setattr(verifier_module, "_all_review_threads", lambda *_args: [])
+
+    with pytest.raises(SystemExit, match="review surfaces did not stabilize before timeout"):
+        verifier_module.main()
+
+
 def test_main_admits_only_after_two_stable_joint_observations(
     monkeypatch: pytest.MonkeyPatch, verifier_module, capsys
 ) -> None:

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -565,6 +565,33 @@ def test_slow_clean_observation_cannot_cross_the_publication_deadline(
         verifier_module.main()
 
 
+def test_publication_deadline_stops_before_starting_another_api_observation(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    expected = "a" * 40
+    clock = [0.0]
+    pr_observations = [0]
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "60")
+    monkeypatch.setattr(verifier_module.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(verifier_module.time, "sleep", lambda _seconds: clock.__setitem__(0, 60))
+
+    def observe_pr(*_args):  # type: ignore[no-untyped-def]
+        pr_observations[0] += 1
+        return {"head": {"sha": expected}}
+
+    monkeypatch.setattr(verifier_module, "_gh", observe_pr)
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+    monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: [])
+
+    with pytest.raises(SystemExit, match="missing clean exact-head Codex advisory evidence"):
+        verifier_module.main()
+    assert pr_observations[0] == 1
+
+
 def test_slow_final_head_check_cannot_cross_the_stabilization_deadline(
     monkeypatch: pytest.MonkeyPatch, verifier_module
 ) -> None:

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -493,6 +493,47 @@ def test_review_surface_change_resets_the_full_quiescence_window(
     assert clock[0] == 80
 
 
+def test_slow_observation_cannot_admit_after_the_stabilization_deadline(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    expected = "a" * 40
+    clean_review = {
+        "id": 1,
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "state": "COMMENTED",
+        "body": verifier_module.REVIEW_MARKER,
+    }
+    clock = [0.0]
+    thread_observations = [0]
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "60")
+    monkeypatch.setenv("CODEX_EVIDENCE_POLL_SECONDS", "10")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "180")
+    monkeypatch.setattr(verifier_module.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        verifier_module.time, "sleep", lambda seconds: clock.__setitem__(0, clock[0] + seconds)
+    )
+    monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+    monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: [clean_review])
+
+    def observe_threads(*_args):  # type: ignore[no-untyped-def]
+        thread_observations[0] += 1
+        if thread_observations[0] == 2:
+            clock[0] = 181
+        return []
+
+    monkeypatch.setattr(verifier_module, "_all_review_threads", observe_threads)
+
+    with pytest.raises(SystemExit, match="review surfaces did not stabilize before timeout"):
+        verifier_module.main()
+
+
 def test_main_admits_only_after_two_stable_joint_observations(
     monkeypatch: pytest.MonkeyPatch, verifier_module, capsys
 ) -> None:

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -296,6 +296,50 @@ def test_main_retries_thread_scan_when_review_set_changes(
         verifier_module.main()
 
 
+def test_main_rechecks_threads_when_review_identity_stays_unchanged(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    """A review can become visible before GitHub publishes its inline threads."""
+    expected = "a" * 40
+    clean_review = {
+        "id": 1,
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "state": "COMMENTED",
+        "body": verifier_module.REVIEW_MARKER,
+    }
+    delayed_blocker = {
+        "id": "thread-delayed",
+        "isOutdated": False,
+        "isResolved": False,
+        "comments": {
+            "nodes": [
+                {
+                    "author": {"login": verifier_module.BOT},
+                    "body": "![P2 Badge] published after the review object",
+                }
+            ]
+        },
+    }
+    review_snapshots = iter([[clean_review], [clean_review], [clean_review]])
+    thread_snapshots = iter([[], [delayed_blocker]])
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "0")
+    monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+    monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: next(review_snapshots))
+    monkeypatch.setattr(
+        verifier_module, "_all_review_threads", lambda *_args: next(thread_snapshots)
+    )
+
+    with pytest.raises(SystemExit, match="current Codex P0/P1/P2 finding blocks admission"):
+        verifier_module.main()
+
+
 def test_all_review_threads_finds_blocker_on_later_graphql_page(
     monkeypatch: pytest.MonkeyPatch, verifier_module
 ) -> None:

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -14,8 +14,9 @@ def test_workflow_is_codex_only_and_runs_the_exact_head_evidence_gate() -> None:
     assert "Verify Codex exact-head evidence" in workflow
     assert "scripts/verify_codex_review.py" in workflow
     assert "CODEX_EVIDENCE_WAIT_SECONDS: 900" in workflow
-    assert "CODEX_EVIDENCE_STABILITY_SECONDS: 10" in workflow
-    assert "CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS: 60" in workflow
+    assert "CODEX_EVIDENCE_STABILITY_SECONDS: 60" in workflow
+    assert "CODEX_EVIDENCE_POLL_SECONDS: 10" in workflow
+    assert "CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS: 180" in workflow
     assert "contents: read" in workflow
     assert "pull-requests: read" in workflow
     assert "issues: read" in workflow
@@ -246,6 +247,7 @@ def test_main_rechecks_review_bodies_after_thread_pagination(
     monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
     monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
     monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_POLL_SECONDS", "0")
     monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
     monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
     monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: next(review_snapshots))
@@ -300,6 +302,7 @@ def test_main_retries_thread_scan_when_review_set_changes(
     monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
     monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
     monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_POLL_SECONDS", "0")
     monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
     monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
     monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: next(review_snapshots))
@@ -344,6 +347,7 @@ def test_main_rechecks_threads_when_review_identity_stays_unchanged(
     monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
     monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
     monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_POLL_SECONDS", "0")
     monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
     monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
     monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: next(review_snapshots))
@@ -353,6 +357,140 @@ def test_main_rechecks_threads_when_review_identity_stays_unchanged(
 
     with pytest.raises(SystemExit, match="current Codex P0/P1/P2 finding blocks admission"):
         verifier_module.main()
+
+
+def test_main_observes_the_full_quiescence_window_before_admission(
+    monkeypatch: pytest.MonkeyPatch, verifier_module, capsys
+) -> None:
+    expected = "a" * 40
+    clean_review = {
+        "id": 1,
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "state": "COMMENTED",
+        "body": verifier_module.REVIEW_MARKER,
+    }
+    clock = [0.0]
+    thread_observations = [0]
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "60")
+    monkeypatch.setenv("CODEX_EVIDENCE_POLL_SECONDS", "10")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "180")
+    monkeypatch.setattr(verifier_module.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        verifier_module.time, "sleep", lambda seconds: clock.__setitem__(0, clock[0] + seconds)
+    )
+    monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+    monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: [clean_review])
+
+    def observe_threads(*_args):  # type: ignore[no-untyped-def]
+        thread_observations[0] += 1
+        return []
+
+    monkeypatch.setattr(verifier_module, "_all_review_threads", observe_threads)
+
+    assert verifier_module.main() == 0
+    assert clock[0] == 60
+    assert thread_observations[0] == 7
+    assert f"CLEAN — EXACT HEAD {expected}" in capsys.readouterr().out
+
+
+def test_main_blocks_a_thread_published_after_the_first_matching_pair(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    expected = "a" * 40
+    clean_review = {
+        "id": 1,
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "state": "COMMENTED",
+        "body": verifier_module.REVIEW_MARKER,
+    }
+    delayed_blocker = {
+        "id": "thread-after-ten-seconds",
+        "isOutdated": False,
+        "isResolved": False,
+        "comments": {
+            "nodes": [
+                {
+                    "author": {"login": verifier_module.BOT},
+                    "body": "![P1 Badge] published after the first matching pair",
+                }
+            ]
+        },
+    }
+    clock = [0.0]
+    thread_snapshots = iter([[], [], [delayed_blocker]])
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "60")
+    monkeypatch.setenv("CODEX_EVIDENCE_POLL_SECONDS", "10")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "180")
+    monkeypatch.setattr(verifier_module.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        verifier_module.time, "sleep", lambda seconds: clock.__setitem__(0, clock[0] + seconds)
+    )
+    monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+    monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: [clean_review])
+    monkeypatch.setattr(
+        verifier_module, "_all_review_threads", lambda *_args: next(thread_snapshots)
+    )
+
+    with pytest.raises(SystemExit, match="current Codex P0/P1/P2 finding blocks admission"):
+        verifier_module.main()
+    assert clock[0] == 20
+
+
+def test_review_surface_change_resets_the_full_quiescence_window(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    expected = "a" * 40
+    clean_review = {
+        "id": 1,
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "state": "COMMENTED",
+        "body": verifier_module.REVIEW_MARKER,
+    }
+    informational_thread = {
+        "id": "informational-thread",
+        "isOutdated": False,
+        "isResolved": True,
+        "comments": {"nodes": [{"author": None, "body": "resolved context"}]},
+    }
+    clock = [0.0]
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "60")
+    monkeypatch.setenv("CODEX_EVIDENCE_POLL_SECONDS", "10")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "180")
+    monkeypatch.setattr(verifier_module.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        verifier_module.time, "sleep", lambda seconds: clock.__setitem__(0, clock[0] + seconds)
+    )
+    monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+    monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: [clean_review])
+    monkeypatch.setattr(
+        verifier_module,
+        "_all_review_threads",
+        lambda *_args: [] if clock[0] < 20 else [informational_thread],
+    )
+
+    assert verifier_module.main() == 0
+    assert clock[0] == 80
 
 
 def test_main_admits_only_after_two_stable_joint_observations(
@@ -374,6 +512,7 @@ def test_main_admits_only_after_two_stable_joint_observations(
     monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
     monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
     monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_POLL_SECONDS", "0")
     monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "60")
     monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
     monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
@@ -404,6 +543,7 @@ def test_main_fails_closed_when_review_surfaces_do_not_stabilize_before_timeout(
     monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
     monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
     monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_POLL_SECONDS", "0")
     monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "0")
     monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
     monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -47,7 +47,7 @@ def test_gate_waits_boundedly_for_asynchronous_codex_evidence() -> None:
 
     assert "CODEX_EVIDENCE_WAIT_SECONDS" in verifier
     assert "time.monotonic()" in verifier
-    assert "time.sleep(10)" in verifier
+    assert "min(10, deadline - observed_at)" in verifier
 
 
 def test_operator_recovery_is_codex_only_and_reenters_the_exact_head_cycle() -> None:
@@ -531,6 +531,37 @@ def test_slow_observation_cannot_admit_after_the_stabilization_deadline(
     monkeypatch.setattr(verifier_module, "_all_review_threads", observe_threads)
 
     with pytest.raises(SystemExit, match="review surfaces did not stabilize before timeout"):
+        verifier_module.main()
+
+
+def test_slow_clean_observation_cannot_cross_the_publication_deadline(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    expected = "a" * 40
+    clean_review = {
+        "id": 1,
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "state": "COMMENTED",
+        "body": verifier_module.REVIEW_MARKER,
+    }
+    clock = [0.0]
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "60")
+    monkeypatch.setattr(verifier_module.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+
+    def slow_reviews(*_args):  # type: ignore[no-untyped-def]
+        clock[0] = 61
+        return [clean_review]
+
+    monkeypatch.setattr(verifier_module, "_all_reviews", slow_reviews)
+
+    with pytest.raises(SystemExit, match="missing clean exact-head Codex advisory evidence"):
         verifier_module.main()
 
 

--- a/tests/unit/test_codex_review_gate.py
+++ b/tests/unit/test_codex_review_gate.py
@@ -14,6 +14,8 @@ def test_workflow_is_codex_only_and_runs_the_exact_head_evidence_gate() -> None:
     assert "Verify Codex exact-head evidence" in workflow
     assert "scripts/verify_codex_review.py" in workflow
     assert "CODEX_EVIDENCE_WAIT_SECONDS: 300" in workflow
+    assert "CODEX_EVIDENCE_STABILITY_SECONDS: 10" in workflow
+    assert "CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS: 60" in workflow
     assert "contents: read" in workflow
     assert "pull-requests: read" in workflow
     assert "issues: read" in workflow
@@ -172,6 +174,17 @@ def test_deleted_review_author_cannot_crash_exact_review_scan(verifier_module) -
     )
 
 
+def test_deleted_comment_author_cannot_crash_clean_evidence_scan(verifier_module) -> None:
+    expected = "a" * 40
+
+    assert not verifier_module._has_clean_evidence(
+        "owner/repo",
+        expected,
+        [{"user": None, "body": None}],
+        [],
+    )
+
+
 def test_any_exact_head_bot_review_with_a_blocker_rejects_the_evidence_set(verifier_module) -> None:
     expected = "a" * 40
     reviews = [
@@ -232,6 +245,7 @@ def test_main_rechecks_review_bodies_after_thread_pagination(
     monkeypatch.setenv("PR_NUMBER", "99")
     monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
     monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "0")
     monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
     monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
     monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: next(review_snapshots))
@@ -285,6 +299,7 @@ def test_main_retries_thread_scan_when_review_set_changes(
     monkeypatch.setenv("PR_NUMBER", "99")
     monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
     monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "0")
     monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
     monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
     monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: next(review_snapshots))
@@ -337,6 +352,65 @@ def test_main_rechecks_threads_when_review_identity_stays_unchanged(
     )
 
     with pytest.raises(SystemExit, match="current Codex P0/P1/P2 finding blocks admission"):
+        verifier_module.main()
+
+
+def test_main_admits_only_after_two_stable_joint_observations(
+    monkeypatch: pytest.MonkeyPatch, verifier_module, capsys
+) -> None:
+    expected = "a" * 40
+    clean_review = {
+        "id": 1,
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "state": "COMMENTED",
+        "body": verifier_module.REVIEW_MARKER,
+    }
+    review_snapshots = iter([[clean_review], [clean_review], [clean_review]])
+    thread_snapshots = iter([[], []])
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "60")
+    monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+    monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: next(review_snapshots))
+    monkeypatch.setattr(
+        verifier_module, "_all_review_threads", lambda *_args: next(thread_snapshots)
+    )
+
+    assert verifier_module.main() == 0
+    assert f"CLEAN — EXACT HEAD {expected}" in capsys.readouterr().out
+
+
+def test_main_fails_closed_when_review_surfaces_do_not_stabilize_before_timeout(
+    monkeypatch: pytest.MonkeyPatch, verifier_module
+) -> None:
+    expected = "a" * 40
+    clean_review = {
+        "id": 1,
+        "user": {"login": verifier_module.BOT},
+        "commit_id": expected,
+        "state": "COMMENTED",
+        "body": verifier_module.REVIEW_MARKER,
+    }
+    review_snapshots = iter([[clean_review], [clean_review]])
+
+    monkeypatch.setenv("EXPECTED_HEAD", expected)
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("CODEX_EVIDENCE_WAIT_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_SECONDS", "0")
+    monkeypatch.setenv("CODEX_EVIDENCE_STABILITY_TIMEOUT_SECONDS", "0")
+    monkeypatch.setattr(verifier_module, "_gh", lambda *_args: {"head": {"sha": expected}})
+    monkeypatch.setattr(verifier_module, "_all_issue_comments", lambda *_args: [])
+    monkeypatch.setattr(verifier_module, "_all_reviews", lambda *_args: next(review_snapshots))
+    monkeypatch.setattr(verifier_module, "_all_review_threads", lambda *_args: [])
+
+    with pytest.raises(SystemExit, match="review surfaces did not stabilize before timeout"):
         verifier_module.main()
 
 


### PR DESCRIPTION
Closes #163.

## Outcome

Makes the trusted Codex admission gate wait for a bounded deep review and reject the GitHub publication race where a top-level review becomes visible before its inline findings.

## What changed

- preserves a red-first regression reproducing the delayed-inline-thread race
- snapshots conversation comments, review objects, and complete paginated review threads/comments together
- binds snapshot identity to mutable review content, not only review IDs
- allows up to fifteen minutes for SOL/xhigh-style asynchronous review publication
- requires the complete surface to remain unchanged for a full 60-second quiescence window, polled every 10 seconds
- resets the quiet window on any surface change and fails closed after a separate 180-second stabilization ceiling
- refuses to begin another API observation once either polling deadline is reached
- enforces both publication and stabilization ceilings after all related network work and before any success path
- preserves one immediate observation when the publication wait is explicitly configured to zero
- re-checks current P0/P1/P2 blockers and clean exact-head evidence on every observation
- fails closed if evidence disappears, pagination reveals a blocker, either timeout expires, or the PR head moves
- retains the trusted-base checkout and read-only permissions

## Architecture guard

This is a verifier hardening only: one script, one existing workflow, its focused tests, and operator documentation. It adds no service, queue, database, credential, reviewer, or candidate-controlled execution path.

## Verification

- red commit `c88a1f5`: delayed P2 regression fails against the old verifier
- green implementation: 39 focused policy/workflow tests pass
- regressions cover post-pair delayed blockers, full-window admission, window reset, no post-deadline API start, slow observations/final-head checks crossing deadlines, pagination, exact-head changes, and timeout
- Ruff: passed
- `mypy --strict scripts/verify_codex_review.py`: passed
- compileall: passed
- workflow YAML parse: passed
- `git diff --check`: passed
- final tree: `6f281ade62f636bcf82738d3c8576be9da546e20`

## Review caveat

This PR's automated workflow starts from the currently protected base, which necessarily contains the old verifier. Merge admission therefore also requires a manual exact-head scan of every Codex review/thread. Once merged, subsequent PRs—including #162—will execute the corrected verifier from the protected base.