### PR TITLE
Harden the ChatGPT Codex live-provider path

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # PM Production Engineering OS — Architecture
 
-Phase Zero is the sole admissible shipped lifecycle authority. The architecture below
-documents the historical V1 fixture retained under `tests.legacy_v1`; it is not an
-installed execution path.
+> **Historical / superseded.** This file documents the retained V1 fixture, not the
+> shipped alpha. The authoritative current architecture and claim boundary are in
+> [README.md](README.md). Do not use this file to infer current runtime capabilities.
 
 Principles, in priority order: **extensibility → reliability → simplicity → speed →
 low cost**. Extensibility comes from interfaces and adapters, not frameworks.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ An open-source, local-first reference implementation that compiles a machine-che
 
 | Capability | Evidence status |
 |---|---|
-| Deterministic contract compilation and compile-time rejection | Proven by [exact-head compiler tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/8c096b18839d8265e0fb3cb6fd9660bb4dca9cd7/tests/unit/test_acceptance_compiler.py) in [exact-head CI #32654697877](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32654697877) |
-| Meaningful-RED baseline, bounded repair, and six-state engine | Proven by the [exact-head E1 fixture](https://github.com/Abhillashjadhav/production-engineering-os/blob/8c096b18839d8265e0fb3cb6fd9660bb4dca9cd7/tests/e2e/test_barebones_e1.py) and [planted eval suite](https://github.com/Abhillashjadhav/production-engineering-os/blob/8c096b18839d8265e0fb3cb6fd9660bb4dca9cd7/tests/e2e/test_barebones_evals.py) in [exact-head CI #32654697877](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32654697877) |
-| Hash-chained events and content-addressed evidence blobs | Proven by [exact-head ledger tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/8c096b18839d8265e0fb3cb6fd9660bb4dca9cd7/tests/unit/test_evidence_ledger.py) in [exact-head CI #32654697877](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32654697877) |
-| Candidate execution with real Bubblewrap, no network, a read-only host view, bounded resources, symlink containment, and fail-closed composition | Proven by the [exact-head isolation tests](https://github.com/Abhillashjadhav/production-engineering-os/blob/8c096b18839d8265e0fb3cb6fd9660bb4dca9cd7/tests/unit/test_candidate_sandbox.py) in the dedicated Linux `candidate-isolation` matrix of [exact-head CI #32654697877](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32654697877) |
-| End-to-end scripted-provider `RELEASE_READY` engine path through real Bubblewrap | Proven by the [exact-head E1 fixture](https://github.com/Abhillashjadhav/production-engineering-os/blob/8c096b18839d8265e0fb3cb6fd9660bb4dca9cd7/tests/e2e/test_barebones_e1.py), with the local sandbox fixture disabled under `PMPE_TEST_REAL_SANDBOX=true`, in [exact-head CI #32654697877](https://github.com/Abhillashjadhav/production-engineering-os/actions/runs/32654697877) |
+| Deterministic contract compilation and compile-time rejection | Proven by the [compiler tests](tests/unit/test_acceptance_compiler.py) enforced in [main CI](https://github.com/Abhillashjadhav/production-engineering-os/actions/workflows/ci.yml?query=branch%3Amain) |
+| Meaningful-RED baseline, bounded repair, and six-state engine | Proven by the [E1 fixture](tests/e2e/test_barebones_e1.py) and [planted eval suite](tests/e2e/test_barebones_evals.py) enforced in [main CI](https://github.com/Abhillashjadhav/production-engineering-os/actions/workflows/ci.yml?query=branch%3Amain) |
+| Hash-chained events and content-addressed evidence blobs | Proven by the [ledger tests](tests/unit/test_evidence_ledger.py) enforced in [main CI](https://github.com/Abhillashjadhav/production-engineering-os/actions/workflows/ci.yml?query=branch%3Amain) |
+| Candidate execution with real Bubblewrap, no network, a read-only host view, bounded resources, symlink containment, and fail-closed composition | Proven by the [isolation tests](tests/unit/test_candidate_sandbox.py) in the dedicated Linux `candidate-isolation` matrix of [main CI](https://github.com/Abhillashjadhav/production-engineering-os/actions/workflows/ci.yml?query=branch%3Amain) |
+| End-to-end scripted-provider `RELEASE_READY` engine path through real Bubblewrap | Proven by the [E1 fixture](tests/e2e/test_barebones_e1.py), with the local sandbox fixture disabled under `PMPE_TEST_REAL_SANDBOX=true`, in [main CI](https://github.com/Abhillashjadhav/production-engineering-os/actions/workflows/ci.yml?query=branch%3Amain) |
 | Canonical PMOS contract and digest-bound approval receipt accepted by the boundary | Proven by the [PMOS executable compatibility gate](https://github.com/Abhillashjadhav/PM-agent-OS/blob/5fa7af8207143194eb242f2edd9f7edfca8bb969/tests/decision-to-contract/validate_contract.py), including a planted post-approval tampering rejection |
 | Product built with a real model provider | **Not yet proven** |
 | Repeated real-provider behavioural drift evidence | **Not yet proven** |
@@ -108,6 +108,11 @@ pmpe barebones inspect e1 \
   --workspace /tmp/pmpe-e1-candidate
 ```
 
+`compile` reports `COMPILES` and the contract's recorded status; it does not imply
+human approval or release eligibility. `status`, `evidence`, and `inspect` surface the
+approval record from the verified ledger. `inspect` exits with code `3` for an
+explicitly unverified direct-call run, even when its candidate is otherwise sealed.
+
 `inspect` reads the candidate manifest from the verified evidence chain. When a
 workspace is supplied, it fails with exit code `3` if any sealed file is changed or
 missing, or if an untracked file or symbolic link appears. Use `--file <path>` to print
@@ -115,7 +120,7 @@ one digest-bound UTF-8 candidate file as escaped JSON before the human release d
 
 The example provider returns scripted responses. It proves compiler-to-engine plumbing; it does not prove that an LLM can build the requested software.
 
-For a real-model run, use one of the documented [reference providers](docs/real-model-provider.md): the Responses API adapter or the Codex CLI adapter with saved ChatGPT subscription authentication. Their implementation and unit tests prove the adapter boundary only; no live PMOS-to-real-model run is claimed until its complete evidence bundle is published.
+For the real-model promotion run, use the documented [Codex CLI provider](docs/real-model-provider.md) with saved ChatGPT subscription authentication. It does not require an API key. The optional Responses API example is not the promotion path. Provider implementation and unit tests prove the adapter boundary only; no live PMOS-to-real-model run is claimed until its complete evidence bundle is published.
 
 A provider receives one JSON object on standard input:
 
@@ -126,7 +131,8 @@ A provider receives one JSON object on standard input:
 The contract must contain `contract_status: APPROVED` and `approved_by`; the CLI requires an exact `--expected-approver` match before invoking the provider. The provider must return one UTF-8 JSON object containing the same `request_digest`. Do not record provider credentials in contracts, commands, candidate workspaces, or evidence.
 
 The Codex CLI path is deliberately explicit about its boundaries: it requires a host
-`CODEX_HOME` authenticated with ChatGPT, strips API-key variables, and enforces ChatGPT
+`CODEX_HOME` authenticated with ChatGPT, gives the Codex child only an explicit safe
+environment allowlist, and enforces ChatGPT
 mode again on the command line. Its ephemeral read-only sandbox protects the provider
 run; the separate Bubblewrap sandbox protects candidate execution. The prompt still
 transits OpenAI. Subscription runs record pricing as not applicable per run rather than

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,9 @@
 # Roadmap — PM Production Engineering OS
 
+> **Historical / superseded.** This roadmap predates the frozen alpha and is not a
+> shipped-capability claim. See [README.md](README.md) for the authoritative current
+> architecture, evidence, non-goals, and promotion gates.
+
 ## V1 (shipped) — one honest vertical slice
 
 Spec → validate → plan → architecture → tests-first → implement → gates → PR record →

--- a/docs/TARGET-ARCHITECTURE.md
+++ b/docs/TARGET-ARCHITECTURE.md
@@ -1,5 +1,9 @@
 # Target architecture
 
+> **Historical / superseded.** This is an unimplemented design study, not the shipped
+> product architecture. See [README.md](../README.md) for the authoritative frozen alpha
+> and its evidence-backed claim boundary.
+
 ## Architecture goals
 
 Production Engineering OS (PEOS) consumes an approved PM Agent OS (PMOS) contract

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,5 +1,9 @@
 # Implementation plan (file-by-file)
 
+> **Historical / superseded.** This completed V1 plan is retained for provenance only.
+> See [README.md](../README.md) for the authoritative current architecture and supported
+> product journey.
+
 Order of commits mirrors this order; tests land before the code they test.
 
 ## Commit 1 — PRD + decisions (done)

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -34,9 +34,12 @@ codex login status
 The adapter depends on saved host authentication in `CODEX_HOME` (by default
 `~/.codex/auth.json` or the operating-system keyring). That credential state is not
 copied into the repository, candidate workspace, prompt, provider response, or evidence.
-The adapter removes `OPENAI_API_KEY` and `CODEX_API_KEY` from the child environment as
-defense in depth, checks `codex login status`, and passes the explicit override
-`forced_login_method="chatgpt"`. It fails closed unless both controls select ChatGPT.
+The adapter gives the network-connected Codex child only an explicit environment
+allowlist (`PATH`, auth/config locations, locale, terminal, temporary-directory, and TLS
+certificate locations). API keys, cloud credentials, repository tokens, database URLs,
+and unrelated host variables are not forwarded. It checks `codex login status` and
+passes the explicit override `forced_login_method="chatgpt"`. It fails closed unless
+both controls select ChatGPT.
 
 ### Run
 
@@ -47,7 +50,8 @@ pmpe barebones run examples/barebones/e1-contract.json \
   --repository-root /tmp/pmpe-codex-e1-evidence \
   --approval-receipt examples/barebones/e1-approval-receipt.json \
   --expected-approver fixture-human \
-  --provider-command "python examples/barebones/codex-cli-provider.py"
+  --provider-command "python examples/barebones/codex-cli-provider.py" \
+  --provider-timeout 960
 ```
 
 The adapter fixes the run to `gpt-5.6-sol` with `xhigh` reasoning and invokes
@@ -57,6 +61,13 @@ output schema. It runs in a fresh temporary working directory and supplies the c
 request through stdin so contract content does not appear in the process argument list.
 Codex stdout and stderr are captured; only one digest-bound PEOS JSON response is
 written to adapter stdout.
+
+The Codex execution budget defaults to 900 seconds and can be lowered with
+`PMPE_CODEX_TIMEOUT_SECONDS`. The outer `--provider-timeout` defaults to 960 seconds;
+PMPE passes that value to the adapter, which clamps its execution budget to remain
+strictly below the outer deadline. Codex inherits the adapter's process group, so an
+outer timeout terminates both instead of leaving an authenticated orphan process.
+Stdout and stderr are bounded while Codex is running rather than after completion.
 
 These controls have precise limits:
 
@@ -75,10 +86,11 @@ These controls have precise limits:
   `per_run_cost_applicable = false`. A core `estimated_cost_usd` counter of `0.0`
   therefore means no per-run API price applies, not that the subscription is free.
 
-The adapter records the Codex CLI version without imposing a version allowlist. Its
-composite `prompt_version` contains adapter version, reasoning effort, and CLI version
-so drift caused by any of those inputs is attributable through the existing behavior
-comparison tuple.
+The adapter records the Codex CLI version without imposing a version allowlist.
+`prompt_version` contains only the adapter version and reasoning effort; the optional
+CLI-version probe is separate telemetry, so a transient failed probe cannot be
+misreported as a prompt-configuration change. The current behavior comparator does not
+attribute CLI-version changes separately; they remain visible in the raw evidence.
 
 ## Responses API adapter
 

--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -66,7 +66,11 @@ The Codex execution budget defaults to 900 seconds and can be lowered with
 `PMPE_CODEX_TIMEOUT_SECONDS`. The outer `--provider-timeout` defaults to 960 seconds;
 PMPE passes that value to the adapter, which clamps its execution budget to remain
 strictly below the outer deadline. Codex inherits the adapter's process group, so an
-outer timeout terminates both instead of leaving an authenticated orphan process.
+outer timeout terminates both instead of leaving an authenticated orphan process. The
+adapter deducts actual authentication and version-preflight time before assigning the
+Codex execution budget. After the provider leader exits, PMPE observes that exit without
+reaping its PID, fences the complete provider process group, and only then reaps the
+leader; this also removes descendants after an inner timeout or output-limit failure.
 Stdout and stderr are bounded while Codex is running rather than after completion.
 
 These controls have precise limits:

--- a/docs/v2-implementation-plan.md
+++ b/docs/v2-implementation-plan.md
@@ -1,5 +1,9 @@
 # V2 implementation plan
 
+> **Historical / superseded.** This completed V2 plan is retained for provenance only.
+> See [README.md](../README.md) for the authoritative frozen alpha and current claim
+> boundary.
+
 ## The two-plane design (PD-11)
 
 ```

--- a/docs/v3/implementation-plan.md
+++ b/docs/v3/implementation-plan.md
@@ -1,5 +1,9 @@
 # V3 implementation plan — atomic PR partition
 
+> **Historical / superseded.** This completed V3 plan is retained for provenance only.
+> See [README.md](../../README.md) for the authoritative frozen alpha and current claim
+> boundary.
+
 Seventeen atomic PRs. Every PR: one independently meaningful capability,
 acceptance tests before implementation, fresh-context read-only review with a
 scope charter, green CI, squash-merge, ledger row. Existing 338 V1/V2 tests

--- a/examples/barebones/codex-cli-provider.py
+++ b/examples/barebones/codex-cli-provider.py
@@ -147,7 +147,11 @@ def _timeout_value(
     return value
 
 
-def _effective_exec_timeout(environment: Mapping[str, str]) -> float:
+def _effective_exec_timeout(
+    environment: Mapping[str, str], *, elapsed_seconds: float = 0.0
+) -> float:
+    if not math.isfinite(elapsed_seconds) or elapsed_seconds < 0:
+        raise ProviderError("CODEX_TIMEOUT_INVALID")
     requested = _timeout_value(
         environment,
         "PMPE_CODEX_TIMEOUT_SECONDS",
@@ -156,7 +160,7 @@ def _effective_exec_timeout(environment: Mapping[str, str]) -> float:
     if "PMPE_PROVIDER_TIMEOUT_SECONDS" not in environment:
         return requested
     outer = _timeout_value(environment, "PMPE_PROVIDER_TIMEOUT_SECONDS")
-    available = outer - _OUTER_TIMEOUT_MARGIN_SECONDS
+    available = outer - elapsed_seconds - _OUTER_TIMEOUT_MARGIN_SECONDS
     if available <= 0:
         raise ProviderError("CODEX_TIMEOUT_INVALID")
     return min(requested, available)
@@ -366,9 +370,9 @@ def _invoke(message: Mapping[str, Any], executable: str) -> dict[str, Any]:
     request = message.get("request")
     if not isinstance(purpose, str) or not isinstance(request, Mapping):
         raise ProviderError("CODEX_INPUT_INVALID")
+    invocation_started = time.monotonic()
     schema = _schema(purpose)
     prompt = _prompt(purpose, request)
-    exec_timeout = _effective_exec_timeout(os.environ)
     environment = _child_environment()
     with tempfile.TemporaryDirectory(prefix="pmpe-codex-provider-") as temporary:
         cwd = Path(temporary)
@@ -377,6 +381,10 @@ def _invoke(message: Mapping[str, Any], executable: str) -> dict[str, Any]:
         schema_path.write_text(json.dumps(schema, sort_keys=True))
         _auth_preflight(executable, cwd=cwd, environment=environment)
         version = _cli_version(executable, cwd=cwd, environment=environment)
+        exec_timeout = _effective_exec_timeout(
+            os.environ,
+            elapsed_seconds=time.monotonic() - invocation_started,
+        )
         argv = (
             executable,
             "exec",

--- a/examples/barebones/codex-cli-provider.py
+++ b/examples/barebones/codex-cli-provider.py
@@ -10,13 +10,15 @@ from __future__ import annotations
 
 import contextlib
 import json
+import math
 import os
 import re
+import selectors
 import shutil
-import signal
 import subprocess
 import sys
 import tempfile
+import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, NoReturn
@@ -24,9 +26,33 @@ from typing import Any, NoReturn
 _MODEL = "gpt-5.6-sol"
 _REASONING_EFFORT = "xhigh"
 _ADAPTER_VERSION = "pmpe-barebones-codex-cli-v1"
-_COMMAND_TIMEOUT_SECONDS = 110.0
+_DEFAULT_EXEC_TIMEOUT_SECONDS = 900.0
+_PREFLIGHT_TIMEOUT_SECONDS = 30.0
+_OUTER_TIMEOUT_MARGIN_SECONDS = 1.0
+_MAX_TIMEOUT_SECONDS = 3600.0
 _OUTPUT_LIMIT_BYTES = 1_000_000
-_API_CREDENTIAL_VARIABLES = frozenset({"OPENAI_API_KEY", "CODEX_API_KEY"})
+_CHILD_ENV_ALLOWLIST = frozenset(
+    {
+        "CODEX_HOME",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "LOGNAME",
+        "PATH",
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+        "TEMP",
+        "TERM",
+        "TMP",
+        "TMPDIR",
+        "USER",
+        "XDG_CACHE_HOME",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "XDG_STATE_HOME",
+    }
+)
 _SAFE_VERSION = re.compile(r"[^A-Za-z0-9._+-]+")
 
 
@@ -95,10 +121,52 @@ def _prompt(purpose: str, request: Mapping[str, Any]) -> bytes:
     return f"{instruction}\n\nPMPE provider request JSON:\n{payload}\n".encode()
 
 
-def _child_environment() -> dict[str, str]:
+def _child_environment(source: Mapping[str, str] | None = None) -> dict[str, str]:
+    parent = os.environ if source is None else source
     return {
-        name: value for name, value in os.environ.items() if name not in _API_CREDENTIAL_VARIABLES
+        name: parent[name]
+        for name in sorted(_CHILD_ENV_ALLOWLIST)
+        if name in parent and parent[name]
     }
+
+
+def _timeout_value(
+    environment: Mapping[str, str], name: str, *, default: float | None = None
+) -> float:
+    raw = environment.get(name)
+    if raw is None:
+        if default is None:
+            raise ProviderError("CODEX_TIMEOUT_INVALID")
+        return default
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ProviderError("CODEX_TIMEOUT_INVALID") from exc
+    if not math.isfinite(value) or value <= 0 or value > _MAX_TIMEOUT_SECONDS:
+        raise ProviderError("CODEX_TIMEOUT_INVALID")
+    return value
+
+
+def _effective_exec_timeout(environment: Mapping[str, str]) -> float:
+    requested = _timeout_value(
+        environment,
+        "PMPE_CODEX_TIMEOUT_SECONDS",
+        default=_DEFAULT_EXEC_TIMEOUT_SECONDS,
+    )
+    if "PMPE_PROVIDER_TIMEOUT_SECONDS" not in environment:
+        return requested
+    outer = _timeout_value(environment, "PMPE_PROVIDER_TIMEOUT_SECONDS")
+    available = outer - _OUTER_TIMEOUT_MARGIN_SECONDS
+    if available <= 0:
+        raise ProviderError("CODEX_TIMEOUT_INVALID")
+    return min(requested, available)
+
+
+def _terminate_process(process: subprocess.Popen[bytes]) -> None:
+    with contextlib.suppress(ProcessLookupError):
+        process.kill()
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=5)
 
 
 def _run_command(
@@ -107,34 +175,66 @@ def _run_command(
     input_bytes: bytes,
     cwd: Path,
     environment: Mapping[str, str],
+    timeout_seconds: float,
+    output_limit_bytes: int = _OUTPUT_LIMIT_BYTES,
 ) -> subprocess.CompletedProcess[bytes]:
-    with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+    with tempfile.TemporaryFile() as stdin_file:
+        stdin_file.write(input_bytes)
+        stdin_file.seek(0)
         try:
             process = subprocess.Popen(
                 argv,
                 cwd=cwd,
                 env=dict(environment),
-                stdin=subprocess.PIPE,
-                stdout=stdout_file,
-                stderr=stderr_file,
-                start_new_session=True,
+                stdin=stdin_file,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=False,
             )
         except OSError as exc:
             raise ProviderError("CODEX_EXEC_START_FAILED") from exc
+        if process.stdout is None or process.stderr is None:
+            _terminate_process(process)
+            raise ProviderError("CODEX_EXEC_IO_UNAVAILABLE")
+        streams = {"stdout": bytearray(), "stderr": bytearray()}
+        selector = selectors.DefaultSelector()
+        selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+        selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+        deadline = time.monotonic() + timeout_seconds
         try:
-            process.communicate(input=input_bytes, timeout=_COMMAND_TIMEOUT_SECONDS)
-        except subprocess.TimeoutExpired as exc:
-            with contextlib.suppress(ProcessLookupError):
-                os.killpg(process.pid, signal.SIGKILL)
-            process.communicate()
-            raise ProviderError("CODEX_EXEC_TIMEOUT") from exc
-        stdout_file.seek(0)
-        stderr_file.seek(0)
-        stdout = stdout_file.read(_OUTPUT_LIMIT_BYTES + 1)
-        stderr = stderr_file.read(_OUTPUT_LIMIT_BYTES + 1)
-    if len(stdout) > _OUTPUT_LIMIT_BYTES or len(stderr) > _OUTPUT_LIMIT_BYTES:
-        raise ProviderError("CODEX_EXEC_OUTPUT_LIMIT")
-    return subprocess.CompletedProcess(tuple(argv), process.returncode, stdout, stderr)
+            while selector.get_map():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ProviderError("CODEX_EXEC_TIMEOUT")
+                for key, _ in selector.select(min(remaining, 0.1)):
+                    chunk = os.read(key.fd, 64 * 1024)
+                    if not chunk:
+                        selector.unregister(key.fileobj)
+                        continue
+                    output = streams[key.data]
+                    output.extend(chunk)
+                    if len(output) > output_limit_bytes:
+                        raise ProviderError("CODEX_EXEC_OUTPUT_LIMIT")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ProviderError("CODEX_EXEC_TIMEOUT")
+            try:
+                returncode = process.wait(timeout=remaining)
+            except subprocess.TimeoutExpired as exc:
+                raise ProviderError("CODEX_EXEC_TIMEOUT") from exc
+        except ProviderError:
+            _terminate_process(process)
+            raise
+        finally:
+            selector.close()
+            process.stdout.close()
+            process.stderr.close()
+        return subprocess.CompletedProcess(
+            tuple(argv),
+            returncode,
+            bytes(streams["stdout"]),
+            bytes(streams["stderr"]),
+        )
 
 
 def _auth_preflight(executable: str, *, cwd: Path, environment: Mapping[str, str]) -> None:
@@ -143,6 +243,7 @@ def _auth_preflight(executable: str, *, cwd: Path, environment: Mapping[str, str
         input_bytes=b"",
         cwd=cwd,
         environment=environment,
+        timeout_seconds=_PREFLIGHT_TIMEOUT_SECONDS,
     )
     status = (completed.stdout + b"\n" + completed.stderr).decode("utf-8", errors="replace").lower()
     if (
@@ -161,6 +262,7 @@ def _cli_version(executable: str, *, cwd: Path, environment: Mapping[str, str]) 
             input_bytes=b"",
             cwd=cwd,
             environment=environment,
+            timeout_seconds=_PREFLIGHT_TIMEOUT_SECONDS,
         )
     except ProviderError:
         return "unknown"
@@ -250,7 +352,7 @@ def _adapt_result(
     response["provider_metadata"] = {
         "provider": "codex-cli-chatgpt",
         "model": _MODEL,
-        "prompt_version": (f"{_ADAPTER_VERSION};effort={_REASONING_EFFORT};cli={version}"),
+        "prompt_version": f"{_ADAPTER_VERSION};effort={_REASONING_EFFORT}",
         "reasoning_effort": _REASONING_EFFORT,
         "cli_version": version,
         "auth_mode": "chatgpt",
@@ -266,6 +368,7 @@ def _invoke(message: Mapping[str, Any], executable: str) -> dict[str, Any]:
         raise ProviderError("CODEX_INPUT_INVALID")
     schema = _schema(purpose)
     prompt = _prompt(purpose, request)
+    exec_timeout = _effective_exec_timeout(os.environ)
     environment = _child_environment()
     with tempfile.TemporaryDirectory(prefix="pmpe-codex-provider-") as temporary:
         cwd = Path(temporary)
@@ -303,6 +406,7 @@ def _invoke(message: Mapping[str, Any], executable: str) -> dict[str, Any]:
             input_bytes=prompt,
             cwd=cwd,
             environment=environment,
+            timeout_seconds=exec_timeout,
         )
         if completed.returncode != 0:
             raise ProviderError("CODEX_EXEC_FAILED")

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -77,7 +77,8 @@ def _compile(args: argparse.Namespace) -> int:
     human = sum(item.form == "human_test" for item in plan.criteria)
     _json(
         {
-            "status": "VALIDATED",
+            "status": "COMPILES",
+            "contract_status": contract.get("contract_status"),
             "coverage": {
                 "structured": structured,
                 "human_test": human,
@@ -100,6 +101,7 @@ def _run_provider_command(
     payload: bytes,
     timeout_seconds: int,
     output_limit_bytes: int = _PROVIDER_OUTPUT_LIMIT_BYTES,
+    environment: Mapping[str, str] | None = None,
 ) -> subprocess.CompletedProcess[bytes]:
     with tempfile.TemporaryFile() as stdin_file:
         stdin_file.write(payload)
@@ -110,6 +112,7 @@ def _run_provider_command(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             start_new_session=True,
+            env=dict(environment) if environment is not None else None,
         )
         if process.stdout is None or process.stderr is None:
             _terminate_provider(process)
@@ -163,10 +166,13 @@ class CommandModelProvider:
         self.timeout_seconds = timeout_seconds
 
     def invoke(self, *, purpose: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        environment = dict(os.environ)
+        environment["PMPE_PROVIDER_TIMEOUT_SECONDS"] = str(self.timeout_seconds)
         completed = _run_provider_command(
             self.argv,
             json.dumps({"purpose": purpose, "request": request}).encode(),
             self.timeout_seconds,
+            environment=environment,
         )
         if completed.returncode != 0:
             raise RuntimeError("MODEL_PROVIDER_FAILED")
@@ -277,9 +283,37 @@ def _evidence_invalid(exc: EvidenceIntegrityError) -> int:
     return 3
 
 
+def _approval_summary(events: tuple[Mapping[str, Any], ...]) -> dict[str, str]:
+    for event in events:
+        if event.get("event_type") != "contract_validated":
+            continue
+        payload = event.get("payload")
+        if not isinstance(payload, Mapping):
+            raise EvidenceIntegrityError("approval evidence is malformed")
+        approval = payload.get("approval")
+        if not isinstance(approval, Mapping):
+            raise EvidenceIntegrityError("approval evidence is malformed")
+        status = approval.get("status")
+        if status == "UNVERIFIED_DIRECT_CALL":
+            return {"status": status}
+        if status != "VERIFIED":
+            raise EvidenceIntegrityError("approval evidence is malformed")
+        authority = approval.get("authority")
+        receipt_digest = approval.get("receipt_digest")
+        if not isinstance(authority, str) or not isinstance(receipt_digest, str):
+            raise EvidenceIntegrityError("approval evidence is malformed")
+        return {
+            "status": status,
+            "authority": authority,
+            "receipt_digest": receipt_digest,
+        }
+    return {"status": "NOT_RECORDED"}
+
+
 def _status(args: argparse.Namespace) -> int:
     try:
         _, events = _verified_events(args)
+        approval = _approval_summary(events)
     except EvidenceIntegrityError as exc:
         return _evidence_invalid(exc)
     terminal = events[-1]
@@ -298,6 +332,7 @@ def _status(args: argparse.Namespace) -> int:
             "events": len(events),
             "head_event_digest": terminal.get("event_digest"),
             "telemetry": dict(telemetry) if isinstance(telemetry, Mapping) else {},
+            "approval": approval,
         }
     )
     return 0
@@ -306,6 +341,7 @@ def _status(args: argparse.Namespace) -> int:
 def _evidence(args: argparse.Namespace) -> int:
     try:
         ledger, events = _verified_events(args)
+        approval = _approval_summary(events)
     except EvidenceIntegrityError as exc:
         return _evidence_invalid(exc)
     referenced = {
@@ -323,6 +359,7 @@ def _evidence(args: argparse.Namespace) -> int:
             "head_event_digest": events[-1].get("event_digest"),
             "events_path": str(ledger.events_path),
             "blobs_directory": str(ledger.blobs_directory),
+            "approval": approval,
         }
     )
     return 0
@@ -444,12 +481,14 @@ def _workspace_comparison(workspace: Path, manifest: Mapping[str, str]) -> dict[
 def _inspect(args: argparse.Namespace) -> int:
     try:
         ledger, events = _verified_events(args)
+        approval = _approval_summary(events)
         candidate_digest, manifest = _candidate_manifest(ledger, events[-1])
         output: dict[str, Any] = {
             "run_id": args.run_id,
             "state": "RELEASE_READY",
             "candidate_digest": candidate_digest,
             "files": manifest,
+            "approval": approval,
         }
         if args.file is not None:
             digest = manifest.get(args.file)
@@ -465,6 +504,11 @@ def _inspect(args: argparse.Namespace) -> int:
                 "content": content,
             }
         exit_code = 0
+        if approval["status"] == "UNVERIFIED_DIRECT_CALL":
+            output["release_eligible"] = False
+            exit_code = 3
+        elif approval["status"] == "VERIFIED":
+            output["release_eligible"] = True
         if args.workspace is not None:
             comparison = _workspace_comparison(Path(args.workspace), manifest)
             output["workspace"] = comparison
@@ -506,7 +550,7 @@ def register(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
         required=True,
         help="local ModelProvider command; receives and returns JSON over stdio",
     )
-    run_parser.add_argument("--provider-timeout", type=int, default=120)
+    run_parser.add_argument("--provider-timeout", type=int, default=960)
     run_parser.set_defaults(fn=_run)
 
     for name, function, help_text in (

--- a/src/pmpe/cli/barebones_cmd.py
+++ b/src/pmpe/cli/barebones_cmd.py
@@ -12,10 +12,10 @@ import signal
 import subprocess
 import tempfile
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, cast
 
 from pmpe.barebones import ContractInvalidError, compile_barebones_plan, run_to_release_ready
 from pmpe.contracts.acceptance import AcceptanceCompileError
@@ -90,10 +90,42 @@ def _compile(args: argparse.Namespace) -> int:
     return 0
 
 
-def _terminate_provider(process: subprocess.Popen[bytes]) -> None:
+def _fence_provider_group(process: subprocess.Popen[bytes]) -> int:
     with suppress(ProcessLookupError):
         os.killpg(process.pid, signal.SIGKILL)
-    process.wait()
+    return process.wait()
+
+
+def _terminate_provider(process: subprocess.Popen[bytes]) -> None:
+    _fence_provider_group(process)
+
+
+def _wait_for_provider_exit_without_reaping(
+    process: subprocess.Popen[bytes], timeout_seconds: float
+) -> bool:
+    """Observe provider exit while retaining its PID until its group is fenced."""
+
+    if not all(hasattr(os, name) for name in ("P_PID", "WEXITED", "WNOHANG", "WNOWAIT")):
+        raise RuntimeError("MODEL_PROVIDER_PROCESS_GROUP_UNAVAILABLE")
+    waitid = cast(
+        Callable[[int, int, int], object | None],
+        vars(os)["waitid"],
+    )
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            result = waitid(
+                os.P_PID,
+                process.pid,
+                os.WEXITED | os.WNOHANG | os.WNOWAIT,
+            )
+        except ChildProcessError as exc:
+            raise RuntimeError("MODEL_PROVIDER_PROCESS_REAPED") from exc
+        if result is not None:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.01)
 
 
 def _run_provider_command(
@@ -139,7 +171,9 @@ def _run_provider_command(
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise RuntimeError("MODEL_PROVIDER_TIMEOUT")
-            returncode = process.wait(timeout=remaining)
+            if not _wait_for_provider_exit_without_reaping(process, remaining):
+                raise RuntimeError("MODEL_PROVIDER_TIMEOUT")
+            returncode = _fence_provider_group(process)
         except subprocess.TimeoutExpired as exc:
             _terminate_provider(process)
             raise RuntimeError("MODEL_PROVIDER_TIMEOUT") from exc
@@ -148,6 +182,8 @@ def _run_provider_command(
             raise
         finally:
             selector.close()
+            process.stdout.close()
+            process.stderr.close()
         return subprocess.CompletedProcess(
             argv,
             returncode,

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import subprocess
 import sys
 from collections.abc import Mapping
 from pathlib import Path
@@ -519,3 +520,52 @@ def test_command_provider_output_is_bounded_before_capture() -> None:
             2,
             output_limit_bytes=32,
         )
+
+
+def test_command_provider_propagates_outer_timeout_to_the_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    def completed(*args: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        observed["args"] = args
+        observed["environment"] = kwargs.get("environment")
+        return subprocess.CompletedProcess(
+            ("provider",),
+            0,
+            b'{"request_digest":"bound","summary":"ok"}',
+            b"",
+        )
+
+    monkeypatch.setattr(barebones_cmd, "_run_provider_command", completed)
+
+    response = CommandModelProvider("provider", 960).invoke(
+        purpose="advisory_review", request={"request_digest": "bound"}
+    )
+
+    assert response["summary"] == "ok"
+    environment = observed["environment"]
+    assert isinstance(environment, dict)
+    assert environment["PMPE_PROVIDER_TIMEOUT_SECONDS"] == "960"
+
+
+def test_default_provider_timeout_allows_the_codex_xhigh_budget() -> None:
+    args = build_parser().parse_args(
+        [
+            "barebones",
+            "run",
+            "contract.json",
+            "--workspace",
+            "candidate",
+            "--run-id",
+            "run",
+            "--approval-receipt",
+            "receipt.json",
+            "--expected-approver",
+            "owner",
+            "--provider-command",
+            "provider",
+        ]
+    )
+
+    assert args.provider_timeout == 960

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -12,7 +12,7 @@ import pytest
 
 from pmpe import barebones as barebones_runtime
 from pmpe.barebones import BudgetCaps, RunState, run_to_release_ready
-from pmpe.cli import barebones_cmd, build_parser
+from pmpe.cli import barebones_cmd, build_parser, main
 from pmpe.cli.barebones_cmd import CommandModelProvider
 
 _REPOSITORY = Path(__file__).parents[2]
@@ -54,6 +54,26 @@ def test_barebones_cli_runs_a_contract_without_cloud_services(
     submitted_digest = "sha256:" + hashlib.sha256(receipt_path.read_bytes()).hexdigest()
     assert approval["receipt_digest"] == receipt["receipt_digest"]
     assert approval["receipt_blob_digest"] == submitted_digest
+
+    for command in ("status", "evidence", "inspect"):
+        assert (
+            main(
+                [
+                    "barebones",
+                    command,
+                    "cli-e1",
+                    "--repository-root",
+                    str(tmp_path),
+                ]
+            )
+            == 0
+        )
+        publication = json.loads(capsys.readouterr().out)
+        assert publication["approval"] == {
+            "status": "VERIFIED",
+            "authority": "fixture-human",
+            "receipt_digest": receipt["receipt_digest"],
+        }
 
 
 def test_unapproved_contract_is_rejected_before_provider(

--- a/tests/integration/test_barebones_cli.py
+++ b/tests/integration/test_barebones_cli.py
@@ -542,6 +542,34 @@ def test_command_provider_output_is_bounded_before_capture() -> None:
         )
 
 
+def test_provider_group_is_fenced_before_the_exited_leader_is_reaped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[object] = []
+
+    class ExitedProvider:
+        pid = 4321
+
+        def wait(self, timeout: float | None = None) -> int:
+            events.append(("wait", timeout))
+            return 7
+
+    def observed_waitid(*args: object) -> object:
+        events.append(("waitid", args))
+        return object()
+
+    def observed_killpg(pid: int, action: object) -> None:
+        events.append(("killpg", pid, action))
+
+    monkeypatch.setattr(barebones_cmd.os, "waitid", observed_waitid)
+    monkeypatch.setattr(barebones_cmd.os, "killpg", observed_killpg)
+    process = ExitedProvider()
+
+    assert barebones_cmd._wait_for_provider_exit_without_reaping(process, 1.0)  # type: ignore[arg-type]
+    assert barebones_cmd._fence_provider_group(process) == 7  # type: ignore[arg-type]
+    assert [event[0] for event in events] == ["waitid", "killpg", "wait"]  # type: ignore[index]
+
+
 def test_command_provider_propagates_outer_timeout_to_the_adapter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_barebones_cli_journey.py
+++ b/tests/unit/test_barebones_cli_journey.py
@@ -10,8 +10,27 @@ from pmpe.evidence.ledger import EvidenceLedger
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _sealed_run(repository_root: Path, run_id: str = "sealed") -> tuple[str, str]:
+def _sealed_run(
+    repository_root: Path,
+    run_id: str = "sealed",
+    *,
+    approval: dict[str, str] | None = None,
+) -> tuple[str, str]:
     ledger = EvidenceLedger(repository_root, run_id)
+    if approval is not None:
+        contract_digest = ledger.put_blob(b'{"contract_status":"APPROVED"}')
+        plan_digest = ledger.put_blob(b'{"criteria":[]}')
+        ledger.append(
+            event_type="contract_validated",
+            state="VALIDATED",
+            subject_digest="sha256:" + "1" * 64,
+            blob_digests=(contract_digest, plan_digest),
+            payload={
+                "approval": approval,
+                "contract_digest": contract_digest,
+                "plan_digest": plan_digest,
+            },
+        )
     content = b"def health():\n    return {'status': 'ok'}\n"
     file_digest = ledger.put_blob(content)
     manifest_digest = ledger.put_blob(
@@ -45,7 +64,8 @@ def test_compile_reports_the_deterministic_plan_without_starting_a_run(
 
     assert result == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["status"] == "VALIDATED"
+    assert output["status"] == "COMPILES"
+    assert output["contract_status"] == "APPROVED"
     assert output["plan"]["plan_digest"].startswith("sha256:")
     assert output["coverage"] == {
         "human_test": 0,
@@ -70,6 +90,60 @@ def test_status_and_evidence_verify_the_sealed_chain(tmp_path: Path, capsys) -> 
     assert evidence["events"] == 1
     assert evidence["referenced_blobs"] == 2
     assert evidence["head_event_digest"].startswith("sha256:")
+
+
+def test_inspection_commands_surface_verified_approval_authority(
+    tmp_path: Path, capsys
+) -> None:  # type: ignore[no-untyped-def]
+    receipt_digest = "sha256:" + "9" * 64
+    approval = {
+        "status": "VERIFIED",
+        "authority": "pmos-owner",
+        "receipt_digest": receipt_digest,
+    }
+    _sealed_run(tmp_path, "approved", approval=approval)
+
+    for command in ("status", "evidence", "inspect"):
+        assert (
+            main(
+                [
+                    "barebones",
+                    command,
+                    "approved",
+                    "--repository-root",
+                    str(tmp_path),
+                ]
+            )
+            == 0
+        )
+        output = json.loads(capsys.readouterr().out)
+        assert output["approval"] == approval
+
+
+def test_inspect_refuses_to_publish_an_unverified_direct_call(
+    tmp_path: Path, capsys
+) -> None:  # type: ignore[no-untyped-def]
+    _sealed_run(
+        tmp_path,
+        "unverified",
+        approval={"status": "UNVERIFIED_DIRECT_CALL"},
+    )
+
+    result = main(
+        [
+            "barebones",
+            "inspect",
+            "unverified",
+            "--repository-root",
+            str(tmp_path),
+        ]
+    )
+
+    assert result == 3
+    output = json.loads(capsys.readouterr().out)
+    assert output["state"] == "RELEASE_READY"
+    assert output["approval"] == {"status": "UNVERIFIED_DIRECT_CALL"}
+    assert output["release_eligible"] is False
 
 
 def test_inspect_reads_only_the_sealed_candidate_and_checks_workspace_drift(

--- a/tests/unit/test_barebones_cli_journey.py
+++ b/tests/unit/test_barebones_cli_journey.py
@@ -75,6 +75,32 @@ def test_compile_reports_the_deterministic_plan_without_starting_a_run(
     assert not (tmp_path / ".pmpe").exists()
 
 
+def test_compile_reports_a_draft_as_compilable_without_claiming_validation(
+    tmp_path: Path, capsys
+) -> None:  # type: ignore[no-untyped-def]
+    contract = json.loads((ROOT / "examples" / "barebones" / "e1-contract.json").read_text())
+    contract["contract_status"] = "DRAFT"
+    draft = tmp_path / "draft.json"
+    draft.write_text(json.dumps(contract))
+
+    assert (
+        main(
+            [
+                "barebones",
+                "compile",
+                str(draft),
+                "--repository-root",
+                str(ROOT),
+            ]
+        )
+        == 0
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "COMPILES"
+    assert output["contract_status"] == "DRAFT"
+
+
 def test_status_and_evidence_verify_the_sealed_chain(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
     _sealed_run(tmp_path)
 
@@ -92,9 +118,7 @@ def test_status_and_evidence_verify_the_sealed_chain(tmp_path: Path, capsys) -> 
     assert evidence["head_event_digest"].startswith("sha256:")
 
 
-def test_inspection_commands_surface_verified_approval_authority(
-    tmp_path: Path, capsys
-) -> None:  # type: ignore[no-untyped-def]
+def test_inspection_commands_surface_verified_approval_authority(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
     receipt_digest = "sha256:" + "9" * 64
     approval = {
         "status": "VERIFIED",
@@ -120,9 +144,7 @@ def test_inspection_commands_surface_verified_approval_authority(
         assert output["approval"] == approval
 
 
-def test_inspect_refuses_to_publish_an_unverified_direct_call(
-    tmp_path: Path, capsys
-) -> None:  # type: ignore[no-untyped-def]
+def test_inspect_refuses_to_publish_an_unverified_direct_call(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
     _sealed_run(
         tmp_path,
         "unverified",

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -38,6 +38,11 @@ def test_default_candidate_sandbox_removes_host_authority(
 
     monkeypatch.setattr(barebones.subprocess, "run", completed)
     sandbox = BubblewrapCandidateSandbox()
+    monkeypatch.setattr(
+        sandbox,
+        "_runtime_roots",
+        lambda: (Path("/usr"), Path("/home/operator/project/.venv")),
+    )
     sandbox.run(
         workspace,
         ("/usr/bin/python3", "-V"),
@@ -55,7 +60,12 @@ def test_default_candidate_sandbox_removes_host_authority(
     assert ["--ro-bind", str(workspace), "/workspace"] == argv[
         argv.index(str(workspace)) - 1 : argv.index(str(workspace)) + 2
     ]
-    assert not {"/root", "/home"}.intersection(argv)
+    host_bind_sources = {
+        argv[index + 1]
+        for index, value in enumerate(argv[:-2])
+        if value in {"--ro-bind", "--ro-bind-try"}
+    }
+    assert not {"/root", "/home"}.intersection(host_bind_sources)
     assert observed["environment"] == {"LC_ALL": "C", "PATH": "/usr/local/bin:/usr/bin:/bin"}
 
 

--- a/tests/unit/test_codex_cli_provider.py
+++ b/tests/unit/test_codex_cli_provider.py
@@ -5,6 +5,7 @@ import io
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -66,6 +67,8 @@ class _FakeCodex:
         input_bytes: bytes,
         cwd: Path,
         environment: dict[str, str],
+        timeout_seconds: float | None = None,
+        output_limit_bytes: int | None = None,
     ) -> subprocess.CompletedProcess[bytes]:
         self.calls.append(
             {
@@ -73,6 +76,8 @@ class _FakeCodex:
                 "input": input_bytes,
                 "cwd": cwd,
                 "environment": environment,
+                "timeout_seconds": timeout_seconds,
+                "output_limit_bytes": output_limit_bytes,
             }
         )
         if argv[1:] == ("login", "status"):
@@ -167,9 +172,70 @@ def test_success_is_one_digest_bound_object_and_codex_jsonl_is_not_forwarded(
     assert exec_call["schema"]["properties"]["files"]["type"] == "array"
     assert exec_call["schema"]["additionalProperties"] is False
     assert exec_call["cwd"].name.startswith("pmpe-codex-provider-")
+    assert exec_call["timeout_seconds"] == 900.0
     assert "OPENAI_API_KEY" not in exec_call["environment"]
     assert "CODEX_API_KEY" not in exec_call["environment"]
     assert exec_call["environment"]["CODEX_HOME"] == "/host/codex-home"
+
+
+def test_codex_child_environment_is_an_explicit_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _provider_module()
+    monkeypatch.setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+    monkeypatch.setenv("HOME", "/home/operator")
+    monkeypatch.setenv("CODEX_HOME", "/home/operator/.codex")
+    monkeypatch.setenv("LANG", "C.UTF-8")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-cross")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "must-not-cross")
+    monkeypatch.setenv("GITHUB_TOKEN", "must-not-cross")
+    monkeypatch.setenv("PMPE_PLANTED_HOST_SECRET", "must-not-cross")
+
+    environment = provider._child_environment()
+
+    assert environment == {
+        "CODEX_HOME": "/home/operator/.codex",
+        "HOME": "/home/operator",
+        "LANG": "C.UTF-8",
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+    }
+
+
+def test_codex_timeout_override_is_clamped_below_the_outer_provider_budget() -> None:
+    provider = _provider_module()
+
+    assert (
+        provider._effective_exec_timeout(
+            {
+                "PMPE_CODEX_TIMEOUT_SECONDS": "1200",
+                "PMPE_PROVIDER_TIMEOUT_SECONDS": "960",
+            }
+        )
+        == 959.0
+    )
+    assert (
+        provider._effective_exec_timeout(
+            {"PMPE_PROVIDER_TIMEOUT_SECONDS": "960"}
+        )
+        == 900.0
+    )
+
+
+@pytest.mark.parametrize(
+    "environment",
+    [
+        {"PMPE_CODEX_TIMEOUT_SECONDS": "not-a-number"},
+        {"PMPE_CODEX_TIMEOUT_SECONDS": "0"},
+        {"PMPE_PROVIDER_TIMEOUT_SECONDS": "1"},
+    ],
+)
+def test_invalid_codex_timeout_configuration_fails_closed(
+    environment: dict[str, str],
+) -> None:
+    provider = _provider_module()
+
+    with pytest.raises(provider.ProviderError, match="CODEX_TIMEOUT_INVALID"):
+        provider._effective_exec_timeout(environment)
 
 
 def test_usage_keeps_output_only_and_preserves_cached_and_reasoning_tokens(
@@ -243,7 +309,10 @@ def test_cli_version_is_recorded_but_not_a_run_gate(
     response = provider._invoke(_message(), "/usr/bin/codex")
 
     assert response["provider_metadata"]["cli_version"] == "unknown"
-    assert response["provider_metadata"]["prompt_version"].endswith("cli=unknown")
+    assert (
+        response["provider_metadata"]["prompt_version"]
+        == "pmpe-barebones-codex-cli-v1;effort=xhigh"
+    )
 
 
 @pytest.mark.parametrize(
@@ -405,60 +474,49 @@ def test_result_output_limit_is_enforced(tmp_path: Path) -> None:
         provider._load_result(result)
 
 
-def test_command_timeout_kills_the_process_group(
+def test_command_timeout_kills_codex_without_creating_a_new_process_group(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     provider = _provider_module()
+    real_popen = provider.subprocess.Popen
+    observed: list[bool | None] = []
 
-    class _TimedOutProcess:
-        pid = 1234
-        returncode = -9
+    def recording_popen(*args: Any, **kwargs: Any) -> subprocess.Popen[bytes]:
+        observed.append(kwargs.get("start_new_session"))
+        return real_popen(*args, **kwargs)
 
-        def __init__(self) -> None:
-            self.calls = 0
-
-        def communicate(self, *, input: bytes | None = None, timeout: float | None = None) -> None:
-            del input, timeout
-            self.calls += 1
-            if self.calls == 1:
-                raise subprocess.TimeoutExpired(("codex", "exec"), 1)
-
-    process = _TimedOutProcess()
-    killed: list[tuple[int, int]] = []
-    monkeypatch.setattr(provider.subprocess, "Popen", lambda *_args, **_kwargs: process)
-    monkeypatch.setattr(provider.os, "killpg", lambda pid, sig: killed.append((pid, sig)))
+    monkeypatch.setattr(provider.subprocess, "Popen", recording_popen)
+    started = time.monotonic()
 
     with pytest.raises(provider.ProviderError, match="CODEX_EXEC_TIMEOUT"):
         provider._run_command(
-            ("codex", "exec"),
+            (sys.executable, "-c", "import time; time.sleep(5)"),
             input_bytes=b"prompt",
             cwd=tmp_path,
             environment={},
+            timeout_seconds=0.1,
         )
 
-    assert killed == [(1234, provider.signal.SIGKILL)]
+    assert time.monotonic() - started < 2
+    assert observed == [False]
 
 
-def test_command_output_limit_is_enforced(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_command_output_limit_is_enforced_while_codex_is_running(tmp_path: Path) -> None:
     provider = _provider_module()
-
-    class _LargeOutputProcess:
-        pid = 1234
-        returncode = 0
-
-        def communicate(self, *, input: bytes | None = None, timeout: float | None = None) -> None:
-            del input, timeout
-
-    def fake_popen(*_args: Any, **kwargs: Any) -> _LargeOutputProcess:
-        kwargs["stdout"].write(b"x" * (provider._OUTPUT_LIMIT_BYTES + 1))
-        return _LargeOutputProcess()
-
-    monkeypatch.setattr(provider.subprocess, "Popen", fake_popen)
+    started = time.monotonic()
 
     with pytest.raises(provider.ProviderError, match="CODEX_EXEC_OUTPUT_LIMIT"):
         provider._run_command(
-            ("codex", "exec"),
+            (
+                sys.executable,
+                "-c",
+                "import os,time; os.write(1, b'x' * 1024); time.sleep(5)",
+            ),
             input_bytes=b"prompt",
             cwd=tmp_path,
             environment={},
+            timeout_seconds=2,
+            output_limit_bytes=32,
         )
+
+    assert time.monotonic() - started < 2

--- a/tests/unit/test_codex_cli_provider.py
+++ b/tests/unit/test_codex_cli_provider.py
@@ -222,6 +222,22 @@ def test_codex_timeout_override_is_clamped_below_the_outer_provider_budget() -> 
     assert provider._effective_exec_timeout({"PMPE_PROVIDER_TIMEOUT_SECONDS": "960"}) == 900.0
 
 
+def test_invoke_deducts_elapsed_preflight_time_from_the_outer_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _provider_module()
+    fake = _FakeCodex()
+    _install_fake(provider, monkeypatch, fake)
+    monkeypatch.setenv("PMPE_CODEX_TIMEOUT_SECONDS", "1200")
+    monkeypatch.setenv("PMPE_PROVIDER_TIMEOUT_SECONDS", "960")
+    moments = iter((100.0, 160.0))
+    monkeypatch.setattr(provider.time, "monotonic", lambda: next(moments))
+
+    provider._invoke(_message(), "/usr/bin/codex")
+
+    assert fake.calls[2]["timeout_seconds"] == 899.0
+
+
 @pytest.mark.parametrize(
     "environment",
     [

--- a/tests/unit/test_codex_cli_provider.py
+++ b/tests/unit/test_codex_cli_provider.py
@@ -145,7 +145,7 @@ def test_success_is_one_digest_bound_object_and_codex_jsonl_is_not_forwarded(
         "auth_mode": "chatgpt",
         "cli_version": "codex-cli_9.8.7",
         "model": "gpt-5.6-sol",
-        "prompt_version": "pmpe-barebones-codex-cli-v1;effort=xhigh;cli=codex-cli_9.8.7",
+        "prompt_version": "pmpe-barebones-codex-cli-v1;effort=xhigh",
         "provider": "codex-cli-chatgpt",
         "reasoning_effort": "xhigh",
     }
@@ -193,12 +193,18 @@ def test_codex_child_environment_is_an_explicit_allowlist(
 
     environment = provider._child_environment()
 
-    assert environment == {
-        "CODEX_HOME": "/home/operator/.codex",
-        "HOME": "/home/operator",
-        "LANG": "C.UTF-8",
-        "PATH": "/usr/local/bin:/usr/bin:/bin",
-    }
+    assert environment["CODEX_HOME"] == "/home/operator/.codex"
+    assert environment["HOME"] == "/home/operator"
+    assert environment["LANG"] == "C.UTF-8"
+    assert environment["PATH"] == "/usr/local/bin:/usr/bin:/bin"
+    assert set(environment).issubset(provider._CHILD_ENV_ALLOWLIST)
+    for secret in (
+        "OPENAI_API_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+        "GITHUB_TOKEN",
+        "PMPE_PLANTED_HOST_SECRET",
+    ):
+        assert secret not in environment
 
 
 def test_codex_timeout_override_is_clamped_below_the_outer_provider_budget() -> None:
@@ -213,12 +219,7 @@ def test_codex_timeout_override_is_clamped_below_the_outer_provider_budget() -> 
         )
         == 959.0
     )
-    assert (
-        provider._effective_exec_timeout(
-            {"PMPE_PROVIDER_TIMEOUT_SECONDS": "960"}
-        )
-        == 900.0
-    )
+    assert provider._effective_exec_timeout({"PMPE_PROVIDER_TIMEOUT_SECONDS": "960"}) == 900.0
 
 
 @pytest.mark.parametrize(
@@ -312,6 +313,26 @@ def test_cli_version_is_recorded_but_not_a_run_gate(
     assert (
         response["provider_metadata"]["prompt_version"]
         == "pmpe-barebones-codex-cli-v1;effort=xhigh"
+    )
+
+
+def test_optional_cli_version_probe_does_not_change_prompt_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _provider_module()
+    known = _FakeCodex()
+    _install_fake(provider, monkeypatch, known)
+    known_response = provider._invoke(_message(), "/usr/bin/codex")
+
+    unknown = _FakeCodex(version_returncode=1)
+    _install_fake(provider, monkeypatch, unknown)
+    unknown_response = provider._invoke(_message(), "/usr/bin/codex")
+
+    assert known_response["provider_metadata"]["cli_version"] == "codex-cli_9.8.7"
+    assert unknown_response["provider_metadata"]["cli_version"] == "unknown"
+    assert (
+        known_response["provider_metadata"]["prompt_version"]
+        == unknown_response["provider_metadata"]["prompt_version"]
     )
 
 

--- a/tests/unit/test_publication_truth.py
+++ b/tests/unit/test_publication_truth.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_readme_capability_evidence_does_not_claim_stale_exact_head_links() -> None:
+    readme = (ROOT / "README.md").read_text()
+
+    assert "exact-head" not in readme.lower()
+    assert re.search(
+        r"github\.com/Abhillashjadhav/production-engineering-os/blob/[0-9a-f]{40}/",
+        readme,
+    ) is None
+
+
+def test_legacy_architecture_and_plan_surfaces_are_marked_historical() -> None:
+    historical = (
+        ROOT / "ARCHITECTURE.md",
+        ROOT / "ROADMAP.md",
+        ROOT / "docs" / "TARGET-ARCHITECTURE.md",
+        ROOT / "docs" / "implementation-plan.md",
+        ROOT / "docs" / "v2-implementation-plan.md",
+        ROOT / "docs" / "v3" / "implementation-plan.md",
+    )
+
+    for path in historical:
+        opening = "\n".join(path.read_text().splitlines()[:8]).lower()
+        assert "historical / superseded" in opening, path
+        assert "readme.md" in opening, path

--- a/tests/unit/test_publication_truth.py
+++ b/tests/unit/test_publication_truth.py
@@ -10,10 +10,13 @@ def test_readme_capability_evidence_does_not_claim_stale_exact_head_links() -> N
     readme = (ROOT / "README.md").read_text()
 
     assert "exact-head" not in readme.lower()
-    assert re.search(
-        r"github\.com/Abhillashjadhav/production-engineering-os/blob/[0-9a-f]{40}/",
-        readme,
-    ) is None
+    assert (
+        re.search(
+            r"github\.com/Abhillashjadhav/production-engineering-os/blob/[0-9a-f]{40}/",
+            readme,
+        )
+        is None
+    )
 
 
 def test_legacy_architecture_and_plan_surfaces_are_marked_historical() -> None:


### PR DESCRIPTION
Closes #167.

## What changed

- hardens the **no-API** ChatGPT-authenticated Codex CLI path with a 900-second inner budget, a 960-second outer budget, live stdout/stderr caps, shared process-group semantics, and an explicit child-environment allowlist;
- makes publication truth observable: `compile` reports `COMPILES` plus `contract_status`, while `status`, `evidence`, and `inspect` surface the verified approval authority; `inspect` refuses an explicitly unverified direct-call candidate;
- separates optional CLI-version telemetry from prompt identity, repairs the sandbox bind-source regression test, replaces stale exact-head README claims with durable main-CI evidence, and marks legacy architecture/plan documents historical.

This deliberately does **not** add an API workflow, hosted service, queue, database, UI, deployer, worker, lifecycle state, or framework. It replaces the direction proposed in #166 because the agreed promotion path is ChatGPT subscription authentication through Codex CLI, not `OPENAI_API_KEY`.

## External-review disposition

Accepted and implemented: provider budgets; process-tree containment; environment allowlist; approval visibility; compile truth; stable evidence links; sandbox test correction; CLI-version/prompt separation; live output limiting; historical-document banners.

Deferred until real-contract evidence demonstrates need: custom-template path generalization, auth-status parser expansion, and additional review-gate machinery.

## PR-review fixes

The first Codex review found two P2 lifecycle edges. Regression commit `6484c6c` proves both, and implementation commit `0a88b409`:

- deducts measured authentication/version-preflight time from the outer provider allowance;
- observes provider-leader exit without reaping, fences the complete process group, and then reaps the retained leader PID, preventing descendants after inner timeout/output-limit failures.

Both review threads are replied to and resolved. A fresh exact-head Codex review is required before merge.

## Verification

- focused unit, integration, scripted E1, and planted-eval suites: pass (two expected real-sandbox skips locally);
- `ruff format --check .` and `ruff check .`: pass;
- `mypy --strict src`: pass for 177 source files;
- `compileall` and workflow YAML parsing: pass;
- published Git tree `d5e107cf010cc9fd6f5ac7e79d819e55aa077ba5` exactly matches the locally verified tree.

The managed local shell does not expose the Linux `/proc` surface required for real Bubblewrap assertions. The repository's exact-head `candidate-isolation` CI job is therefore the authoritative check for that boundary.

## Claim boundary

This makes the alpha ready for a real authenticated E1 attempt; it does not yet prove arbitrary-app platform behavior. That claim remains gated by one real PMOS contract and then materially different repeated contracts with published evidence.