### PR TITLE
Run real E1 on a protected GitHub Linux runner

### DIFF
--- a/.github/workflows/real-e1.yml
+++ b/.github/workflows/real-e1.yml
@@ -1,0 +1,182 @@
+name: real-e1-evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_paid_run:
+        description: "This run calls the paid OpenAI API"
+        required: true
+        default: CANCEL
+        type: choice
+        options:
+          - CANCEL
+          - RUN_REAL_E1
+
+permissions:
+  contents: read
+
+concurrency:
+  group: real-e1-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  real-e1:
+    if: inputs.confirm_paid_run == 'RUN_REAL_E1'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      RUN_ID: real-e1-${{ github.run_id }}-${{ github.run_attempt }}
+      RUN_ROOT: ${{ runner.temp }}/pmpe-real-e1
+      ARTIFACT_ROOT: ${{ runner.temp }}/pmpe-real-e1-artifact
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Prepare evidence output
+        run: |
+          mkdir -p "$ARTIFACT_ROOT"
+          {
+            echo "repository=$GITHUB_REPOSITORY"
+            echo "commit=$GITHUB_SHA"
+            echo "run_id=$RUN_ID"
+          } > "$ARTIFACT_ROOT/preflight.txt"
+
+      - name: Require the private API credential
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [[ -z "$OPENAI_API_KEY" ]]; then
+            echo "::error::Add OPENAI_API_KEY as a repository Actions secret. Never paste it into a workflow input or repository file."
+            exit 1
+          fi
+
+      - name: Install candidate isolation runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap util-linux
+          sudo tee /etc/apparmor.d/pmpe-bwrap >/dev/null <<'EOF'
+          abi <abi/4.0>,
+          include <tunables/global>
+          /usr/bin/bwrap flags=(unconfined) {
+            userns,
+          }
+          EOF
+          sudo apparmor_parser -r /etc/apparmor.d/pmpe-bwrap
+
+      - name: Install PMPE
+        run: pip install -e ".[dev]"
+
+      - name: Compile the approved contract
+        run: |
+          mkdir -p "$RUN_ROOT"
+          pmpe barebones compile examples/barebones/e1-contract.json \
+            --repository-root "$RUN_ROOT/evidence" \
+            | tee "$ARTIFACT_ROOT/compile.json"
+
+      - name: Run real E1
+        id: real_e1
+        continue-on-error: true
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PMPE_OPENAI_MODEL: gpt-5.6-sol
+          PMPE_OPENAI_INPUT_USD_PER_MILLION: "4"
+          PMPE_OPENAI_OUTPUT_USD_PER_MILLION: "20"
+        run: |
+          set +e
+          pmpe barebones run examples/barebones/e1-contract.json \
+            --workspace "$RUN_ROOT/candidate" \
+            --run-id "$RUN_ID" \
+            --repository-root "$RUN_ROOT/evidence" \
+            --approval-receipt examples/barebones/e1-approval-receipt.json \
+            --expected-approver fixture-human \
+            --provider-command "python $GITHUB_WORKSPACE/examples/barebones/openai-responses-provider.py" \
+            2>&1 | tee "$ARTIFACT_ROOT/run-output.json"
+          run_exit="${PIPESTATUS[0]}"
+          set -e
+          echo "exit_code=$run_exit" >> "$GITHUB_OUTPUT"
+          exit "$run_exit"
+
+      - name: Validate and package all evidence
+        id: package
+        if: always()
+        run: |
+          set +e
+          pmpe barebones status "$RUN_ID" \
+            --repository-root "$RUN_ROOT/evidence" \
+            2>&1 | tee "$ARTIFACT_ROOT/status.json"
+          status_exit="${PIPESTATUS[0]}"
+          pmpe barebones evidence "$RUN_ID" \
+            --repository-root "$RUN_ROOT/evidence" \
+            2>&1 | tee "$ARTIFACT_ROOT/evidence-validation.json"
+          evidence_exit="${PIPESTATUS[0]}"
+          pmpe barebones inspect "$RUN_ID" \
+            --repository-root "$RUN_ROOT/evidence" \
+            --workspace "$RUN_ROOT/candidate" \
+            2>&1 | tee "$ARTIFACT_ROOT/candidate-inspection.json"
+          inspect_exit="${PIPESTATUS[0]}"
+          set -e
+
+          if [[ -d "$RUN_ROOT/evidence" ]]; then
+            mkdir -p "$ARTIFACT_ROOT/evidence"
+            cp -a "$RUN_ROOT/evidence/." "$ARTIFACT_ROOT/evidence/"
+          fi
+          if [[ -d "$RUN_ROOT/candidate" ]]; then
+            mkdir -p "$ARTIFACT_ROOT/candidate"
+            cp -a "$RUN_ROOT/candidate/." "$ARTIFACT_ROOT/candidate/"
+          fi
+
+          {
+            echo "# Real E1 execution"
+            echo
+            echo "- Repository: $GITHUB_REPOSITORY"
+            echo "- Commit: $GITHUB_SHA"
+            echo "- Run ID: $RUN_ID"
+            echo "- Engine exit: ${{ steps.real_e1.outputs.exit_code }}"
+            echo "- Status validation exit: $status_exit"
+            echo "- Evidence validation exit: $evidence_exit"
+            echo "- Candidate inspection exit: $inspect_exit"
+            echo "- Model: gpt-5.6-sol"
+          } > "$ARTIFACT_ROOT/summary.md"
+
+          (
+            cd "$ARTIFACT_ROOT"
+            find . -type f ! -name SHA256SUMS -print0 \
+              | sort -z \
+              | xargs -0 sha256sum > SHA256SUMS
+          )
+
+          echo "status_exit=$status_exit" >> "$GITHUB_OUTPUT"
+          echo "evidence_exit=$evidence_exit" >> "$GITHUB_OUTPUT"
+          echo "inspect_exit=$inspect_exit" >> "$GITHUB_OUTPUT"
+
+          cat "$ARTIFACT_ROOT/summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload complete evidence package
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: real-e1-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/pmpe-real-e1-artifact/
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce successful terminal evidence
+        if: always()
+        env:
+          RUN_EXIT: ${{ steps.real_e1.outputs.exit_code }}
+          STATUS_EXIT: ${{ steps.package.outputs.status_exit }}
+          EVIDENCE_EXIT: ${{ steps.package.outputs.evidence_exit }}
+          INSPECT_EXIT: ${{ steps.package.outputs.inspect_exit }}
+        run: |
+          for result in "$RUN_EXIT" "$STATUS_EXIT" "$EVIDENCE_EXIT" "$INSPECT_EXIT"; do
+            if [[ "$result" != "0" ]]; then
+              echo "::error::Real E1 did not produce a complete RELEASE_READY evidence package."
+              exit 1
+            fi
+          done

--- a/.github/workflows/real-e1.yml
+++ b/.github/workflows/real-e1.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   real-e1:
-    if: inputs.confirm_paid_run == 'RUN_REAL_E1'
+    if: inputs.confirm_paid_run == 'RUN_REAL_E1' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:

--- a/.github/workflows/real-e1.yml
+++ b/.github/workflows/real-e1.yml
@@ -24,6 +24,7 @@ jobs:
     if: inputs.confirm_paid_run == 'RUN_REAL_E1' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    environment: real-e1-paid
     env:
       RUN_ID: real-e1-${{ github.run_id }}-${{ github.run_attempt }}
       RUN_ROOT: ${{ runner.temp }}/pmpe-real-e1
@@ -51,7 +52,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           if [[ -z "$OPENAI_API_KEY" ]]; then
-            echo "::error::Add OPENAI_API_KEY as a repository Actions secret. Never paste it into a workflow input or repository file."
+            echo "::error::Add OPENAI_API_KEY to the protected real-e1-paid environment. Never paste it into a workflow input or repository file."
             exit 1
           fi
 

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -109,10 +109,13 @@ Bubblewrap, and `prlimit` environment required by the candidate sandbox. It has
 read-only repository permission, runs only from merged `main` and never for a pull
 request or push, and requires the explicit `RUN_REAL_E1` paid-run confirmation.
 
-Before the first run, add an Actions repository secret named `OPENAI_API_KEY`. Put the
-key only in that secret; never paste it into a workflow input, issue, PR, chat, or file.
-Then open **Actions → real-e1-evidence → Run workflow**, select `RUN_REAL_E1`, and run
-it from merged `main`.
+Before the first run, create the GitHub environment `real-e1-paid`. Limit its deployment
+branch to `main`, add the API-key owner as its required reviewer, disable administrator
+bypass, and add `OPENAI_API_KEY` as an **environment secret** rather than a repository
+secret. Put the key only in that environment secret; never paste it into a workflow
+input, issue, PR, chat, or file. Then open **Actions → real-e1-evidence → Run
+workflow**, select `RUN_REAL_E1`, run it from merged `main`, and approve the protected
+environment prompt after checking the commit and run identity.
 
 The workflow uses `gpt-5.6-sol` and records the operator rates current on 2026-08-26
 ($4 per million input tokens and $20 per million output tokens). It uploads the run

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -102,6 +102,25 @@ Prices are not hard-coded; the operator supplies the rates recorded in the evide
 bundle. Do not put credentials in a contract, provider command, candidate workspace,
 shell history, evidence directory, or committed file.
 
+### Run E1 on GitHub's Linux runner
+
+The manual `real-e1-evidence` Actions workflow provides the normal Linux `/proc`,
+Bubblewrap, and `prlimit` environment required by the candidate sandbox. It has
+read-only repository permission, never runs for a pull request or push, and requires
+the explicit `RUN_REAL_E1` paid-run confirmation.
+
+Before the first run, add an Actions repository secret named `OPENAI_API_KEY`. Put the
+key only in that secret; never paste it into a workflow input, issue, PR, chat, or file.
+Then open **Actions → real-e1-evidence → Run workflow**, select `RUN_REAL_E1`, and run
+it from merged `main`.
+
+The workflow uses `gpt-5.6-sol` and records the operator rates current on 2026-08-26
+($4 per million input tokens and $20 per million output tokens). It uploads the run
+output, candidate, complete hidden evidence directory, validation results, and a
+SHA-256 manifest even when execution halts. The workflow remains failed unless the
+engine reaches a successful terminal state and every evidence/inspection command
+passes.
+
 ## Usage mapping
 
 PEOS consumes `usage.input_tokens`, `usage.output_tokens`, and an optional

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -106,8 +106,8 @@ shell history, evidence directory, or committed file.
 
 The manual `real-e1-evidence` Actions workflow provides the normal Linux `/proc`,
 Bubblewrap, and `prlimit` environment required by the candidate sandbox. It has
-read-only repository permission, never runs for a pull request or push, and requires
-the explicit `RUN_REAL_E1` paid-run confirmation.
+read-only repository permission, runs only from merged `main` and never for a pull
+request or push, and requires the explicit `RUN_REAL_E1` paid-run confirmation.
 
 Before the first run, add an Actions repository secret named `OPENAI_API_KEY`. Put the
 key only in that secret; never paste it into a workflow input, issue, PR, chat, or file.

--- a/tests/unit/test_real_e1_workflow.py
+++ b/tests/unit/test_real_e1_workflow.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "real-e1.yml"
 

--- a/tests/unit/test_real_e1_workflow.py
+++ b/tests/unit/test_real_e1_workflow.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "real-e1.yml"
+
+
+def test_real_e1_workflow_is_manual_read_only_and_evidence_preserving() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert "workflow_dispatch:" in workflow
+    assert "pull_request:" not in workflow
+    assert "push:" not in workflow
+    assert "schedule:" not in workflow
+    assert "contents: read" in workflow
+    assert "contents: write" not in workflow
+    assert "confirm_paid_run" in workflow
+    assert "RUN_REAL_E1" in workflow
+
+    assert "secrets.OPENAI_API_KEY" in workflow
+    assert "gpt-5.6-sol" in workflow
+    assert 'PMPE_OPENAI_INPUT_USD_PER_MILLION: "4"' in workflow
+    assert 'PMPE_OPENAI_OUTPUT_USD_PER_MILLION: "20"' in workflow
+    assert "bubblewrap util-linux" in workflow
+    assert "apparmor_parser" in workflow
+
+    assert "pmpe barebones run" in workflow
+    assert "examples/barebones/openai-responses-provider.py" in workflow
+    assert "pmpe barebones status" in workflow
+    assert "pmpe barebones evidence" in workflow
+    assert "pmpe barebones inspect" in workflow
+    assert "sha256sum" in workflow
+
+    assert "actions/upload-artifact@v4" in workflow
+    assert "if: always()" in workflow
+    assert "include-hidden-files: true" in workflow
+    assert "if-no-files-found: error" in workflow
+    assert "retention-days: 30" in workflow
+
+    forbidden = ("git push", "gh pr merge", "pmpe legacy deploy", "kubectl", "terraform")
+    assert all(command not in workflow for command in forbidden)

--- a/tests/unit/test_real_e1_workflow.py
+++ b/tests/unit/test_real_e1_workflow.py
@@ -15,6 +15,7 @@ def test_real_e1_workflow_is_manual_read_only_and_evidence_preserving() -> None:
     assert "contents: write" not in workflow
     assert "confirm_paid_run" in workflow
     assert "RUN_REAL_E1" in workflow
+    assert "github.ref == 'refs/heads/main'" in workflow
 
     assert "secrets.OPENAI_API_KEY" in workflow
     assert "gpt-5.6-sol" in workflow

--- a/tests/unit/test_real_e1_workflow.py
+++ b/tests/unit/test_real_e1_workflow.py
@@ -13,11 +13,13 @@ def test_real_e1_workflow_is_manual_read_only_and_evidence_preserving() -> None:
     assert "schedule:" not in workflow
     assert "contents: read" in workflow
     assert "contents: write" not in workflow
+    assert "environment: real-e1-paid" in workflow
     assert "confirm_paid_run" in workflow
     assert "RUN_REAL_E1" in workflow
     assert "github.ref == 'refs/heads/main'" in workflow
 
     assert "secrets.OPENAI_API_KEY" in workflow
+    assert "protected real-e1-paid environment" in workflow
     assert "gpt-5.6-sol" in workflow
     assert 'PMPE_OPENAI_INPUT_USD_PER_MILLION: "4"' in workflow
     assert 'PMPE_OPENAI_OUTPUT_USD_PER_MILLION: "20"' in workflow


### PR DESCRIPTION
Closes #165. Advances #143.

## What changed and why

Adds a manual GitHub Actions path for the one real E1 run that cannot execute in the managed ChatGPT shell because that shell has no normal `/proc`. The workflow uses the existing Responses API adapter on GitHub's Ubuntu runner, preserves the Linux Bubblewrap safety boundary, validates the terminal evidence, and uploads the complete evidence/candidate package.

## Requirement reference

- #143 — one real PMOS contract through a real provider
- #165 — protected GitHub Linux execution path

## Architecture impact

No product-runtime architecture change. This is an execution-only workflow around the already reviewed frozen path:

`approved contract → deterministic compiler → existing Responses provider → Bubblewrap candidate sandbox → evidence validation → human decision`

No service, queue, database, UI, deployment adapter, GitHub mutation, or automatic release is added.

## Tests added

- Red-first remote commit `be982e4`: the workflow safety contract fails because the workflow does not yet exist.
- Final focused suite: 174 collected; 172 passed and 2 environment-dependent sandbox checks skipped in the managed shell.
- Workflow YAML parse: passed.
- Ruff format/lint and diff hygiene: passed.

## Risk level

High because the workflow handles a paid API credential. Owner authorization: Abhillash Jadhav instructed execution of the full piece. Controls: manual confirmation, merged-`main` binding, protected `real-e1-paid` environment approval by the credential owner, administrator bypass disabled, `contents: read`, disabled checkout credentials, no automatic trigger, environment-scoped secret only on the provider step, bounded engine calls/output, Bubblewrap candidate isolation, and no deployment or GitHub write.

## Rollback plan

Revert this PR. The workflow creates no deployment and no durable runtime state outside 30-day GitHub Actions artifacts.

## Evidence

- Exact head: `aa80afbf23712d2760dbdce322ae99a6786ebd29`
- Final tree: `27bcafbbbfa7b35253f6a07a42292237148eafe5` (matches the locally verified tree)
- Test command: focused compiler/provider/evidence/sandbox/CLI/E1–E5 suite plus `tests/unit/test_real_e1_workflow.py`

## Exact-head review admission

- [x] Current head SHA recorded: `aa80afbf23712d2760dbdce322ae99a6786ebd29`
- [ ] Required CI is green for that exact head
- [ ] `PR Review Agent / review` is green for that exact head
- [ ] No unresolved current P0/P1/P2 Codex thread
- [x] Named human release owner has authorized completion after passing review

## Required owner setup before the paid run

Create the protected GitHub environment `real-e1-paid`, restrict it to `main`, make the API-key owner its required reviewer, disable administrator bypass, and add `OPENAI_API_KEY` there as an environment secret. Never paste it into this PR, an issue, chat, workflow input, or repository file.