### PR TITLE
Fix package proof child startup deadlines

### DIFF
--- a/src/pmpe/support_package.py
+++ b/src/pmpe/support_package.py
@@ -34,6 +34,8 @@ _MAX_TOTAL_COPIED_EVIDENCE_BYTES = 8_388_608
 _MAX_PACKAGE_MANIFEST_BYTES = 1_048_576
 _MAX_TOTAL_PACKAGE_BYTES = 67_108_864
 _MAX_PACKAGE_ENTRIES = 4_096
+_PROOF_CHILD_STARTUP_TIMEOUT_SECONDS = 25.0
+_PROOF_PROCESS_TIMEOUT_SECONDS = 60.0
 _REQUIRED_PACKAGE_FILES = frozenset(
     {
         "Dockerfile",
@@ -172,7 +174,7 @@ capability = sys.argv[1]
 emit = os.write
 payload = json.loads(sys.stdin.buffer.read())
 source = payload["app_source"].encode()
-proof_deadline = time.monotonic() + 25
+startup_timeout = float(payload["startup_timeout_seconds"])
 with tempfile.TemporaryDirectory(prefix="pmpe-pinned-runtime-") as directory:
     runtime_policy = dict(payload["policy"])
     base_threshold = float(runtime_policy["additional_confidence_below"])
@@ -205,7 +207,8 @@ with tempfile.TemporaryDirectory(prefix="pmpe-pinned-runtime-") as directory:
     try:
         documented_health = None
         documented_url = None
-        while time.monotonic() < proof_deadline:
+        documented_deadline = time.monotonic() + startup_timeout
+        while time.monotonic() < documented_deadline:
             try:
                 if documented_url is None:
                     with open(documented_port_file, encoding="utf-8") as handle:
@@ -242,7 +245,8 @@ with tempfile.TemporaryDirectory(prefix="pmpe-pinned-runtime-") as directory:
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait(timeout=2)
-    while time.monotonic() < proof_deadline:
+    verified_deadline = time.monotonic() + startup_timeout
+    while time.monotonic() < verified_deadline:
         try:
             with open(port_file, encoding="utf-8") as handle:
                 port = int(handle.read())
@@ -264,7 +268,7 @@ with tempfile.TemporaryDirectory(prefix="pmpe-pinned-runtime-") as directory:
             assert response.status == 200
             return json.loads(response.read())
     try:
-        while time.monotonic() < proof_deadline:
+        while time.monotonic() < verified_deadline:
             try:
                 health = request("/health")
                 break
@@ -1360,6 +1364,7 @@ def _run_reference_verification(
                 "app_source": app_source.decode(),
                 "corpus": strict_loads(corpus_source),
                 "policy": strict_loads(policy_source),
+                "startup_timeout_seconds": _PROOF_CHILD_STARTUP_TIMEOUT_SECONDS,
             }
         )
     except (UnicodeError, ValueError, SyntaxError) as exc:
@@ -1424,7 +1429,7 @@ def _run_reference_verification(
             ),
         )
         try:
-            stdout, _ = proof.communicate(proof_input, timeout=30)
+            stdout, _ = proof.communicate(proof_input, timeout=_PROOF_PROCESS_TIMEOUT_SECONDS)
         except subprocess.TimeoutExpired as exc:
             if os.name == "nt":
                 subprocess.run(  # nosec B603 - fixed Windows process-tree terminator

--- a/tests/unit/test_support_package_v1.py
+++ b/tests/unit/test_support_package_v1.py
@@ -451,6 +451,10 @@ def test_runtime_proofs_require_completion_and_standard_library_imports(tmp_path
 
 
 def test_proof_runner_gives_each_child_its_own_startup_deadline() -> None:
+    runner = support_package_module._PROOF_RUNNER
+    assert "proof_deadline = time.monotonic() + 25" not in runner
+    assert "documented_deadline = time.monotonic() + startup_timeout" in runner
+    assert "verified_deadline = time.monotonic() + startup_timeout" in runner
     delayed_source = support_package_module._APP_SOURCE.replace(
         "MEMORY: dict[str, dict[str, object]] = {}\n",
         "MEMORY: dict[str, dict[str, object]] = {}\ntime.sleep(0.6)\n",
@@ -466,12 +470,29 @@ def test_proof_runner_gives_each_child_its_own_startup_deadline() -> None:
             "startup_timeout_seconds": 1.0,
         }
     )
+    shared_deadline_runner = runner.replace(
+        "documented_deadline = time.monotonic() + startup_timeout",
+        "proof_deadline = time.monotonic() + startup_timeout",
+    ).replace("documented_deadline", "proof_deadline")
+    shared_deadline_runner = shared_deadline_runner.replace(
+        "    verified_deadline = time.monotonic() + startup_timeout\n",
+        "",
+    ).replace("verified_deadline", "proof_deadline")
+    shared = subprocess.run(
+        [sys.executable, "-I", "-c", shared_deadline_runner, "ordinary_ticket"],
+        input=proof_input,
+        capture_output=True,
+        check=False,
+        timeout=5,
+    )
+    assert shared.returncode != 0
+
     completed = subprocess.run(
         [
             sys.executable,
             "-I",
             "-c",
-            support_package_module._PROOF_RUNNER,
+            runner,
             "ordinary_ticket",
         ],
         input=proof_input,

--- a/tests/unit/test_support_package_v1.py
+++ b/tests/unit/test_support_package_v1.py
@@ -450,6 +450,39 @@ def test_runtime_proofs_require_completion_and_standard_library_imports(tmp_path
             support_package_module._run_reference_verification(bundle, forbidden, expected_files)
 
 
+def test_proof_runner_gives_each_child_its_own_startup_deadline() -> None:
+    delayed_source = support_package_module._APP_SOURCE.replace(
+        "MEMORY: dict[str, dict[str, object]] = {}\n",
+        "MEMORY: dict[str, dict[str, object]] = {}\ntime.sleep(0.6)\n",
+    )
+    proof_input = canonical_json_bytes(
+        {
+            "app_source": delayed_source,
+            "corpus": support_package_module._RECORDED_CORPUS,
+            "policy": {
+                "additional_confidence_below": 0.75,
+                "max_processing_seconds": 30,
+            },
+            "startup_timeout_seconds": 1.0,
+        }
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            support_package_module._PROOF_RUNNER,
+            "ordinary_ticket",
+        ],
+        input=proof_input,
+        capture_output=True,
+        check=False,
+        timeout=5,
+    )
+    assert completed.returncode == 0
+    assert completed.stdout == b"PMPE_PROOF_COMPLETE:ordinary_ticket"
+
+
 def test_corpus_and_proof_implementations_are_verifier_owned(tmp_path: Path) -> None:
     for relative, replacement, message in (
         ("recorded-corpus.json", b"{}\n", "trusted v1 corpus"),


### PR DESCRIPTION
## Outcome

Repair the Python 3.12 full-suite failure that was discovered after PR #177 was prematurely merged.

## Failure evidence

Run `33090452568` failed in `tests (3.12)` at `test_repeated_release_blob_references_have_bounded_reads`; Python 3.11 was cancelled. The proof runner shared one 25-second startup deadline across its documented child and verified child, so a slow first launch could exhaust the second child's budget.

## Fix

- Give the documented child and verified child separate monotonic startup deadlines.
- Keep each child bounded at 25 seconds.
- Expand the enclosing verifier-owned proof-process timeout to 60 seconds so both bounded startups plus teardown can complete.
- Add a direct regression with two deliberately slow child startups; it fails under a shared deadline and passes only when each child gets its own budget.

## Local verification

- Exact failing repeated-reference test passes.
- New slow-child deadline regression passes.
- Relevant package/publication suite passes locally.
- Ruff format/lint and strict mypy pass.

Follow-up to #177. Refs #176.