### PR TITLE
Ingest LinkedIn V1 as one seven-stage eval run

### DIFF
--- a/products/pm-evals-web/adapters/linkedin-os.settings.json
+++ b/products/pm-evals-web/adapters/linkedin-os.settings.json
@@ -1,21 +1,232 @@
 {
   "mapper_version": "0.1",
   "adapter_id": "linkedin-os-monitoring",
-  "adapter_version": "1",
-  "product": {"id":"linkedin-research-os","display_name":"LinkedIn Research OS","environment":"production","freshness_sla_seconds":93600},
+  "adapter_version": "2",
+  "product": {
+    "id": "linkedin-research-os",
+    "display_name": "LinkedIn Research OS",
+    "environment": "production",
+    "freshness_sla_seconds": 93600
+  },
   "case_types": {
-    "topic-value": ["research-trust", "claim-body-support", "atomic-value-novelty"],
-    "critic": ["critic-anchor-integrity"],
-    "critic-reproducibility": ["critic-reproducibility"],
-    "resonance": ["solution-plausibility", "reader-attention"]
+    "linkedin-run": [
+      "research-trust",
+      "claim-body-support",
+      "atomic-value-novelty",
+      "critic-anchor-integrity",
+      "critic-reproducibility",
+      "solution-plausibility",
+      "reader-attention"
+    ]
   },
   "definitions": [
-    {"id":"research-trust","layer":"INPUT","concern":"INVARIANT","suite_id":"linkedin-v1","suite_version":"1","method":"DETERMINISTIC","component_id":"research","stage_id":"topic-value","stage_index":1,"parameter_id":"research-trust","owner_id":"linkedin-research-owner","fix_location":"research trust contract","depends_on":[],"threshold":1.0,"tolerance":0.0,"unit":"pass","higher_is_better":true,"required":true,"current_summary_by_status":{"PASS":"Research trust passed.","FAIL":"Research trust failed.","BLOCKED":"Research trust evidence is missing.","NOT_EVALUATED":"Research trust was not evaluated."},"expected_summary":"Research evidence meets the body-read trust contract.","remediation":"Inspect source trust before downstream writing checks."},
-    {"id":"claim-body-support","layer":"RETRIEVAL_TOOL","concern":"QUALITY","suite_id":"linkedin-v1","suite_version":"1","method":"DETERMINISTIC","component_id":"research","stage_id":"topic-value","stage_index":1,"parameter_id":"claim-body-support","owner_id":"linkedin-research-owner","fix_location":"claim support contract","depends_on":[],"threshold":1.0,"tolerance":0.0,"unit":"pass","higher_is_better":true,"required":true,"current_summary_by_status":{"PASS":"Claim support passed.","FAIL":"Claim support failed.","BLOCKED":"Claim support evidence is missing.","NOT_EVALUATED":"Claim support was not evaluated."},"expected_summary":"Every factual claim is supported by approved evidence.","remediation":"Inspect claim-to-body evidence binding."},
-    {"id":"atomic-value-novelty","layer":"SYSTEM","concern":"INVARIANT","suite_id":"linkedin-v1","suite_version":"1","method":"DETERMINISTIC","component_id":"topic-value","stage_id":"topic-value","stage_index":1,"parameter_id":"atomic-value-novelty","owner_id":"linkedin-topic-owner","fix_location":"atomic value novelty contract","depends_on":[],"threshold":1.0,"tolerance":0.0,"unit":"pass","higher_is_better":true,"required":true,"current_summary_by_status":{"PASS":"Atomic value is novel.","FAIL":"Atomic value is not sufficiently novel.","BLOCKED":"Novelty evidence is missing.","NOT_EVALUATED":"Novelty was not evaluated."},"expected_summary":"Atomic value is materially different from published history.","remediation":"Inspect the atomic-value distinction and published history."},
-    {"id":"critic-anchor-integrity","layer":"OUTPUT","concern":"QUALITY","suite_id":"linkedin-v1","suite_version":"1","method":"HYBRID","component_id":"critic","stage_id":"critic","stage_index":2,"parameter_id":"behavioral-anchor-integrity","owner_id":"linkedin-quality-owner","fix_location":"critic anchor validator","depends_on":[],"threshold":1.0,"tolerance":0.0,"unit":"pass","higher_is_better":true,"required":true,"current_summary_by_status":{"PASS":"Critic anchors are valid.","FAIL":"Critic anchors are invalid.","BLOCKED":"Critic anchor evidence is missing.","NOT_EVALUATED":"Critic anchors were not evaluated."},"expected_summary":"Every Critic score has valid behavioral anchor evidence.","remediation":"Inspect the rejected score anchor and adjacent-boundary rationale."},
-    {"id":"critic-reproducibility","layer":"SYSTEM","concern":"QUALITY","suite_id":"linkedin-v1","suite_version":"1","method":"MODEL_JUDGE","component_id":"critic","stage_id":"critic-reproducibility","stage_index":3,"parameter_id":"maximum-axis-disagreement","owner_id":"linkedin-eval-owner","fix_location":"critic reproducibility calibration","depends_on":[],"threshold":1.0,"tolerance":0.0,"unit":"pass","higher_is_better":true,"required":true,"current_summary_by_status":{"PASS":"Critic reproducibility is within the calibration band.","FAIL":"Critic reproducibility exceeded the calibration band.","BLOCKED":"Reproducibility evidence is missing.","NOT_EVALUATED":"Reproducibility was not evaluated."},"expected_summary":"Repeated Critic scoring stays within one point per axis.","remediation":"Review evaluator calibration without changing the product gate automatically."},
-    {"id":"solution-plausibility","layer":"OUTPUT","concern":"CAPABILITY","suite_id":"linkedin-v1","suite_version":"1","method":"MODEL_JUDGE","component_id":"resonance","stage_id":"resonance","stage_index":4,"parameter_id":"solution-plausibility","owner_id":"linkedin-content-owner","fix_location":"resonance solution contract","depends_on":[],"threshold":1.0,"tolerance":0.0,"unit":"pass","higher_is_better":true,"required":true,"current_summary_by_status":{"PASS":"Solution plausibility passed.","FAIL":"Solution plausibility failed.","BLOCKED":"Solution plausibility evidence is missing.","NOT_EVALUATED":"Solution plausibility was not evaluated."},"expected_summary":"The proposed solution is coherent and implementable.","remediation":"Inspect the missing implementation mechanism."},
-    {"id":"reader-attention","layer":"OUTCOME","concern":"QUALITY","suite_id":"linkedin-v1","suite_version":"1","method":"MODEL_JUDGE","component_id":"resonance","stage_id":"resonance","stage_index":4,"parameter_id":"reader-attention","owner_id":"linkedin-content-owner","fix_location":"reader attention contract","depends_on":[],"threshold":1.0,"tolerance":0.0,"unit":"pass","higher_is_better":true,"required":true,"current_summary_by_status":{"PASS":"Reader attention passed.","FAIL":"Reader attention failed.","BLOCKED":"Reader attention evidence is missing.","NOT_EVALUATED":"Reader attention was not evaluated."},"expected_summary":"The final post sustains reader attention.","remediation":"Inspect the first attention drop after upstream evidence is healthy."}
+    {
+      "id": "research-trust",
+      "layer": "INPUT",
+      "concern": "INVARIANT",
+      "suite_id": "linkedin-v1",
+      "suite_version": "1",
+      "method": "DETERMINISTIC",
+      "component_id": "research",
+      "stage_id": "topic-value",
+      "stage_index": 1,
+      "parameter_id": "research-trust",
+      "owner_id": "linkedin-research-owner",
+      "fix_location": "research trust contract",
+      "depends_on": [],
+      "threshold": 1,
+      "tolerance": 0,
+      "unit": "pass",
+      "higher_is_better": true,
+      "required": true,
+      "current_summary_by_status": {
+        "PASS": "Research trust passed.",
+        "FAIL": "Research trust failed.",
+        "BLOCKED": "Research trust evidence is missing.",
+        "NOT_EVALUATED": "Research trust was not evaluated."
+      },
+      "expected_summary": "Research evidence meets the body-read trust contract.",
+      "remediation": "Inspect source trust before downstream writing checks."
+    },
+    {
+      "id": "claim-body-support",
+      "layer": "RETRIEVAL_TOOL",
+      "concern": "QUALITY",
+      "suite_id": "linkedin-v1",
+      "suite_version": "1",
+      "method": "DETERMINISTIC",
+      "component_id": "research",
+      "stage_id": "topic-value",
+      "stage_index": 2,
+      "parameter_id": "claim-body-support",
+      "owner_id": "linkedin-research-owner",
+      "fix_location": "claim support contract",
+      "depends_on": [
+        "research-trust"
+      ],
+      "threshold": 1,
+      "tolerance": 0,
+      "unit": "pass",
+      "higher_is_better": true,
+      "required": true,
+      "current_summary_by_status": {
+        "PASS": "Claim support passed.",
+        "FAIL": "Claim support failed.",
+        "BLOCKED": "Claim support evidence is missing.",
+        "NOT_EVALUATED": "Claim support was not evaluated."
+      },
+      "expected_summary": "Every factual claim is supported by approved evidence.",
+      "remediation": "Inspect claim-to-body evidence binding."
+    },
+    {
+      "id": "atomic-value-novelty",
+      "layer": "SYSTEM",
+      "concern": "INVARIANT",
+      "suite_id": "linkedin-v1",
+      "suite_version": "1",
+      "method": "DETERMINISTIC",
+      "component_id": "topic-value",
+      "stage_id": "topic-value",
+      "stage_index": 3,
+      "parameter_id": "atomic-value-novelty",
+      "owner_id": "linkedin-topic-owner",
+      "fix_location": "atomic value novelty contract",
+      "depends_on": [
+        "claim-body-support"
+      ],
+      "threshold": 1,
+      "tolerance": 0,
+      "unit": "pass",
+      "higher_is_better": true,
+      "required": true,
+      "current_summary_by_status": {
+        "PASS": "Atomic value is novel.",
+        "FAIL": "Atomic value is not sufficiently novel.",
+        "BLOCKED": "Novelty evidence is missing.",
+        "NOT_EVALUATED": "Novelty was not evaluated."
+      },
+      "expected_summary": "Atomic value is materially different from published history.",
+      "remediation": "Inspect the atomic-value distinction and published history."
+    },
+    {
+      "id": "critic-anchor-integrity",
+      "layer": "OUTPUT",
+      "concern": "QUALITY",
+      "suite_id": "linkedin-v1",
+      "suite_version": "1",
+      "method": "HYBRID",
+      "component_id": "critic",
+      "stage_id": "critic",
+      "stage_index": 4,
+      "parameter_id": "behavioral-anchor-integrity",
+      "owner_id": "linkedin-quality-owner",
+      "fix_location": "critic anchor validator",
+      "depends_on": [
+        "atomic-value-novelty"
+      ],
+      "threshold": 1,
+      "tolerance": 0,
+      "unit": "pass",
+      "higher_is_better": true,
+      "required": true,
+      "current_summary_by_status": {
+        "PASS": "Critic anchors are valid.",
+        "FAIL": "Critic anchors are invalid.",
+        "BLOCKED": "Critic anchor evidence is missing.",
+        "NOT_EVALUATED": "Critic anchors were not evaluated."
+      },
+      "expected_summary": "Every Critic score has valid behavioral anchor evidence.",
+      "remediation": "Inspect the rejected score anchor and adjacent-boundary rationale."
+    },
+    {
+      "id": "critic-reproducibility",
+      "layer": "SYSTEM",
+      "concern": "QUALITY",
+      "suite_id": "linkedin-v1",
+      "suite_version": "1",
+      "method": "MODEL_JUDGE",
+      "component_id": "critic",
+      "stage_id": "critic-reproducibility",
+      "stage_index": 5,
+      "parameter_id": "maximum-axis-disagreement",
+      "owner_id": "linkedin-eval-owner",
+      "fix_location": "critic reproducibility calibration",
+      "depends_on": [
+        "critic-anchor-integrity"
+      ],
+      "threshold": 1,
+      "tolerance": 0,
+      "unit": "pass",
+      "higher_is_better": true,
+      "required": true,
+      "current_summary_by_status": {
+        "PASS": "Critic reproducibility is within the calibration band.",
+        "FAIL": "Critic reproducibility exceeded the calibration band.",
+        "BLOCKED": "Reproducibility evidence is missing.",
+        "NOT_EVALUATED": "Reproducibility was not evaluated."
+      },
+      "expected_summary": "Repeated Critic scoring stays within one point per axis.",
+      "remediation": "Review evaluator calibration without changing the product gate automatically."
+    },
+    {
+      "id": "solution-plausibility",
+      "layer": "OUTPUT",
+      "concern": "CAPABILITY",
+      "suite_id": "linkedin-v1",
+      "suite_version": "1",
+      "method": "MODEL_JUDGE",
+      "component_id": "resonance",
+      "stage_id": "resonance",
+      "stage_index": 6,
+      "parameter_id": "solution-plausibility",
+      "owner_id": "linkedin-content-owner",
+      "fix_location": "resonance solution contract",
+      "depends_on": [
+        "critic-reproducibility"
+      ],
+      "threshold": 1,
+      "tolerance": 0,
+      "unit": "pass",
+      "higher_is_better": true,
+      "required": true,
+      "current_summary_by_status": {
+        "PASS": "Solution plausibility passed.",
+        "FAIL": "Solution plausibility failed.",
+        "BLOCKED": "Solution plausibility evidence is missing.",
+        "NOT_EVALUATED": "Solution plausibility was not evaluated."
+      },
+      "expected_summary": "The proposed solution is coherent and implementable.",
+      "remediation": "Inspect the missing implementation mechanism."
+    },
+    {
+      "id": "reader-attention",
+      "layer": "OUTCOME",
+      "concern": "QUALITY",
+      "suite_id": "linkedin-v1",
+      "suite_version": "1",
+      "method": "MODEL_JUDGE",
+      "component_id": "resonance",
+      "stage_id": "resonance",
+      "stage_index": 7,
+      "parameter_id": "reader-attention",
+      "owner_id": "linkedin-content-owner",
+      "fix_location": "reader attention contract",
+      "depends_on": [
+        "solution-plausibility"
+      ],
+      "threshold": 1,
+      "tolerance": 0,
+      "unit": "pass",
+      "higher_is_better": true,
+      "required": true,
+      "current_summary_by_status": {
+        "PASS": "Reader attention passed.",
+        "FAIL": "Reader attention failed.",
+        "BLOCKED": "Reader attention evidence is missing.",
+        "NOT_EVALUATED": "Reader attention was not evaluated."
+      },
+      "expected_summary": "The final post sustains reader attention.",
+      "remediation": "Inspect the first attention drop after upstream evidence is healthy."
+    }
   ]
 }

--- a/products/pm-evals-web/backend/tests/test_monitoring_production.py
+++ b/products/pm-evals-web/backend/tests/test_monitoring_production.py
@@ -1287,7 +1287,7 @@ def test_both_product_settings_map_through_the_same_contract() -> None:
     products: list[str] = []
     for filename, case_type, definition_id in (
         ("dream-job.settings.json", "job-search", "input-constraint-completeness"),
-        ("linkedin-os.settings.json", "critic", "critic-anchor-integrity"),
+        ("linkedin-os.settings.json", "linkedin-run", "critic-anchor-integrity"),
     ):
         settings = AdapterSettings.model_validate(
             json.loads((root / "adapters" / filename).read_text())
@@ -1867,3 +1867,46 @@ def test_v01_adjudication_is_verified_and_migrated_on_read(tmp_path: Path) -> No
     rejected_store.adjudication_path.write_text(json.dumps(contradictory, sort_keys=True) + "\n")
     with pytest.raises(ValueError, match="completed adjudication ledger record is invalid"):
         MonitoringStore(rejected_dir)
+
+
+def test_linkedin_adapter_maps_complete_seven_stage_run() -> None:
+    root = Path(__file__).resolve().parents[2]
+    template = _run()
+    settings = AdapterSettings.model_validate(
+        json.loads((root / "adapters" / "linkedin-os.settings.json").read_text())
+    )
+    definition_ids = settings.case_types["linkedin-run"]
+    normalized = NormalizedRun.model_validate(
+        {
+            "run_id": "linkedin-complete-run",
+            "observed_at": template.observed_at,
+            "product_version": "release-1",
+            "comparison": template.comparison.model_dump(mode="json"),
+            "change_manifest": template.change_manifest.model_dump(mode="json"),
+            "provenance": template.provenance.model_dump(mode="json"),
+            "cases": [
+                {
+                    "case_type": "linkedin-run",
+                    "case": template.observations[0].case.model_dump(mode="json"),
+                    "checks": [
+                        {
+                            "definition_id": definition_id,
+                            "status": "PASS",
+                            "current_value": 1.0,
+                            "expected_value": 1.0,
+                            "reason_code": "CHECK_PASSED",
+                        }
+                        for definition_id in definition_ids
+                    ],
+                }
+            ],
+        }
+    )
+
+    mapped = map_normalized_run(settings, normalized)
+
+    assert len(mapped.observations) == 7
+    assert [item.location.stage_index for item in mapped.observations] == list(range(1, 8))
+    assert mapped.observations[0].depends_on == []
+    for previous, current in zip(mapped.observations, mapped.observations[1:]):
+        assert current.depends_on == [previous.observation_id]


### PR DESCRIPTION
## What changed
- replace the four disconnected LinkedIn case types with one `linkedin-run` case
- give the seven V1 checks ordered stage indexes and explicit dependencies
- update the shared production mapping test
- add a complete seven-check fixture proving the adapter emits seven linked observations

This matches the exporter contract in Abhillashjadhav/Linkedin-research-posts#120.