### PR TITLE
Run symlinked trusted Python inside candidate sandbox

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -51,9 +51,11 @@ Python installation are supported. The candidate sandbox validates that
 interpreter's canonical target against the independently reported Python
 base/prefix roots, which are bound read-only. It preserves the original path
 when that path is inside a bound root so Python retains virtual-environment
-identity; an alias outside those roots is replaced with the validated canonical
-path. It does not trust a root derived from the executable target or resolve
-candidate-selected command links.
+identity. For a symlinked virtualenv directory, it uses the equivalent path
+inside the mounted real virtualenv after proving that it resolves to the same
+trusted interpreter. Other aliases outside the bound roots use the validated
+canonical path. It does not trust a root derived from the executable target or
+resolve candidate-selected command links.
 
 ## Legacy compatibility verification
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -46,6 +46,11 @@ pmpe legacy validate examples/taskflow_mvp_spec.yaml
 pytest tests/unit           # fast sanity (~10s); full suite: pytest (~2 min)
 ```
 
+Virtual environments whose active Python executable is a symlink to a managed
+Python installation are supported. The candidate sandbox canonicalizes only
+that trusted interpreter into an already-bound read-only runtime root; it does
+not resolve candidate-selected command links.
+
 ## Legacy compatibility verification
 
 ```bash

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -49,9 +49,11 @@ pytest tests/unit           # fast sanity (~10s); full suite: pytest (~2 min)
 Virtual environments whose active Python executable is a symlink to a managed
 Python installation are supported. The candidate sandbox validates that
 interpreter's canonical target against the independently reported Python
-base/prefix roots, which are bound read-only, while invoking the original path
-to preserve virtual-environment identity. It does not trust a root derived from
-the executable target or resolve candidate-selected command links.
+base/prefix roots, which are bound read-only. It preserves the original path
+when that path is inside a bound root so Python retains virtual-environment
+identity; an alias outside those roots is replaced with the validated canonical
+path. It does not trust a root derived from the executable target or resolve
+candidate-selected command links.
 
 ## Legacy compatibility verification
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -53,9 +53,11 @@ base/prefix roots, which are bound read-only. It preserves the original path
 when that path is inside a bound root so Python retains virtual-environment
 identity. For a symlinked virtualenv directory, it uses the equivalent path
 inside the mounted real virtualenv after proving that it resolves to the same
-trusted interpreter. Other aliases outside the bound roots use the validated
-canonical path. It does not trust a root derived from the executable target or
-resolve candidate-selected command links.
+trusted interpreter. If that path's link chain crosses an external alias, only
+the verified link entries are recreated in otherwise empty sandbox directories;
+no external directory is mounted. Other aliases outside the bound roots use the
+validated canonical path. It does not trust a root derived from the executable
+target or resolve candidate-selected command links.
 
 ## Legacy compatibility verification
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -48,8 +48,9 @@ pytest tests/unit           # fast sanity (~10s); full suite: pytest (~2 min)
 
 Virtual environments whose active Python executable is a symlink to a managed
 Python installation are supported. The candidate sandbox canonicalizes only
-that trusted interpreter into an already-bound read-only runtime root; it does
-not resolve candidate-selected command links.
+that trusted interpreter after validating it against the independently reported
+Python base/prefix roots, which are bound read-only. It does not trust a root
+derived from the executable target or resolve candidate-selected command links.
 
 ## Legacy compatibility verification
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -47,10 +47,11 @@ pytest tests/unit           # fast sanity (~10s); full suite: pytest (~2 min)
 ```
 
 Virtual environments whose active Python executable is a symlink to a managed
-Python installation are supported. The candidate sandbox canonicalizes only
-that trusted interpreter after validating it against the independently reported
-Python base/prefix roots, which are bound read-only. It does not trust a root
-derived from the executable target or resolve candidate-selected command links.
+Python installation are supported. The candidate sandbox validates that
+interpreter's canonical target against the independently reported Python
+base/prefix roots, which are bound read-only, while invoking the original path
+to preserve virtual-environment identity. It does not trust a root derived from
+the executable target or resolve candidate-selected command links.
 
 ## Legacy compatibility verification
 

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -165,6 +165,22 @@ class BubblewrapCandidateSandbox:
             current = current.parent
         return tuple(reversed(parents))
 
+    @staticmethod
+    def _trusted_command(argv: Sequence[str], runtime_roots: tuple[Path, ...]) -> list[str]:
+        command = list(argv)
+        if not command or command[0] != sys.executable:
+            return command
+        try:
+            canonical = Path(sys.executable).resolve(strict=True)
+        except OSError as exc:
+            raise ContractInvalidError("active Python interpreter is unavailable") from exc
+        if not canonical.is_file() or not any(
+            canonical.is_relative_to(root) for root in runtime_roots
+        ):
+            raise ContractInvalidError("active Python interpreter is outside trusted runtime roots")
+        command[0] = str(canonical)
+        return command
+
     def run(
         self,
         workspace: Path,
@@ -177,6 +193,8 @@ class BubblewrapCandidateSandbox:
         limiter = shutil.which(self.limiter, path=_SANDBOX_PATH)
         if sandbox is None or limiter is None:
             raise ContractInvalidError("candidate OS sandbox is unavailable")
+        runtime_roots = self._runtime_roots()
+        sandbox_command = self._trusted_command(argv, runtime_roots)
         sandbox_argv = [
             sandbox,
             "--die-with-parent",
@@ -192,7 +210,7 @@ class BubblewrapCandidateSandbox:
         ]
         created_directories: set[str] = {"/etc", "/workspace"}
         bound_roots: list[Path] = []
-        for runtime_root in self._runtime_roots():
+        for runtime_root in runtime_roots:
             if any(runtime_root.is_relative_to(bound) for bound in bound_roots):
                 continue
             for parent in self._parent_directories(runtime_root):
@@ -235,7 +253,7 @@ class BubblewrapCandidateSandbox:
         )
         for name, value in sorted(environment.items()):
             sandbox_argv.extend(("--setenv", name, value))
-        sandbox_argv.extend(("--chdir", "/workspace", "--", *argv))
+        sandbox_argv.extend(("--chdir", "/workspace", "--", *sandbox_command))
         command = [
             limiter,
             f"--as={1024 * 1024 * 1024}",

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -176,7 +176,6 @@ class BubblewrapCandidateSandbox:
             canonical.is_relative_to(root) for root in runtime_roots
         ):
             raise ContractInvalidError("active Python interpreter is outside trusted runtime roots")
-        command[0] = str(canonical)
         return command
 
     def run(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -177,8 +177,27 @@ class BubblewrapCandidateSandbox:
         ):
             raise ContractInvalidError("active Python interpreter is outside trusted runtime roots")
         active = Path(sys.executable)
-        if not any(active.is_relative_to(root) for root in runtime_roots):
-            command[0] = str(canonical)
+        if any(active.is_relative_to(root) for root in runtime_roots):
+            return command
+        prefix = Path(sys.prefix)
+        if prefix != Path(sys.base_prefix) and active.is_relative_to(prefix):
+            relative = active.relative_to(prefix)
+            if ".." in relative.parts:
+                raise ContractInvalidError("active Python virtualenv path is invalid")
+            try:
+                mounted = prefix.resolve(strict=True) / relative
+                mounted_target = mounted.resolve(strict=True)
+            except OSError as exc:
+                raise ContractInvalidError("active Python virtualenv is unavailable") from exc
+            if not any(mounted.is_relative_to(root) for root in runtime_roots):
+                raise ContractInvalidError(
+                    "active Python virtualenv is outside trusted runtime roots"
+                )
+            if mounted_target != canonical:
+                raise ContractInvalidError("active Python virtualenv target is inconsistent")
+            command[0] = str(mounted)
+            return command
+        command[0] = str(canonical)
         return command
 
     def run(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -176,6 +176,9 @@ class BubblewrapCandidateSandbox:
             canonical.is_relative_to(root) for root in runtime_roots
         ):
             raise ContractInvalidError("active Python interpreter is outside trusted runtime roots")
+        active = Path(sys.executable)
+        if not any(active.is_relative_to(root) for root in runtime_roots):
+            command[0] = str(canonical)
         return command
 
     def run(

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -143,7 +143,6 @@ class BubblewrapCandidateSandbox:
 
     @staticmethod
     def _runtime_roots() -> tuple[Path, ...]:
-        executable_root = Path(sys.executable).resolve().parent.parent
         candidates = {
             Path("/usr"),
             Path("/bin"),
@@ -152,7 +151,6 @@ class BubblewrapCandidateSandbox:
             Path("/lib64"),
             Path(sys.base_prefix).resolve(),
             Path(sys.prefix).resolve(),
-            executable_root,
         }
         return tuple(sorted((item for item in candidates if item.exists()), key=str))
 

--- a/src/pmpe/barebones.py
+++ b/src/pmpe/barebones.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import math
 import operator as comparison
+import os
 import re
 import shutil
 import subprocess
@@ -101,6 +102,9 @@ _ACTION_TIMEOUT_SECONDS = 10.0
 _PYTEST_TIMEOUT_SECONDS = 30.0
 _CANDIDATE_OUTPUT_LIMIT_BYTES = 1_000_000
 _SANDBOX_PATH = "/usr/local/bin:/usr/bin:/bin"
+_SANDBOX_RESERVED_ALIAS_ROOTS = tuple(
+    Path(path) for path in ("/workspace", "/tmp", "/etc", "/dev", "/proc")
+)
 _PYTEST_RESULT_PREFIX = "__PMPE_PYTEST_RESULT__:"
 
 _PROVIDER_ERROR_CODE = re.compile(r"[A-Z][A-Z0-9_]*\Z")
@@ -164,10 +168,12 @@ class BubblewrapCandidateSandbox:
         return tuple(reversed(parents))
 
     @staticmethod
-    def _trusted_command(argv: Sequence[str], runtime_roots: tuple[Path, ...]) -> list[str]:
+    def _trusted_command(
+        argv: Sequence[str], runtime_roots: tuple[Path, ...]
+    ) -> tuple[list[str], Path | None]:
         command = list(argv)
         if not command or command[0] != sys.executable:
-            return command
+            return command, None
         try:
             canonical = Path(sys.executable).resolve(strict=True)
         except OSError as exc:
@@ -178,7 +184,7 @@ class BubblewrapCandidateSandbox:
             raise ContractInvalidError("active Python interpreter is outside trusted runtime roots")
         active = Path(sys.executable)
         if any(active.is_relative_to(root) for root in runtime_roots):
-            return command
+            return command, canonical
         prefix = Path(sys.prefix)
         if prefix != Path(sys.base_prefix) and active.is_relative_to(prefix):
             relative = active.relative_to(prefix)
@@ -196,9 +202,61 @@ class BubblewrapCandidateSandbox:
             if mounted_target != canonical:
                 raise ContractInvalidError("active Python virtualenv target is inconsistent")
             command[0] = str(mounted)
-            return command
+            return command, canonical
         command[0] = str(canonical)
-        return command
+        return command, canonical
+
+    @staticmethod
+    def _interpreter_aliases(
+        executable: Path,
+        canonical: Path,
+        runtime_roots: tuple[Path, ...],
+    ) -> tuple[tuple[str, str], ...]:
+        def first_link(path: Path) -> tuple[Path, Path, tuple[str, ...]] | None:
+            parts = path.parts
+            current = Path(parts[0])
+            for index, part in enumerate(parts[1:], start=1):
+                current /= part
+                if current.is_symlink():
+                    try:
+                        return current, current.readlink(), parts[index + 1 :]
+                    except OSError as exc:
+                        raise ContractInvalidError(
+                            "active Python interpreter alias is unavailable"
+                        ) from exc
+            return None
+
+        if not executable.is_absolute():
+            raise ContractInvalidError("active Python interpreter alias is not absolute")
+        aliases: list[tuple[str, str]] = []
+        current = executable
+        seen: set[Path] = set()
+        while current != canonical:
+            if current in seen:
+                raise ContractInvalidError("active Python interpreter alias has a cycle")
+            seen.add(current)
+            link_record = first_link(current)
+            if link_record is None:
+                raise ContractInvalidError(
+                    "active Python interpreter alias does not reach the trusted runtime"
+                )
+            alias, link, remainder = link_record
+            if not any(alias.is_relative_to(root) for root in runtime_roots):
+                if any(
+                    alias == root or alias.is_relative_to(root)
+                    for root in _SANDBOX_RESERVED_ALIAS_ROOTS
+                ):
+                    raise ContractInvalidError(
+                        "active Python interpreter alias uses a reserved path"
+                    )
+                aliases.append((str(link), str(alias)))
+            target = link if link.is_absolute() else alias.parent / link
+            current = Path(os.path.normpath(str(target.joinpath(*remainder))))
+        if not any(current.is_relative_to(root) for root in runtime_roots):
+            raise ContractInvalidError(
+                "active Python interpreter alias escapes trusted runtime roots"
+            )
+        return tuple(aliases)
 
     def run(
         self,
@@ -213,7 +271,14 @@ class BubblewrapCandidateSandbox:
         if sandbox is None or limiter is None:
             raise ContractInvalidError("candidate OS sandbox is unavailable")
         runtime_roots = self._runtime_roots()
-        sandbox_command = self._trusted_command(argv, runtime_roots)
+        sandbox_command, canonical_interpreter = self._trusted_command(argv, runtime_roots)
+        interpreter_aliases = (
+            ()
+            if canonical_interpreter is None
+            else self._interpreter_aliases(
+                Path(sandbox_command[0]), canonical_interpreter, runtime_roots
+            )
+        )
         sandbox_argv = [
             sandbox,
             "--die-with-parent",
@@ -240,6 +305,13 @@ class BubblewrapCandidateSandbox:
                     created_directories.add(parent)
             sandbox_argv.extend(("--ro-bind", str(runtime_root), str(runtime_root)))
             bound_roots.append(runtime_root)
+        for target, destination in interpreter_aliases:
+            destination_path = Path(destination)
+            for parent in self._parent_directories(destination_path):
+                if parent not in created_directories:
+                    sandbox_argv.extend(("--dir", parent))
+                    created_directories.add(parent)
+            sandbox_argv.extend(("--symlink", target, destination))
         for host_path in (
             "/etc/alternatives",
             "/etc/group",

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -69,6 +69,78 @@ def test_default_candidate_sandbox_removes_host_authority(
     assert observed["environment"] == {"LC_ALL": "C", "PATH": "/usr/local/bin:/usr/bin:/bin"}
 
 
+def test_active_symlinked_interpreter_uses_bound_canonical_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    managed_root = tmp_path / "managed-python"
+    managed_bin = managed_root / "bin"
+    managed_bin.mkdir(parents=True)
+    canonical = managed_bin / "python3.12"
+    canonical.write_text("trusted interpreter")
+    virtualenv_bin = tmp_path / "venv" / "bin"
+    virtualenv_bin.mkdir(parents=True)
+    active = virtualenv_bin / "python"
+    active.symlink_to(canonical)
+    observed: list[str] = []
+
+    monkeypatch.setattr(barebones.sys, "executable", str(active))
+    monkeypatch.setattr(
+        barebones.shutil,
+        "which",
+        lambda name, path=None: f"/usr/bin/{name}",
+    )
+
+    def completed(argv: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        observed.extend(argv)  # type: ignore[arg-type]
+        return subprocess.CompletedProcess(argv, 0, b"", b"")  # type: ignore[arg-type]
+
+    monkeypatch.setattr(barebones.subprocess, "run", completed)
+
+    BubblewrapCandidateSandbox().run(
+        workspace,
+        (str(active), "-V"),
+        timeout_seconds=2,
+        environment={},
+    )
+
+    assert observed[-2:] == [str(canonical), "-V"]
+
+
+def test_arbitrary_command_symlink_is_not_resolved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    target = tmp_path / "tool-target"
+    target.write_text("candidate-selected tool")
+    command_link = tmp_path / "tool"
+    command_link.symlink_to(target)
+    observed: list[str] = []
+
+    monkeypatch.setattr(
+        barebones.shutil,
+        "which",
+        lambda name, path=None: f"/usr/bin/{name}",
+    )
+
+    def completed(argv: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        observed.extend(argv)  # type: ignore[arg-type]
+        return subprocess.CompletedProcess(argv, 0, b"", b"")  # type: ignore[arg-type]
+
+    monkeypatch.setattr(barebones.subprocess, "run", completed)
+
+    BubblewrapCandidateSandbox().run(
+        workspace,
+        (str(command_link), "--version"),
+        timeout_seconds=2,
+        environment={},
+    )
+
+    assert observed[-2:] == [str(command_link), "--version"]
+
+
 def test_model_file_path_cannot_escape_candidate_root(tmp_path: Path) -> None:
     workspace = tmp_path / "candidate"
     workspace.mkdir()

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -141,6 +141,37 @@ def test_arbitrary_command_symlink_is_not_resolved(
     assert observed[-2:] == [str(command_link), "--version"]
 
 
+def test_active_interpreter_outside_bound_roots_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    managed_bin = tmp_path / "managed-python" / "bin"
+    managed_bin.mkdir(parents=True)
+    canonical = managed_bin / "python3.12"
+    canonical.write_text("trusted interpreter")
+    active = tmp_path / "venv" / "bin" / "python"
+    active.parent.mkdir(parents=True)
+    active.symlink_to(canonical)
+    sandbox = BubblewrapCandidateSandbox()
+
+    monkeypatch.setattr(barebones.sys, "executable", str(active))
+    monkeypatch.setattr(sandbox, "_runtime_roots", lambda: (Path("/usr"),))
+    monkeypatch.setattr(
+        barebones.shutil,
+        "which",
+        lambda name, path=None: f"/usr/bin/{name}",
+    )
+
+    with pytest.raises(ContractInvalidError, match="outside trusted runtime roots"):
+        sandbox.run(
+            workspace,
+            (str(active), "-V"),
+            timeout_seconds=2,
+            environment={},
+        )
+
+
 def test_model_file_path_cannot_escape_candidate_root(tmp_path: Path) -> None:
     workspace = tmp_path / "candidate"
     workspace.mkdir()

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -69,7 +69,7 @@ def test_default_candidate_sandbox_removes_host_authority(
     assert observed["environment"] == {"LC_ALL": "C", "PATH": "/usr/local/bin:/usr/bin:/bin"}
 
 
-def test_active_symlinked_interpreter_uses_bound_canonical_target(
+def test_active_symlinked_interpreter_preserves_virtualenv_identity(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     workspace = tmp_path / "candidate"
@@ -107,7 +107,7 @@ def test_active_symlinked_interpreter_uses_bound_canonical_target(
         environment={},
     )
 
-    assert observed[-2:] == [str(canonical), "-V"]
+    assert observed[-2:] == [str(active), "-V"]
 
 
 def test_runtime_roots_do_not_trust_resolved_executable_root(

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -177,6 +177,55 @@ def test_active_interpreter_alias_outside_bound_roots_uses_canonical_target(
     assert observed[-2:] == [str(canonical), "-V"]
 
 
+def test_symlinked_virtualenv_uses_mounted_virtualenv_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    managed_root = tmp_path / "managed-python"
+    canonical = managed_root / "bin" / "python3.12"
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text("trusted interpreter")
+    virtualenv_root = tmp_path / "venvs" / "v1"
+    virtualenv_python = virtualenv_root / "bin" / "python"
+    virtualenv_python.parent.mkdir(parents=True)
+    virtualenv_python.symlink_to(canonical)
+    (virtualenv_root / "pyvenv.cfg").write_text("home = managed-python/bin\n")
+    virtualenv_alias = tmp_path / "current"
+    virtualenv_alias.symlink_to(virtualenv_root, target_is_directory=True)
+    active = virtualenv_alias / "bin" / "python"
+    observed: list[str] = []
+
+    monkeypatch.setattr(barebones.sys, "executable", str(active))
+    monkeypatch.setattr(barebones.sys, "prefix", str(virtualenv_alias))
+    monkeypatch.setattr(
+        barebones.shutil,
+        "which",
+        lambda name, path=None: f"/usr/bin/{name}",
+    )
+    sandbox = BubblewrapCandidateSandbox()
+    monkeypatch.setattr(
+        sandbox,
+        "_runtime_roots",
+        lambda: (managed_root, virtualenv_root),
+    )
+
+    def completed(argv: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        observed.extend(argv)  # type: ignore[arg-type]
+        return subprocess.CompletedProcess(argv, 0, b"", b"")  # type: ignore[arg-type]
+
+    monkeypatch.setattr(barebones.subprocess, "run", completed)
+
+    sandbox.run(
+        workspace,
+        (str(active), "-V"),
+        timeout_seconds=2,
+        environment={},
+    )
+
+    assert observed[-2:] == [str(virtualenv_python), "-V"]
+
+
 def test_arbitrary_command_symlink_is_not_resolved(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -108,6 +108,26 @@ def test_active_symlinked_interpreter_uses_bound_canonical_target(
     assert observed[-2:] == [str(canonical), "-V"]
 
 
+def test_runtime_roots_do_not_trust_resolved_executable_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    managed_root = tmp_path / "untrusted-python"
+    canonical = managed_root / "bin" / "python3.12"
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text("untrusted interpreter")
+    active = tmp_path / "venv" / "bin" / "python"
+    active.parent.mkdir(parents=True)
+    active.symlink_to(canonical)
+
+    monkeypatch.setattr(barebones.sys, "executable", str(active))
+    monkeypatch.setattr(barebones.sys, "base_prefix", "/usr")
+    monkeypatch.setattr(barebones.sys, "prefix", "/usr")
+
+    runtime_roots = BubblewrapCandidateSandbox._runtime_roots()
+
+    assert not any(canonical.is_relative_to(root) for root in runtime_roots)
+
+
 def test_arbitrary_command_symlink_is_not_resolved(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -91,6 +91,8 @@ def test_active_symlinked_interpreter_uses_bound_canonical_target(
         "which",
         lambda name, path=None: f"/usr/bin/{name}",
     )
+    sandbox = BubblewrapCandidateSandbox()
+    monkeypatch.setattr(sandbox, "_runtime_roots", lambda: (managed_root,))
 
     def completed(argv: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
         observed.extend(argv)  # type: ignore[arg-type]
@@ -98,7 +100,7 @@ def test_active_symlinked_interpreter_uses_bound_canonical_target(
 
     monkeypatch.setattr(barebones.subprocess, "run", completed)
 
-    BubblewrapCandidateSandbox().run(
+    sandbox.run(
         workspace,
         (str(active), "-V"),
         timeout_seconds=2,

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -226,6 +226,64 @@ def test_symlinked_virtualenv_uses_mounted_virtualenv_path(
     assert observed[-2:] == [str(virtualenv_python), "-V"]
 
 
+def test_symlinked_virtualenv_recreates_verified_external_interpreter_alias(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    managed_root = tmp_path / "managed-python"
+    canonical = managed_root / "bin" / "python3.12"
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text("trusted interpreter")
+    external_alias = tmp_path / "external-alias" / "python"
+    external_alias.parent.mkdir()
+    external_alias.symlink_to(canonical)
+    virtualenv_root = tmp_path / "venvs" / "v1"
+    virtualenv_python = virtualenv_root / "bin" / "python"
+    virtualenv_python.parent.mkdir(parents=True)
+    virtualenv_python.symlink_to(external_alias)
+    (virtualenv_root / "pyvenv.cfg").write_text("home = external-alias\n")
+    virtualenv_alias = tmp_path / "current"
+    virtualenv_alias.symlink_to(virtualenv_root, target_is_directory=True)
+    active = virtualenv_alias / "bin" / "python"
+    observed: list[str] = []
+
+    monkeypatch.setattr(barebones.sys, "executable", str(active))
+    monkeypatch.setattr(barebones.sys, "prefix", str(virtualenv_alias))
+    monkeypatch.setattr(
+        barebones.shutil,
+        "which",
+        lambda name, path=None: f"/usr/bin/{name}",
+    )
+    sandbox = BubblewrapCandidateSandbox()
+    monkeypatch.setattr(
+        sandbox,
+        "_runtime_roots",
+        lambda: (managed_root, virtualenv_root),
+    )
+
+    def completed(argv: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        observed.extend(argv)  # type: ignore[arg-type]
+        return subprocess.CompletedProcess(argv, 0, b"", b"")  # type: ignore[arg-type]
+
+    monkeypatch.setattr(barebones.subprocess, "run", completed)
+
+    sandbox.run(
+        workspace,
+        (str(active), "-V"),
+        timeout_seconds=2,
+        environment={},
+    )
+
+    assert observed[-2:] == [str(virtualenv_python), "-V"]
+    alias_index = observed.index("--symlink")
+    assert observed[alias_index : alias_index + 3] == [
+        "--symlink",
+        str(canonical),
+        str(external_alias),
+    ]
+
+
 def test_arbitrary_command_symlink_is_not_resolved(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -250,6 +250,7 @@ def test_symlinked_virtualenv_recreates_verified_external_interpreter_alias(
 
     monkeypatch.setattr(barebones.sys, "executable", str(active))
     monkeypatch.setattr(barebones.sys, "prefix", str(virtualenv_alias))
+    monkeypatch.setattr(barebones, "_SANDBOX_RESERVED_ALIAS_ROOTS", ())
     monkeypatch.setattr(
         barebones.shutil,
         "which",

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -92,7 +92,12 @@ def test_active_symlinked_interpreter_preserves_virtualenv_identity(
         lambda name, path=None: f"/usr/bin/{name}",
     )
     sandbox = BubblewrapCandidateSandbox()
-    monkeypatch.setattr(sandbox, "_runtime_roots", lambda: (managed_root,))
+    virtualenv_root = virtualenv_bin.parent
+    monkeypatch.setattr(
+        sandbox,
+        "_runtime_roots",
+        lambda: (managed_root, virtualenv_root),
+    )
 
     def completed(argv: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
         observed.extend(argv)  # type: ignore[arg-type]
@@ -108,6 +113,9 @@ def test_active_symlinked_interpreter_preserves_virtualenv_identity(
     )
 
     assert observed[-2:] == [str(active), "-V"]
+    assert ["--ro-bind", str(virtualenv_root), str(virtualenv_root)] == observed[
+        observed.index(str(virtualenv_root)) - 1 : observed.index(str(virtualenv_root)) + 2
+    ]
 
 
 def test_runtime_roots_do_not_trust_resolved_executable_root(

--- a/tests/unit/test_candidate_sandbox.py
+++ b/tests/unit/test_candidate_sandbox.py
@@ -138,6 +138,45 @@ def test_runtime_roots_do_not_trust_resolved_executable_root(
     assert not any(canonical.is_relative_to(root) for root in runtime_roots)
 
 
+def test_active_interpreter_alias_outside_bound_roots_uses_canonical_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "candidate"
+    workspace.mkdir()
+    managed_root = tmp_path / "managed-python"
+    canonical = managed_root / "bin" / "python3.12"
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text("trusted interpreter")
+    active = tmp_path / "external-alias" / "python"
+    active.parent.mkdir()
+    active.symlink_to(canonical)
+    observed: list[str] = []
+
+    monkeypatch.setattr(barebones.sys, "executable", str(active))
+    monkeypatch.setattr(
+        barebones.shutil,
+        "which",
+        lambda name, path=None: f"/usr/bin/{name}",
+    )
+    sandbox = BubblewrapCandidateSandbox()
+    monkeypatch.setattr(sandbox, "_runtime_roots", lambda: (managed_root,))
+
+    def completed(argv: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        observed.extend(argv)  # type: ignore[arg-type]
+        return subprocess.CompletedProcess(argv, 0, b"", b"")  # type: ignore[arg-type]
+
+    monkeypatch.setattr(barebones.subprocess, "run", completed)
+
+    sandbox.run(
+        workspace,
+        (str(active), "-V"),
+        timeout_seconds=2,
+        environment={},
+    )
+
+    assert observed[-2:] == [str(canonical), "-V"]
+
+
 def test_arbitrary_command_symlink_is_not_resolved(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #171.

## Live evidence and root cause

The first real E1 attempt in a ChatGPT-authenticated Lima Linux VM halted before any model call:

```
bwrap: execvp .../.venv/bin/python: No such file or directory
```

Bubblewrap succeeded with `/usr/bin/python3`, isolating the defect to the active uv virtual-environment interpreter path: the sandbox mounted the trusted runtime target but did not make every trusted interpreter alias/path component executable inside the sandbox.

## Final change

- Select runtime roots independently from the interpreter symlink target, preventing a circular trust decision.
- Strictly resolve the active trusted interpreter and require its canonical target to be a file inside the selected read-only runtime roots.
- Preserve an already mounted virtual-environment interpreter path so Python retains virtual-environment package identity.
- Map a symlinked virtual-environment directory to the same canonical trusted interpreter when that path is mounted.
- Validate the complete interpreter path-component symlink chain.
- Recreate only verified external interpreter aliases with Bubblewrap `--symlink` in otherwise empty parent directories; do not mount external directories.
- Reject reserved sandbox locations, cycles, missing links, and final escapes.
- Leave candidate-selected arbitrary command symlinks unchanged.
- Document the compatibility and security boundary.

No provider, API-key, approval-contract, evidence-schema, or platform-architecture changes are included.

## Tests-first and review evidence

The PR contains 13 incremental commits so each newly discovered edge case first appears as a failing regression test and then as its bounded fix.

Five genuine Codex review findings were accepted, fixed, replied to, and resolved:

1. circular runtime-root trust
2. loss of virtual-environment package identity
3. unmounted external interpreter aliases
4. symlinked virtual-environment directories
5. external alias components missing inside the sandbox

Final focused verification:

- `pytest tests/unit/test_candidate_sandbox.py -q` — 13 passed, 2 skipped
- `ruff format --check .`
- `ruff check .`
- `mypy --strict src`
- `bandit -q -r src -lll`
- compile-all plus generated-file diff check

The managed Work Mode host lacks the Linux `/proc`/sandbox behavior required by the complete suite, so GitHub's normal Linux CI is the full-suite gate.

## Merge and promotion gate

Merge only after:

1. exact-head Codex review completes with no unresolved finding
2. all 13 exact-head CI jobs pass
3. final exact-head owner review is recorded

After squash merge, verify `main` CI and rerun E1 in the user's ChatGPT-authenticated Lima VM. The real run uses ChatGPT subscription authentication only and no OpenAI API key.