### PR TITLE
Accept canonical ProductDecisionContract arrays in compiler

### DIFF
--- a/src/pmpe/contracts/acceptance.py
+++ b/src/pmpe/contracts/acceptance.py
@@ -111,6 +111,49 @@ def _mapping(value: Any) -> Mapping[str, Any] | None:
     return value if isinstance(value, Mapping) else None
 
 
+def _id_keyed_collection(
+    value: Any,
+    *,
+    collection: str,
+    diagnostics: list[AcceptanceDiagnostic],
+) -> Mapping[str, Any] | None:
+    """Accept both compiler-native maps and canonical PDC ID-keyed arrays."""
+
+    if isinstance(value, Mapping):
+        return value
+    if not isinstance(value, list):
+        return None
+    keyed: dict[str, Any] = {}
+    for index, raw in enumerate(value):
+        item = _mapping(raw)
+        item_id = "" if item is None else item.get("id")
+        if item is None or not isinstance(item_id, str) or not item_id:
+            diagnostics.append(
+                AcceptanceDiagnostic(
+                    f"{collection.upper()}_ID_MISSING",
+                    f"{collection}[{index}]",
+                    f"{collection} item requires a non-empty id",
+                )
+            )
+            continue
+        if item_id in keyed:
+            diagnostics.append(
+                AcceptanceDiagnostic(
+                    f"{collection.upper()}_ID_DUPLICATE",
+                    item_id,
+                    f"{collection} contains a duplicate id",
+                )
+            )
+            continue
+        normalized = dict(item)
+        if collection == "criterion" and "requirement_refs" not in normalized:
+            requirement = normalized.get("requirement")
+            if isinstance(requirement, str) and requirement:
+                normalized["requirement_refs"] = [requirement]
+        keyed[item_id] = normalized
+    return keyed
+
+
 def _assertions(
     value: Any,
     *,
@@ -491,8 +534,16 @@ def compile_acceptance_plan(
     """Compile typed criteria and prove task/test coverage before any build."""
 
     diagnostics: list[AcceptanceDiagnostic] = []
-    requirements_raw = _mapping(contract.get("functional_requirements"))
-    criteria_raw = _mapping(contract.get("acceptance_criteria"))
+    requirements_raw = _id_keyed_collection(
+        contract.get("functional_requirements"),
+        collection="requirement",
+        diagnostics=diagnostics,
+    )
+    criteria_raw = _id_keyed_collection(
+        contract.get("acceptance_criteria"),
+        collection="criterion",
+        diagnostics=diagnostics,
+    )
     if not requirements_raw:
         diagnostics.append(
             AcceptanceDiagnostic(

--- a/tests/unit/test_acceptance_compiler.py
+++ b/tests/unit/test_acceptance_compiler.py
@@ -41,6 +41,88 @@ def test_compiles_structured_given_when_then_without_model_interpretation(
     assert plan.plan_digest.startswith("sha256:")
 
 
+def test_compiles_canonical_product_contract_arrays(tmp_path: Path) -> None:
+    contract = {
+        "functional_requirements": [
+            {
+                "id": "FR-001",
+                "title": "Health status",
+                "description": "The service reports its health.",
+            }
+        ],
+        "acceptance_criteria": [
+            {
+                "id": "AC-001",
+                "requirement": "FR-001",
+                "criterion": "A running service reports OK.",
+                "given": [{"path": "service.running", "operator": "eq", "value": True}],
+                "when": {"action": "health", "arguments": {}},
+                "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+            }
+        ],
+    }
+
+    plan = compile_acceptance_plan(
+        contract,
+        repository_root=tmp_path,
+        registered_actions=frozenset({"health"}),
+        template_version="barebones-1",
+        template_test_digests={},
+    )
+
+    assert plan.requirements == ("FR-001",)
+    assert plan.criteria[0].criterion_id == "AC-001"
+    assert plan.criteria[0].requirement_refs == ("FR-001",)
+
+
+@pytest.mark.parametrize(
+    ("field", "code"),
+    [
+        ("functional_requirements", "REQUIREMENT_ID_DUPLICATE"),
+        ("acceptance_criteria", "CRITERION_ID_DUPLICATE"),
+    ],
+)
+def test_canonical_contract_arrays_reject_duplicate_ids(
+    tmp_path: Path, field: str, code: str
+) -> None:
+    contract = {
+        "functional_requirements": [
+            {"id": "FR-001", "title": "Health"},
+            {"id": "FR-002", "title": "Other"},
+        ],
+        "acceptance_criteria": [
+            {
+                "id": "AC-001",
+                "requirement": "FR-001",
+                "criterion": "Health passes.",
+                "given": [{"path": "service.running", "operator": "eq", "value": True}],
+                "when": {"action": "health", "arguments": {}},
+                "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+            },
+            {
+                "id": "AC-002",
+                "requirement": "FR-002",
+                "criterion": "Other passes.",
+                "given": [{"path": "service.running", "operator": "eq", "value": True}],
+                "when": {"action": "health", "arguments": {}},
+                "then": [{"path": "result.status", "operator": "eq", "value": "ok"}],
+            },
+        ],
+    }
+    contract[field][1]["id"] = contract[field][0]["id"]
+
+    with pytest.raises(AcceptanceCompileError) as failure:
+        compile_acceptance_plan(
+            contract,
+            repository_root=tmp_path,
+            registered_actions=frozenset({"health"}),
+            template_version="barebones-1",
+            template_test_digests={},
+        )
+
+    assert any(item.code == code for item in failure.value.diagnostics)
+
+
 def test_free_text_criterion_fails_before_build(tmp_path: Path) -> None:
     contract = _contract(
         {


### PR DESCRIPTION
## What changed
- normalize canonical ID-bearing requirement and acceptance-criterion arrays at the acceptance compiler boundary
- preserve the existing compiler-native mapping form
- reject missing or duplicate IDs deterministically

## Why
PMOS publishes the canonical ProductDecisionContract schema as arrays, while the acceptance compiler previously accepted only mappings. A contract could pass one validator but could not traverse the full PMOS → PEOS handoff unchanged.

## How to test
```bash
PYTHONPATH=src python -m pytest -q tests/unit/test_acceptance_compiler.py tests/unit/test_contract_authoring.py tests/unit/test_contracts.py tests/unit/test_pmos_contract_schema.py tests/unit/test_contract_semantic_validator.py tests/unit/test_barebones_drift.py tests/unit/test_barebones_cli_journey.py tests/integration/test_barebones_cli.py tests/integration/test_contract_validation_evidence.py tests/e2e/test_barebones_e1.py tests/e2e/test_barebones_evals.py
ruff check src/pmpe/contracts/acceptance.py tests/unit/test_acceptance_compiler.py
mypy --strict src/pmpe/contracts/acceptance.py
```

Local result: 491 tests passed; Ruff and strict mypy passed.