### PR TITLE
Harden monitoring store migration and lifecycle state

### DIFF
--- a/products/pm-evals-web/backend/src/pm_evals_monitoring/diagnosis.py
+++ b/products/pm-evals-web/backend/src/pm_evals_monitoring/diagnosis.py
@@ -632,7 +632,7 @@ def build_empty_overview(
     )
     return MonitoringOverview(
         generated_at=reference_time,
-        mode="NO_DATA",
+        mode="LIVE" if receipts else "NO_DATA",
         products=_receipt_products(receipts or [], generated_at=reference_time, existing=products),
         incidents=[],
         trend=[],

--- a/products/pm-evals-web/backend/src/pm_evals_monitoring/storage.py
+++ b/products/pm-evals-web/backend/src/pm_evals_monitoring/storage.py
@@ -71,16 +71,23 @@ def _validate_store_directory(data_dir: Path, *, migrate_legacy_permissions: boo
         directory_stat = os.fstat(descriptor)
         if directory_stat.st_uid != os.getuid():
             raise ValueError("existing monitoring data directory must be owned by this process")
-        if stat.S_IMODE(directory_stat.st_mode) == 0o700:
+        directory_mode = stat.S_IMODE(directory_stat.st_mode)
+        if directory_mode == 0o700:
             return
         legacy_store = False
-        if migrate_legacy_permissions:
+        legacy_mode_is_safe = directory_mode & 0o022 == 0 and directory_mode & 0o700 == 0o700
+        if migrate_legacy_permissions and legacy_mode_is_safe:
             for marker in _LEGACY_STORE_MARKERS:
                 try:
                     marker_stat = os.stat(marker, dir_fd=descriptor, follow_symlinks=False)
                 except FileNotFoundError:
                     continue
-                if stat.S_ISREG(marker_stat.st_mode):
+                marker_mode = stat.S_IMODE(marker_stat.st_mode)
+                if (
+                    stat.S_ISREG(marker_stat.st_mode)
+                    and marker_stat.st_uid == os.getuid()
+                    and marker_mode & 0o022 == 0
+                ):
                     legacy_store = True
                     break
         if not legacy_store:

--- a/products/pm-evals-web/backend/src/pm_evals_monitoring/storage.py
+++ b/products/pm-evals-web/backend/src/pm_evals_monitoring/storage.py
@@ -75,21 +75,27 @@ def _validate_store_directory(data_dir: Path, *, migrate_legacy_permissions: boo
         if directory_mode == 0o700:
             return
         legacy_store = False
-        legacy_mode_is_safe = directory_mode & 0o022 == 0 and directory_mode & 0o700 == 0o700
+        legacy_mode_is_safe = (
+            directory_mode & 0o022 == 0 and directory_mode & 0o700 == 0o700
+        )
         if migrate_legacy_permissions and legacy_mode_is_safe:
+            existing_markers = 0
+            all_markers_are_safe = True
             for marker in _LEGACY_STORE_MARKERS:
                 try:
                     marker_stat = os.stat(marker, dir_fd=descriptor, follow_symlinks=False)
                 except FileNotFoundError:
                     continue
+                existing_markers += 1
                 marker_mode = stat.S_IMODE(marker_stat.st_mode)
                 if (
-                    stat.S_ISREG(marker_stat.st_mode)
-                    and marker_stat.st_uid == os.getuid()
-                    and marker_mode & 0o022 == 0
+                    not stat.S_ISREG(marker_stat.st_mode)
+                    or marker_stat.st_uid != os.getuid()
+                    or marker_mode & 0o022 != 0
                 ):
-                    legacy_store = True
+                    all_markers_are_safe = False
                     break
+            legacy_store = existing_markers > 0 and all_markers_are_safe
         if not legacy_store:
             raise ValueError("existing monitoring data directory must be owner-only mode 0700")
         os.fchmod(descriptor, 0o700)

--- a/products/pm-evals-web/backend/src/pm_evals_monitoring/storage.py
+++ b/products/pm-evals-web/backend/src/pm_evals_monitoring/storage.py
@@ -36,6 +36,9 @@ _SHARED_STORE_ROOTS = frozenset(
 _LEGACY_STORE_MARKERS = (
     "observations.jsonl",
     "observations.sqlite3",
+    "observations.sqlite3-wal",
+    "observations.sqlite3-shm",
+    "observations.sqlite3-journal",
     "observations.lock",
     "run-receipts.jsonl",
     "adjudications.jsonl",

--- a/products/pm-evals-web/backend/src/pm_evals_monitoring/storage.py
+++ b/products/pm-evals-web/backend/src/pm_evals_monitoring/storage.py
@@ -75,9 +75,7 @@ def _validate_store_directory(data_dir: Path, *, migrate_legacy_permissions: boo
         if directory_mode == 0o700:
             return
         legacy_store = False
-        legacy_mode_is_safe = (
-            directory_mode & 0o022 == 0 and directory_mode & 0o700 == 0o700
-        )
+        legacy_mode_is_safe = directory_mode & 0o022 == 0 and directory_mode & 0o700 == 0o700
         if migrate_legacy_permissions and legacy_mode_is_safe:
             existing_markers = 0
             all_markers_are_safe = True

--- a/products/pm-evals-web/backend/tests/test_monitoring_production.py
+++ b/products/pm-evals-web/backend/tests/test_monitoring_production.py
@@ -318,7 +318,7 @@ def test_started_receipt_makes_missing_product_visible(tmp_path: Path) -> None:
     )
     assert response.status_code == 200
     overview = client.get("/api/monitoring/overview").json()
-    assert overview["mode"] == "NO_DATA"
+    assert overview["mode"] == "LIVE"
     assert overview["products"][0]["health"] == "BLOCKED"
     assert overview["products"][0]["latest_run_id"] == "scheduled run 1"
 
@@ -1552,6 +1552,27 @@ def test_existing_store_and_outbox_must_already_be_private(tmp_path: Path) -> No
 
     assert stat.S_IMODE(store_dir.stat().st_mode) == 0o755
     assert stat.S_IMODE(outbox_dir.stat().st_mode) == 0o755
+
+
+@pytest.mark.parametrize(
+    ("directory_mode", "marker_mode"),
+    [(0o777, 0o600), (0o755, 0o666)],
+)
+def test_unsafe_legacy_store_permissions_are_rejected(
+    tmp_path: Path, directory_mode: int, marker_mode: int
+) -> None:
+    store_dir = tmp_path / "unsafe-legacy-store"
+    store_dir.mkdir(mode=0o700)
+    marker = store_dir / "observations.jsonl"
+    marker.touch(mode=0o600)
+    marker.chmod(marker_mode)
+    store_dir.chmod(directory_mode)
+
+    with pytest.raises(ValueError, match="owner-only mode 0700"):
+        MonitoringStore(store_dir)
+
+    assert stat.S_IMODE(store_dir.stat().st_mode) == directory_mode
+    assert stat.S_IMODE(marker.stat().st_mode) == marker_mode
 
 
 def test_owned_legacy_store_permissions_are_migrated(tmp_path: Path) -> None:

--- a/products/pm-evals-web/backend/tests/test_monitoring_production.py
+++ b/products/pm-evals-web/backend/tests/test_monitoring_production.py
@@ -1591,6 +1591,31 @@ def test_legacy_migration_rejects_any_unsafe_existing_marker(tmp_path: Path) -> 
     assert stat.S_IMODE(unsafe_marker.stat().st_mode) == 0o666
 
 
+@pytest.mark.parametrize(
+    "sidecar_name",
+    [
+        "observations.sqlite3-wal",
+        "observations.sqlite3-shm",
+        "observations.sqlite3-journal",
+    ],
+)
+def test_legacy_migration_rejects_unsafe_sqlite_sidecars(
+    tmp_path: Path, sidecar_name: str
+) -> None:
+    store_dir = tmp_path / "sidecar-legacy-store"
+    store_dir.mkdir(mode=0o755)
+    (store_dir / "observations.sqlite3").touch(mode=0o600)
+    sidecar = store_dir / sidecar_name
+    sidecar.touch(mode=0o600)
+    sidecar.chmod(0o666)
+
+    with pytest.raises(ValueError, match="owner-only mode 0700"):
+        MonitoringStore(store_dir)
+
+    assert stat.S_IMODE(store_dir.stat().st_mode) == 0o755
+    assert stat.S_IMODE(sidecar.stat().st_mode) == 0o666
+
+
 def test_owned_legacy_store_permissions_are_migrated(tmp_path: Path) -> None:
     store_dir = tmp_path / "legacy-store"
     store_dir.mkdir(mode=0o755)

--- a/products/pm-evals-web/backend/tests/test_monitoring_production.py
+++ b/products/pm-evals-web/backend/tests/test_monitoring_production.py
@@ -1575,6 +1575,22 @@ def test_unsafe_legacy_store_permissions_are_rejected(
     assert stat.S_IMODE(marker.stat().st_mode) == marker_mode
 
 
+def test_legacy_migration_rejects_any_unsafe_existing_marker(tmp_path: Path) -> None:
+    store_dir = tmp_path / "mixed-legacy-store"
+    store_dir.mkdir(mode=0o755)
+    safe_marker = store_dir / "observations.jsonl"
+    unsafe_marker = store_dir / "run-receipts.jsonl"
+    safe_marker.touch(mode=0o600)
+    unsafe_marker.touch(mode=0o600)
+    unsafe_marker.chmod(0o666)
+
+    with pytest.raises(ValueError, match="owner-only mode 0700"):
+        MonitoringStore(store_dir)
+
+    assert stat.S_IMODE(store_dir.stat().st_mode) == 0o755
+    assert stat.S_IMODE(unsafe_marker.stat().st_mode) == 0o666
+
+
 def test_owned_legacy_store_permissions_are_migrated(tmp_path: Path) -> None:
     store_dir = tmp_path / "legacy-store"
     store_dir.mkdir(mode=0o755)


### PR DESCRIPTION
## Outcome
Lands the two final full-PR review fixes that arrived immediately after #193 merged.

- Reject group/world-writable legacy monitoring directories and unowned/writable marker files before any permission migration
- Render receipt-only lifecycle evidence as LIVE/BLOCKED; reserve NO_DATA for a store with neither runs nor receipts

## Verification
Targeted backend coverage is included. Full CI, trusted security, and exact-head Codex review are required before merge.