### PR TITLE
Preserve valid results when Codex telemetry truncates

### DIFF
--- a/docs/real-model-provider.md
+++ b/docs/real-model-provider.md
@@ -71,7 +71,10 @@ adapter deducts actual authentication and version-preflight time before assignin
 Codex execution budget. After the provider leader exits, PMPE observes that exit without
 reaping its PID, fences the complete provider process group, and only then reaps the
 leader; this also removes descendants after an inner timeout or output-limit failure.
-Stdout and stderr are bounded while Codex is running rather than after completion.
+Stdout and stderr are bounded while Codex is running rather than after completion. Excess
+telemetry bytes are drained and discarded so a valid authoritative result is not rejected
+solely because a progress stream is verbose. The independent result-file limit remains a
+hard failure.
 
 These controls have precise limits:
 
@@ -124,9 +127,11 @@ PEOS consumes `usage.input_tokens`, `usage.output_tokens`, and an optional
 `usage.estimated_cost_usd`. Both adapters keep `output_tokens` output-only. The Responses
 adapter preserves the provider's complete usage object, including any nested cached or
 reasoning details. The Codex adapter records `cached_input_tokens` and
-`reasoning_output_tokens` as additional keys. Missing or truncated Codex JSONL telemetry
-does not invalidate a schema-valid result: input and output are recorded as zero with
-`telemetry_status = "unavailable"`.
+`reasoning_output_tokens` as additional keys. Missing Codex JSONL telemetry does not
+invalidate a schema-valid result and records `telemetry_status = "unavailable"`.
+Oversized stdout or stderr is retained only up to the configured cap and records
+`telemetry_status = "truncated"`; any complete usage event captured before truncation is
+preserved, otherwise input and output fall back to zero.
 
 Successful responses with complete non-secret provider metadata also emit normalized
 `provider_behavior` observations into hash-chained events. Those observations enable

--- a/examples/barebones/codex-cli-provider.py
+++ b/examples/barebones/codex-cli-provider.py
@@ -21,7 +21,7 @@ import tempfile
 import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import Any, NamedTuple, NoReturn
 
 _MODEL = "gpt-5.6-sol"
 _REASONING_EFFORT = "xhigh"
@@ -58,6 +58,15 @@ _SAFE_VERSION = re.compile(r"[^A-Za-z0-9._+-]+")
 
 class ProviderError(RuntimeError):
     """A compact failure safe to expose to the parent provider process."""
+
+
+class _CommandResult(NamedTuple):
+    args: tuple[str, ...]
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+    stdout_truncated: bool
+    stderr_truncated: bool
 
 
 def _fail(code: str) -> NoReturn:
@@ -181,7 +190,7 @@ def _run_command(
     environment: Mapping[str, str],
     timeout_seconds: float,
     output_limit_bytes: int = _OUTPUT_LIMIT_BYTES,
-) -> subprocess.CompletedProcess[bytes]:
+) -> _CommandResult:
     with tempfile.TemporaryFile() as stdin_file:
         stdin_file.write(input_bytes)
         stdin_file.seek(0)
@@ -201,6 +210,7 @@ def _run_command(
             _terminate_process(process)
             raise ProviderError("CODEX_EXEC_IO_UNAVAILABLE")
         streams = {"stdout": bytearray(), "stderr": bytearray()}
+        truncated = {"stdout": False, "stderr": False}
         selector = selectors.DefaultSelector()
         selector.register(process.stdout, selectors.EVENT_READ, "stdout")
         selector.register(process.stderr, selectors.EVENT_READ, "stderr")
@@ -215,10 +225,12 @@ def _run_command(
                     if not chunk:
                         selector.unregister(key.fileobj)
                         continue
-                    output = streams[key.data]
-                    output.extend(chunk)
-                    if len(output) > output_limit_bytes:
-                        raise ProviderError("CODEX_EXEC_OUTPUT_LIMIT")
+                    stream_name = key.data
+                    output = streams[stream_name]
+                    remaining_capacity = max(output_limit_bytes - len(output), 0)
+                    output.extend(chunk[:remaining_capacity])
+                    if len(chunk) > remaining_capacity:
+                        truncated[stream_name] = True
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise ProviderError("CODEX_EXEC_TIMEOUT")
@@ -233,11 +245,13 @@ def _run_command(
             selector.close()
             process.stdout.close()
             process.stderr.close()
-        return subprocess.CompletedProcess(
+        return _CommandResult(
             tuple(argv),
             returncode,
             bytes(streams["stdout"]),
             bytes(streams["stderr"]),
+            truncated["stdout"],
+            truncated["stderr"],
         )
 
 
@@ -251,7 +265,9 @@ def _auth_preflight(executable: str, *, cwd: Path, environment: Mapping[str, str
     )
     status = (completed.stdout + b"\n" + completed.stderr).decode("utf-8", errors="replace").lower()
     if (
-        completed.returncode != 0
+        completed.stdout_truncated
+        or completed.stderr_truncated
+        or completed.returncode != 0
         or re.search(r"\blogged in (?:using|with) chatgpt\b", status) is None
         or "api key" in status
         or "api-key" in status
@@ -270,7 +286,7 @@ def _cli_version(executable: str, *, cwd: Path, environment: Mapping[str, str]) 
         )
     except ProviderError:
         return "unknown"
-    if completed.returncode != 0:
+    if completed.returncode != 0 or completed.stdout_truncated or completed.stderr_truncated:
         return "unknown"
     first_line = completed.stdout.decode("utf-8", errors="replace").strip().splitlines()
     if not first_line:
@@ -279,7 +295,7 @@ def _cli_version(executable: str, *, cwd: Path, environment: Mapping[str, str]) 
     return sanitized[:120] or "unknown"
 
 
-def _usage_from_jsonl(raw: bytes) -> dict[str, Any]:
+def _usage_from_jsonl(raw: bytes, *, truncated: bool = False) -> dict[str, Any]:
     usage: Mapping[str, Any] | None = None
     for line in raw.splitlines():
         try:
@@ -298,7 +314,10 @@ def _usage_from_jsonl(raw: bytes) -> dict[str, Any]:
             recorded[name] = value
     recorded.setdefault("input_tokens", 0)
     recorded.setdefault("output_tokens", 0)
-    recorded["telemetry_status"] = "reported" if usage is not None else "unavailable"
+    if truncated:
+        recorded["telemetry_status"] = "truncated"
+    else:
+        recorded["telemetry_status"] = "reported" if usage is not None else "unavailable"
     recorded["pricing"] = {
         "source": "chatgpt_subscription",
         "per_run_cost_applicable": False,
@@ -329,6 +348,7 @@ def _adapt_result(
     generated: Mapping[str, Any],
     version: str,
     jsonl: bytes,
+    telemetry_truncated: bool = False,
 ) -> dict[str, Any]:
     request_digest = request.get("request_digest")
     if not isinstance(request_digest, str):
@@ -361,7 +381,7 @@ def _adapt_result(
         "cli_version": version,
         "auth_mode": "chatgpt",
     }
-    response["usage"] = _usage_from_jsonl(jsonl)
+    response["usage"] = _usage_from_jsonl(jsonl, truncated=telemetry_truncated)
     return response
 
 
@@ -425,6 +445,7 @@ def _invoke(message: Mapping[str, Any], executable: str) -> dict[str, Any]:
             generated=generated,
             version=version,
             jsonl=completed.stdout,
+            telemetry_truncated=(completed.stdout_truncated or completed.stderr_truncated),
         )
 
 

--- a/tests/unit/test_codex_cli_provider.py
+++ b/tests/unit/test_codex_cli_provider.py
@@ -60,6 +60,15 @@ class _FakeCodex:
         self.write_result = write_result
         self.calls: list[dict[str, Any]] = []
 
+    @staticmethod
+    def _completed(
+        argv: tuple[str, ...], returncode: int, stdout: bytes, stderr: bytes
+    ) -> subprocess.CompletedProcess[bytes]:
+        completed = subprocess.CompletedProcess(argv, returncode, stdout, stderr)
+        completed.stdout_truncated = False  # type: ignore[attr-defined]
+        completed.stderr_truncated = False  # type: ignore[attr-defined]
+        return completed
+
     def __call__(
         self,
         argv: tuple[str, ...],
@@ -81,18 +90,16 @@ class _FakeCodex:
             }
         )
         if argv[1:] == ("login", "status"):
-            return subprocess.CompletedProcess(argv, 0, self.auth, b"")
+            return self._completed(argv, 0, self.auth, b"")
         if argv[1:] == ("--version",):
-            return subprocess.CompletedProcess(
-                argv, self.version_returncode, b"codex-cli 9.8.7\n", b""
-            )
+            return self._completed(argv, self.version_returncode, b"codex-cli 9.8.7\n", b"")
         assert argv[1] == "exec"
         schema_path = Path(argv[argv.index("--output-schema") + 1])
         self.calls[-1]["schema"] = json.loads(schema_path.read_text())
         if self.write_result:
             output_path = Path(argv[argv.index("--output-last-message") + 1])
             output_path.write_text(json.dumps(self.generated))
-        return subprocess.CompletedProcess(argv, self.exec_returncode, self.jsonl, b"private")
+        return self._completed(argv, self.exec_returncode, self.jsonl, b"private")
 
 
 def _install_fake(
@@ -397,6 +404,41 @@ def test_optional_cli_version_probe_does_not_change_prompt_identity(
     )
 
 
+def test_truncated_auth_preflight_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    provider = _provider_module()
+    result = provider._CommandResult(
+        ("/usr/bin/codex", "login", "status"),
+        0,
+        b"Logged in using ChatGPT\n",
+        b"",
+        True,
+        False,
+    )
+    monkeypatch.setattr(provider, "_run_command", lambda *args, **kwargs: result)
+
+    with pytest.raises(provider.ProviderError, match="CODEX_CHATGPT_AUTH_REQUIRED"):
+        provider._auth_preflight("/usr/bin/codex", cwd=tmp_path, environment={})
+
+
+def test_truncated_optional_version_probe_returns_unknown(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    provider = _provider_module()
+    result = provider._CommandResult(
+        ("/usr/bin/codex", "--version"),
+        0,
+        b"codex-cli 9.8.7\n",
+        b"",
+        True,
+        False,
+    )
+    monkeypatch.setattr(provider, "_run_command", lambda *args, **kwargs: result)
+
+    assert provider._cli_version("/usr/bin/codex", cwd=tmp_path, environment={}) == "unknown"
+
+
 @pytest.mark.parametrize(
     "auth",
     [
@@ -583,22 +625,22 @@ def test_command_timeout_kills_codex_without_creating_a_new_process_group(
     assert observed == [False]
 
 
-def test_command_output_limit_is_enforced_while_codex_is_running(tmp_path: Path) -> None:
+def test_command_output_is_bounded_while_codex_is_running(tmp_path: Path) -> None:
     provider = _provider_module()
     started = time.monotonic()
 
-    with pytest.raises(provider.ProviderError, match="CODEX_EXEC_OUTPUT_LIMIT"):
-        provider._run_command(
-            (
-                sys.executable,
-                "-c",
-                "import os,time; os.write(1, b'x' * 1024); time.sleep(5)",
-            ),
-            input_bytes=b"prompt",
-            cwd=tmp_path,
-            environment={},
-            timeout_seconds=2,
-            output_limit_bytes=32,
-        )
+    completed = provider._run_command(
+        (sys.executable, "-c", "import os; os.write(1, b'x' * 1024)"),
+        input_bytes=b"prompt",
+        cwd=tmp_path,
+        environment={},
+        timeout_seconds=2,
+        output_limit_bytes=32,
+    )
 
     assert time.monotonic() - started < 2
+    assert completed.returncode == 0
+    assert completed.stdout == b"x" * 32
+    assert completed.stderr == b""
+    assert completed.stdout_truncated is True
+    assert completed.stderr_truncated is False

--- a/tests/unit/test_codex_cli_provider.py
+++ b/tests/unit/test_codex_cli_provider.py
@@ -299,6 +299,51 @@ def test_missing_or_truncated_telemetry_does_not_fail_a_valid_result(
     }
 
 
+@pytest.mark.parametrize(
+    ("oversized_stream", "expected_input_tokens"),
+    [("stdout", 0), ("stderr", 100)],
+)
+def test_oversized_exec_telemetry_does_not_discard_a_valid_result(
+    tmp_path: Path,
+    oversized_stream: str,
+    expected_input_tokens: int,
+) -> None:
+    provider = _provider_module()
+    executable = tmp_path / "codex"
+    executable.write_text(
+        f"""#!{sys.executable}
+import json
+import sys
+from pathlib import Path
+
+arguments = sys.argv[1:]
+if arguments == ["login", "status"]:
+    print("Logged in using ChatGPT")
+elif arguments == ["--version"]:
+    print("codex-cli 9.8.7")
+else:
+    output = Path(arguments[arguments.index("--output-last-message") + 1])
+    output.write_text(json.dumps({{"files": []}}))
+    usage = (
+        b'{{"type":"turn.completed","usage":{{"input_tokens":100,'
+        b'"output_tokens":20}}}}\\n'
+    )
+    if {oversized_stream!r} == "stdout":
+        sys.stdout.buffer.write(b"x" * ({provider._OUTPUT_LIMIT_BYTES} + 1))
+    else:
+        sys.stdout.buffer.write(usage)
+        sys.stderr.buffer.write(b"x" * ({provider._OUTPUT_LIMIT_BYTES} + 1))
+"""
+    )
+    executable.chmod(0o755)
+
+    response = provider._invoke(_message(), str(executable))
+
+    assert response["files"] == {}
+    assert response["usage"]["telemetry_status"] == "truncated"
+    assert response["usage"]["input_tokens"] == expected_input_tokens
+
+
 def test_advisory_uses_its_own_schema_and_remains_digest_bound(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes #169.

## Why

External architecture review after #168 found that the 1 MB stdout/stderr cap could terminate a valid long-running Codex session even when `--output-last-message` contained a complete authoritative result. That would make the real E1 gate in #143 measure telemetry verbosity rather than product behavior.

## What changed

- retain at most the configured cap independently for stdout and stderr;
- continue draining excess bytes so Codex can finish without pipe backpressure;
- report `usage.telemetry_status = "truncated"` if either exec stream exceeds its cap;
- preserve complete usage telemetry captured before truncation, otherwise retain the existing zero-token fallback;
- keep authentication fail-closed when auth output is truncated;
- keep CLI version optional and return `unknown` for a truncated version probe;
- leave the independent authoritative result-file limit strict;
- document the distinction.

## Tests-first evidence

- Regression-first commit: `b52735e` (remote; local equivalent `0be7df4`) proves >1 MB stdout and >1 MB stderr both failed before implementation despite valid result files.
- Implementation commit: `29838ab` (remote; local equivalent `95c05a1`).
- Remote Git tree `dd47014e27a9b52d6146836f63dc01e20e8c5101` exactly matches the locally verified tree.

## Local verification

- Codex provider suite: pass.
- Focused compiler, provider, evidence, sandbox, CLI, E1–E5, and publication-truth suites: pass with two expected real-sandbox skips.
- Ruff formatting and lint: pass.
- Strict mypy: pass for 177 source files.
- Compileall and diff hygiene: pass.

## Boundaries

No API key, paid API workflow, model/configuration drift implementation, hosted service, deployment layer, or approval semantics change. F2 remains deferred until after real E1 as required by the external review. Unknown approval states continue to fail closed.

## Review plan

Before merge this PR requires: an initial independent Codex review, fixes and replies for every substantive finding, resolved threads, a fresh exact-head Codex follow-up review, an owner exact-head verification review, and all CI checks green.